### PR TITLE
feat: version compatibility checks and review-fix feedback loop

### DIFF
--- a/agents/research/best-practices-researcher.md
+++ b/agents/research/best-practices-researcher.md
@@ -39,6 +39,7 @@ Map the project's technology landscape before researching anything. Scan these f
 
 - **Package manifests**: `package.json`, `Gemfile`, `requirements.txt`, `pyproject.toml`, `go.mod`, `Cargo.toml`, `pubspec.yaml`, `composer.json`, `build.gradle`, `pom.xml`, `*.csproj`
 - **Lock files**: `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `Gemfile.lock`, `poetry.lock`, `Cargo.lock`
+- **Version pinning files**: `gradle/wrapper/gradle-wrapper.properties`, `Podfile.lock`, `.node-version`, `.nvmrc`, `.ruby-version`, `.python-version`, `.java-version`, `.tool-versions`, `rust-toolchain.toml`, `Package.resolved`, `global.json`, `.swift-version`
 - **Config files**: `tsconfig.json`, `.babelrc`, `webpack.config.*`, `vite.config.*`, `next.config.*`, `tailwind.config.*`, `eslint.config.*`, `.rubocop.yml`, `docker-compose.yml`
 - **Entry points**: Scan 2-3 main source files to identify frameworks in use (e.g., imports of React, Rails, Django, Flask, Express)
 
@@ -73,6 +74,7 @@ If context7 returns insufficient results for a technology, note the gap and supp
 1. Search for: `"[technology] deprecated 2025 2026 sunset"` and `"[technology] breaking changes migration"`
 2. Check context7 docs for deprecation notices, sunset banners, or migration guides.
 3. Cross-reference version numbers: if the project uses v2.x but docs reference v3.x with breaking changes, flag this explicitly.
+4. **Build tool version resolution.** For build tool and configuration changes, always read the wrapper/lockfile to determine the actual version in use. Cross-reference API changes against **that version's** documentation, not the latest version. When the lockfile is part of the diff, validate against the post-change version. When a version range is specified, validate against the minimum version. If the version file is absent, note the gap but do not block on it.
 
 **Report deprecated items immediately** -- do not bury them in recommendations. A 5-minute deprecation check prevents hours of debugging dead APIs.
 

--- a/agents/review/code-review.md
+++ b/agents/review/code-review.md
@@ -84,6 +84,26 @@ Check that changes follow current idioms and library conventions.
 3. Check error handling: are errors caught, logged, and propagated correctly?
 4. Check resource management: are connections, file handles, and subscriptions properly cleaned up?
 5. Verify that new dependencies (if any) are justified and actively maintained.
+6. **Version compatibility for build configs.** When the diff modifies build configuration files (`build.gradle`, `build.gradle.kts`, `settings.gradle`, `Podfile`, `package.json`, `Cargo.toml`, `CMakeLists.txt`, `Package.swift`, `*.csproj`, `go.mod`, `pyproject.toml`, `Makefile`, `pubspec.yaml`), locate the project's version lockfile or wrapper config nearest to the changed file in the directory hierarchy. Read the locked version and cross-reference APIs in the diff against that version's documentation via context7. Apply these resolution rules:
+   - **Lockfile in diff:** Validate against the **post-change** (new) version -- the review assesses the state after merge.
+   - **Version range:** Validate against the **minimum** version in the range (weakest supported).
+   - **No lockfile found:** Skip the version check silently. Do not produce a finding about the missing lockfile -- it is outside the diff's scope.
+   - **context7 lacks version-specific docs:** Report a Low-severity "version not verified" note rather than guessing compatibility.
+   - **Monorepo:** Use the lockfile nearest to the changed file (walk up the directory tree).
+
+   **Version lockfile/wrapper lookup table:**
+
+   | Build Config File | Version Source File |
+   |---|---|
+   | `build.gradle` / `build.gradle.kts` / `settings.gradle` | `gradle/wrapper/gradle-wrapper.properties` |
+   | `Podfile` | `Podfile.lock` (COCOAPODS version), `.ruby-version` |
+   | `package.json` | `.node-version`, `.nvmrc`, `package.json` engines field |
+   | `Cargo.toml` | `rust-toolchain.toml`, `rust-toolchain` |
+   | `go.mod` | `go.mod` go directive line |
+   | `pubspec.yaml` | `pubspec.yaml` environment.sdk constraint |
+   | `*.csproj` | `global.json` (sdk.version) |
+   | `Package.swift` | `.swift-version`, `Package.swift` swift-tools-version comment |
+   | `pyproject.toml` | `.python-version`, `pyproject.toml` requires-python |
 
 ## Phase 3 -- Performance
 

--- a/commands/review.md
+++ b/commands/review.md
@@ -222,6 +222,8 @@ One paragraph: what the PR does, overall risk, top-line recommendation.
 [Unified verdict] -- [severity counts] -- [one-line justification]
 ```
 
