### PR TITLE
fix: address review findings from PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Automatically save and restore session context across Claude Code conversations.
 ## Prerequisites
 
 - `jq` (for the auto-compact hook — `brew install jq` or `apt install jq`)
-- `claude` CLI globally available in your shell PATH
+- `claude` CLI (v1.0.0+, requires `-p` flag with stdin support) globally available in your shell PATH
 
 ## Installation
 
@@ -31,6 +31,7 @@ If you previously used the skills-based handover system, remove the old hooks fr
 | `/quiver:load-handover` | Loads the most recent handover into context |
 | `/quiver:delete-all-handovers` | Deletes all handover files |
 | `/quiver:delete-last-handover` | Deletes the most recent handover file |
+| `/quiver:status` | Shows plugin version, handover count, and hook status |
 
 ### Auto-Compact Protection
 
@@ -50,12 +51,25 @@ A PreCompact hook automatically generates a handover from the session transcript
 | `CLAUDE_PLUGIN_ROOT` | `hooks.json`, hook scripts | Path to the plugin root directory. **Not** available in command `.md` files |
 | `CLAUDE_PROJECT_DIR` | Hook scripts (via `$CLAUDE_PROJECT_DIR`) | Path to the current project. Falls back to `pwd` |
 
-## .gitignore
+## Required Setup
+
+> **Warning:** Handover files contain full session context including code snippets,
+> decisions, and work-in-progress details. You **must** add the handover directory
+> to `.gitignore` to avoid committing sensitive content to your repository.
 
 Add to your project's `.gitignore`:
 
 ```
 .claude/handovers/
+```
+
+## Recommended: Auto-load Handovers
+
+For agent sessions (subagents, CI) to benefit from context continuity,
+add this to your project's `CLAUDE.md`:
+
+```
+At session start, run /quiver:load-handover to restore context from the previous session.
 ```
 
 ## Uninstall

--- a/commands/handover.md
+++ b/commands/handover.md
@@ -12,6 +12,7 @@ description: Summarize the current work state and prepare a handover note for th
 
 # Handover Instructions
 
+<!-- SYNC: The 8 section headings below must match hooks/scripts/pre-compact-handover.sh PROMPT_PREFIX. -->
 Using the context above and our conversation, prepare a structured handover note with these exact sections:
 
 ## Summary

--- a/commands/load-handover.md
+++ b/commands/load-handover.md
@@ -13,4 +13,4 @@ The content above is the most recent handover from `.claude/handovers/`.
 Review it and:
 1. Confirm you understand the current state of the project
 2. State what the top priority Next Step is
-3. Ask the user how they want to proceed
+3. Proceed directly with the highest-priority Next Step unless the user has already provided instructions

--- a/commands/status.md
+++ b/commands/status.md
@@ -1,0 +1,29 @@
+---
+description: Show Quiver plugin status — version, handover count, latest handover, and hook health.
+---
+
+# Quiver Status
+
+## Plugin Info
+- **Name:** quiver
+- **Version:** !`jq -r '.name + " v" + .version' .claude-plugin/plugin.json 2>/dev/null || echo "unknown"`
+
+## Handovers
+- **Directory:** `.claude/handovers/`
+- **Count:** !`ls -1 .claude/handovers/*.md 2>/dev/null | wc -l | tr -d ' '` file(s)
+- **Latest:** !`ls -1t .claude/handovers/*.md 2>/dev/null | head -1 || echo "none"`
+
+## Available Commands
+| Command | File |
+|---------|------|
+| `/quiver:handover` | `commands/handover.md` |
+| `/quiver:load-handover` | `commands/load-handover.md` |
+| `/quiver:delete-all-handovers` | `commands/delete-all-handovers.md` |
+| `/quiver:delete-last-handover` | `commands/delete-last-handover.md` |
+| `/quiver:status` | `commands/status.md` |
+
+## Hook Status
+- **PreCompact hook:** !`if jq -e '.hooks.PreCompact' hooks/hooks.json &>/dev/null; then echo "registered"; else echo "NOT registered"; fi`
+- **Hook script:** !`if [ -x hooks/scripts/pre-compact-handover.sh ]; then echo "executable"; elif [ -f hooks/scripts/pre-compact-handover.sh ]; then echo "exists but NOT executable"; else echo "MISSING"; fi`
+- **jq available:** !`command -v jq &>/dev/null && echo "yes ($(jq --version 2>&1))" || echo "NO — hook will skip handover generation"`
+- **claude CLI available:** !`command -v claude &>/dev/null && echo "yes" || echo "NO — hook will fail"`

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/pre-compact-handover.sh",
-            "timeout": 600
+            "timeout": 180
           }
         ]
       }