+<!-- SYNC: This report format is parsed by skills/work/SKILL.md Phase 4c (review finding verification). If you change the report structure (section headings, finding format), update the verification parsing logic there. -->
+
 ## Step 4 -- Save Review Report
 
 ### 4a -- Determine output destination

--- a/commands/work.md
+++ b/commands/work.md
@@ -48,6 +48,11 @@ You are a plan executor. Your job is to load a work plan, set up the environment
   > - `/plan <task>` -- create a plan first
   **Stop here.**
 
+After loading the plan, check if it references a review report:
+- Check YAML frontmatter for `review_source` field.
+- Fall back to scanning content for `.claude/reports/review-*.md` paths.
+- If found, load the review report and note this as a review-fix plan for Step 5.
+
 ## Step 2 -- Review and Confirm
 
 1. Read the plan file (or inline spec).
@@ -101,6 +106,7 @@ Before shipping:
 2. Run linting if configured.
 3. Verify all TodoWrite tasks are completed.
 4. For non-trivial changes, check system-wide impact (callbacks, middleware, parallel interfaces).
+5. If this is a review-fix plan (detected in Step 1), run review finding verification per the work skill's Phase 4c methodology. Present the verification summary table. Block on unaddressed Critical findings.
 
 ## Step 6 -- Ship
 

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -40,9 +40,15 @@ Execute a work plan, specification, or task list systematically. The focus is on
 
 2. **Review references.** If the plan links to files, patterns, or prior research -- read those now. Understanding context before coding prevents rework.
 
-3. **Flag ambiguities.** If anything is unclear or contradictory, ask clarifying questions now. Better to ask one question upfront than build the wrong thing. If the plan is clear, skip this step.
+3. **Detect review-fix plan.** Check if this is a plan created to address review findings:
+   - **Primary**: Check plan YAML frontmatter for a `review_source` field (e.g., `review_source: .claude/reports/review-2026-03-10_14-30-00.md`).
+   - **Fallback**: Scan plan content for paths matching `.claude/reports/review-*.md` or `review-*_*-*-*.md`.
+   - If detected, read the review report file. If the file exists, note this as a **review-fix plan** and carry the parsed findings forward to Phase 4. If the file does not exist, warn: "Review report not found at {path}. Proceeding without review-aware verification."
+   - If no review reference detected, proceed normally.
 
-4. **Get approval to proceed.** Summarize what you are about to build in 2-3 sentences and confirm the user wants to proceed.
+4. **Flag ambiguities.** If anything is unclear or contradictory, ask clarifying questions now. Better to ask one question upfront than build the wrong thing. If the plan is clear, skip this step.
+
+5. **Get approval to proceed.** Summarize what you are about to build in 2-3 sentences and confirm the user wants to proceed.
 
 ### Phase 2: Setup Environment
 
@@ -140,7 +146,48 @@ For non-trivial changes, pause and consider:
 
 **Skip this check for:** leaf-node changes with no callbacks, no state persistence, no parallel interfaces. Purely additive changes (new helper, new partial) need only a quick scan.
 
-#### 4c -- Optional: Agent-assisted review
+#### 4c -- Review finding verification (review-fix plans only)
+
+If Phase 1 identified this as a review-fix plan and the review report was successfully loaded:
+
+1. **Parse findings.** Extract all non-filtered findings from the review report, grouped by severity (Critical, High, Medium, Low). Skip the `## Filtered Findings` section entirely.
+
+2. **Map findings to plan steps.** For each finding, identify whether the plan had a corresponding task:
+   - Match by file path referenced in the finding against files mentioned in plan steps.
+   - Match by finding title/description against plan step descriptions.
+   - Findings with no matching plan step are marked "Not in scope."
+
+3. **Check addressed status.** For each in-scope finding:
+   - Verify the referenced file was modified (check `git diff` for changes to that file).
+   - Verify the corresponding TodoWrite task is marked `completed`.
+   - If both conditions met: mark as **Addressed**.
+   - If file not modified or task incomplete: mark as **Not addressed**.
+
+4. **Cross-reference check.** Flag when a file modified to fix finding A is also referenced by finding B (potential regression area). Present these as notes, not blockers.
+
+5. **Present verification summary:**
+
+   ```
+   ## Review Finding Verification
+   | # | Severity | Finding | Status | Notes |
+   |---|----------|---------|--------|-------|
+   | 1 | Critical | SQL injection in auth.py:42 | Addressed | File modified, task completed |
+   | 2 | High     | Missing input validation | Addressed | File modified, task completed |
+   | 3 | Medium   | Inconsistent error handling | Not in scope | No plan step for this finding |
+   | 4 | Low      | Naming convention | Not addressed | File not modified |
+   ```
+
+6. **Apply gates:**
+   - **BLOCKING**: Any Critical finding marked "Not addressed" (in-scope but not fixed). Use `AskUserQuestion`:
+     > Critical review finding not addressed: {finding title}
+     > Original finding: {finding text}
+     Buttons: `["I've verified this is fixed", "Fix it now", "Skip -- not applicable"]`
+   - **WARNING**: Any High/Medium/Low finding marked "Not addressed" (in-scope but not fixed). List in summary but do not block.
+   - **INFO**: Findings marked "Not in scope." Listed for awareness only.
+
+<!-- SYNC: This verification parses the report format defined in commands/review.md:188-223. If the report structure changes, update the parsing logic here. -->
+
+#### 4d -- Optional: Agent-assisted review
 
 For large, risky, or security-sensitive changes, consider dispatching review agents. Discover available review agents by scanning `agents/review/*.md` and dispatch them using the `orchestrate-agents` skill patterns.
 