--- a/hooks/scripts/pre-compact-handover.sh
+++ b/hooks/scripts/pre-compact-handover.sh
@@ -8,11 +8,8 @@ if ! command -v jq &>/dev/null; then
   exit 0
 fi
 
-# Read stdin JSON event
-EVENT=$(cat)
-
-# Extract transcript_path (empty string if key is missing or null)
-TRANSCRIPT_PATH=$(printf '%s' "$EVENT" | jq -r '.transcript_path // empty')
+# Extract transcript_path from stdin JSON (empty string if key is missing or null)
+TRANSCRIPT_PATH=$(jq -r '.transcript_path // empty')
 
 # Guard: no transcript path in event
 if [[ -z "$TRANSCRIPT_PATH" ]]; then
@@ -68,6 +65,12 @@ printf '%s\n' "$CONTENT" > "$OUT_FILE"
 # Prune: keep only the 3 most recent .md files
 # ls -1r gives reverse alpha order; filenames are timestamps so newest sort last alphabetically,
 # meaning ls -1r gives newest first — identical to Python's sorted(..., reverse=True)
-ls -1r "${HANDOVER_DIR}"/*.md 2>/dev/null | tail -n +4 | xargs rm -f || true
+count=0
+while IFS= read -r f; do
+  count=$((count + 1))
+  if (( count > 3 )); then
+    rm -f "$f"
+  fi
+done < <(ls -1r "${HANDOVER_DIR}"/*.md 2>/dev/null)
 
 exit 0

--- a/hooks/scripts/pre-compact-handover.sh
+++ b/hooks/scripts/pre-compact-handover.sh
@@ -28,6 +28,7 @@ HANDOVER_DIR="${PROJECT_DIR}/.claude/handovers"
 # Ensure handover directory exists
 mkdir -p "$HANDOVER_DIR"
 
+# SYNC: The 8 section headings below must match commands/handover.md lines 17-38.
 # Prompt template prefix — transcript is appended via stdin pipe to avoid ARG_MAX limits
 PROMPT_PREFIX='Read the following Claude Code session transcript and produce a HANDOVER note.
 Goal: The next Claude session (or a teammate) should be able to continue from where we left off.
@@ -49,7 +50,7 @@ CONTENT=$(
   {
     printf '%s\n' "$PROMPT_PREFIX"
     cat "$TRANSCRIPT_PATH"
-  } | claude -p 2>/dev/null
+  } | timeout 150 claude -p 2>/dev/null
 ) || CONTENT=""
 
 # Guard: empty output (claude failed or produced nothing)


### PR DESCRIPTION
## Summary                                                                                                                                                               
                                                                                                                                                                           
  - Replace `xargs` prune pipeline with `while-read` loop for safe filename handling                                                                                
  - Simplify jq stdin by removing unnecessary `EVENT` intermediate variable                                                                                         
  - Add inner timeout (150s) to `claude -p` and reduce outer hook timeout to 180s
  - Add SYNC comments linking section headings between hook and command
  - Fix agent-blocking "ask user" prompt in load-handover
  - Elevate `.gitignore` to Required Setup with sensitive content warning
  - Add auto-load handover snippet for agent/CI sessions
  - Specify minimum CLI version requirement
  - Add `/quiver:status` diagnostic command