### PR DESCRIPTION
## Summary

This PR adds two complementary features that strengthen the review and work pipelines:

### 1. Version Compatibility Checks in Review Agents

**Problem:** Review agents had no awareness of build tool or runtime versions when reviewing build configuration changes (e.g., `build.gradle`, `Podfile`, `package.json`). This meant API compatibility issues could slip through — a config might use APIs only available in a newer version than the project actually pins.

**What changed:**
- **`agents/review/code-review.md`** — Added a new Phase 2 check (#6: "Version compatibility for build configs") with a full lookup table mapping build config files → version lockfiles/wrappers (e.g., `build.gradle` → `gradle/wrapper/gradle-wrapper.properties`). Includes resolution rules for lockfile-in-diff, version ranges, missing lockfiles, monorepos, and missing context7 docs.
- **`agents/research/best-practices-researcher.md`** — Expanded the tech stack scan list to include version pinning files (`.node-version`, `.nvmrc`, `.ruby-version`, `.python-version`, `.java-version`, `.tool-versions`, `rust-toolchain.toml`, `Package.resolved`, `global.json`, `.swift-version`, `Podfile.lock`, `gradle-wrapper.properties`). Added a new deprecation-check step for build tool version resolution — always read the wrapper/lockfile to determine actual version before cross-referencing docs.

**Usage change:** No new commands or flags. The review agents automatically perform version compatibility checks when a diff includes build config files. Users will see version-aware findings in review reports.

### 2. Review-Fix Feedback Loop in Work Command/Skill

**Problem:** When `/review` found issues and the user created a plan to fix them, `/work` had no way to verify that the review findings were actually addressed. Users had to manually cross-reference the review report after fixing.

**What changed:**
- **`skills/work/SKILL.md`** — Added Phase 1 step 3 ("Detect review-fix plan") that checks for `review_source` in plan YAML frontmatter or scans for `.claude/reports/review-*.md` paths. Added Phase 4c ("Review finding verification") — a complete verification workflow that parses findings, maps them to plan steps, checks addressed status via `git diff`, presents a summary table, and applies blocking gates (Critical findings block, High/Medium/Low warn).
- **`commands/work.md`** — Added review report detection in Step 1 (checks frontmatter `review_source` field, falls back to content scanning). Added Step 5 in pre-ship checks to run review finding verification for review-fix plans, blocking on unaddressed Critical findings.
- **`commands/review.md`** — Added a `SYNC` comment noting that the report format is parsed by `skills/work/SKILL.md` Phase 4c.

**Usage scenario (new):**
1. Run `/review` → generates `.claude/reports/review-*.md` with findings
2. Run `/plan` referencing the review report → creates a plan with `review_source` in frontmatter
3. Run `/work` on that plan → work skill detects it as a review-fix plan
4. After implementing fixes, Phase 4c automatically verifies each finding:
   - **Addressed**: file modified + task completed
   - **Not addressed**: blocks on Critical, warns on others
   - **Not in scope**: listed for awareness
5. Summary table presented before shipping

## Files Changed

| File | Change |
|------|--------|
| `agents/review/code-review.md` | Added version compatibility check with lockfile lookup table |
| `agents/research/best-practices-researcher.md` | Expanded scan list + build tool version resolution step |
| `skills/work/SKILL.md` | Review-fix plan detection (Phase 1) + finding verification (Phase 4c) |
| `commands/work.md` | Review report detection + pre-ship verification gate |
| `commands/review.md` | SYNC comment for report format dependency |

## Test plan

- [x] Run `/review` on a project with build config files (e.g., `build.gradle`, `package.json`) — verify version compatibility findings appear in the report
- [x] Create a plan with `review_source: .claude/reports/review-*.md` in frontmatter, run `/work` — verify it detects as review-fix plan
- [x] Complete some but not all review fixes, hit Step 5 — verify the verification summary table is shown with correct statuses
- [x] Leave a Critical finding unaddressed — verify it blocks shipping with `AskUserQuestion`
- [x] Run `/work` on a normal (non-review) plan — verify no review verification is triggered


🤖 Generated with [Claude Code](https://claude.com/claude-code)