### PR TITLE
feat(work): add subagent orchestration for parallel task execution

### DIFF
--- a/commands/review.md
+++ b/commands/review.md
@@ -227,7 +227,7 @@ After **all** agents return, merge their outputs into a single unified report. F
    **CI severity cap:** Configuration issues that cause CI to fail visibly (build errors, missing tools, wrong paths) are capped at Medium. Reserve High for CI issues that silently produce wrong results or expose secrets. Rationale: a failing CI pipeline blocks bad code from merging -- it is self-evident on first run and easily fixed.
 3. **Tag the source.** Prefix each finding with the agent that produced it for traceability. When 2+ agents flagged the same issue, include the `Flagged by:` annotation:
    ```
-   [SEVERITY] (waste-detector) file_path:line_number -- Short title
+   [ID] [SEVERITY] (waste-detector) file_path:line_number -- Short title
    Flagged by: waste-detector, architecture-strategist
    ```
    The `Flagged by:` line only appears when 2+ agents independently flagged the same issue.
@@ -286,34 +286,37 @@ One paragraph: what the PR does, overall risk, top-line recommendation.
 {If architecture-strategist ran: include its Architecture Context (3-5 bullets) and Structural Summary here. If it did not run or returned empty, omit this section entirely.}
 
 ## Findings
+
+Each finding gets a short ID: severity initial + sequence number (C1, C2... for Critical; H1, H2... for High; M1, M2... for Medium; L1, L2... for Low). These IDs are stable within a report and can be used to reference findings concisely (e.g., "except L1", "fix H2 first").
+
 ### Critical
-[merged critical findings]
+[C1, C2, ... merged critical findings]
 
 ### High
-[merged high findings]
+[H1, H2, ... merged high findings]
 
 ### Medium
-[merged medium findings]
+[M1, M2, ... merged medium findings]
 
 ### Low
-[merged low findings]
+[L1, L2, ... merged low findings]
 
 {For findings flagged by 2+ agents, include the annotation: "Flagged by: agent1, agent2"}
 
 ## Recommended Fix Order
 {Prioritized action plan for findings of Medium severity or above. Omit this section if 0-2 findings qualify.}
 
-| Priority | Finding | Severity | Effort |
-|----------|---------|----------|--------|
-| 1 | [Short title with file:line] | Critical | ~X min |
-| 2 | [Short title with file:line] | High | ~X min |
-| ... | ... | ... | ... |
+| Priority | ID | Finding | Severity | Effort |
+|----------|----|---------|----------|--------|
+| 1 | C1 | [Short title with file:line] | Critical | ~X min |
+| 2 | H1 | [Short title with file:line] | High | ~X min |
+| ... | ... | ... | ... | ... |
 
 ## Filtered Findings
 
 **{N} findings reported, {M} filtered** ({classification breakdown, e.g., "3 out-of-scope, 2 aspirational, 1 subjective style"})
 
-- [brief reason for each, e.g., "~~[Medium] (waste-detector) config/routes.rb:15 -- Consider extracting nested routes~~ -- Aspirational: working code, no concrete problem"]
+- [brief reason for each, e.g., "~~[M3] [Medium] (waste-detector) config/routes.rb:15 -- Consider extracting nested routes~~ -- Aspirational: working code, no concrete problem"]
 
 (Omit this section entirely if no findings were filtered.)
 

--- a/commands/work.md
+++ b/commands/work.md
@@ -102,9 +102,16 @@ Check the current branch from the context above.
 
 ## Step 2.5 -- Orchestration Decision
 
-1. **Count tasks** in the loaded plan (### Task N headings or equivalent numbered sections).
-2. **1-2 tasks:** Proceed to Step 3 as normal.
-3. **3+ tasks:** Follow the **work** skill's Phase 2.5 (Orchestration Decision). This REPLACES Step 3 -- skip directly to Step 4.
+1. **Count tasks** in the loaded plan. A "task" is any top-level section that describes a discrete, independently completable piece of work -- regardless of heading format or label.
+2. **1-2 tasks:** Sequential execution. Proceed to Step 3.
+3. **3+ tasks:** Parallel orchestration. Follow the **work** skill's Phase 2.5. This REPLACES Step 3 -- skip directly to Step 4.
+
+**Announce your decision immediately after counting:**
+
+```
+Strategy: {sequential | parallel orchestration} ({N} tasks found)
+Reason: {why -- e.g., "2 tasks, below parallel threshold" or "4 tasks with 2 independent groups"}
+```
 
 ## Step 3 -- Execute
 

--- a/commands/work.md
+++ b/commands/work.md
@@ -102,37 +102,9 @@ Check the current branch from the context above.
 
 ## Step 2.5 -- Orchestration Decision
 
-Determine execution strategy based on task count:
-
 1. **Count tasks** in the loaded plan (### Task N headings or equivalent numbered sections).
-
-2. **1-2 tasks:** Proceed to Step 3 as normal. Sequential single-context execution.
-
-3. **3+ tasks:** Use parallel subagent orchestration. This REPLACES Step 3.
-
-   Follow the orchestrator reference (`skills/work/orchestrator.md`):
-
-   a. **Parse** each task's title, description, acceptance criteria, and file list.
-   
-   b. **Resolve dependencies:**
-      - Read explicit `blockedBy` fields from the plan.
-      - Compare file lists between all task pairs. If tasks i and j (i < j) share any file, add implicit blockedBy from j to i.
-      - Build execution groups: Group 0 = no dependencies, Group N = depends only on Groups 0..N-1.
-   
-   c. **Report** the execution plan (groups, dependencies, reasons) to the user. Do NOT ask for confirmation.
-   
-   d. **Dispatch** — For each group, spawn one `general-purpose` Agent per task:
-      - `isolation: "worktree"`
-      - `run_in_background: true`
-      - Prompt: self-contained with task description, acceptance criteria, file list, project context, and constraints (only modify listed files, follow existing patterns, self-review, report blockers).
-   
-   e. **Collect results** — Classify as DONE / BLOCKED / FAILED. Update task tracking. Pause dependents of failed/blocked tasks.
-   
-   f. **Merge** worktree branches in dependency order (topological sort). Stop on conflict, report to user.
-   
-   g. **Post-merge** — Run test suite on merged result. Report failures.
-   
-   h. **Skip to Step 4** (Quality Check). Step 3 is not used when orchestrating.
+2. **1-2 tasks:** Proceed to Step 3 as normal.
+3. **3+ tasks:** Follow the **work** skill's Phase 2.5 (Orchestration Decision). This REPLACES Step 3 -- skip directly to Step 4.
 
 ## Step 3 -- Execute
 

--- a/commands/work.md
+++ b/commands/work.md
@@ -100,6 +100,40 @@ Check the current branch from the context above.
 - Create a new branch: `git checkout -b <meaningful-name>` derived from the plan goal.
 - Use a descriptive branch name (e.g., `feat/user-auth`, `fix/email-validation`).
 
+## Step 2.5 -- Orchestration Decision
+
+Determine execution strategy based on task count:
+
+1. **Count tasks** in the loaded plan (### Task N headings or equivalent numbered sections).
+
+2. **1-2 tasks:** Proceed to Step 3 as normal. Sequential single-context execution.
+
+3. **3+ tasks:** Use parallel subagent orchestration. This REPLACES Step 3.
+
+   Follow the orchestrator reference (`skills/work/orchestrator.md`):
+
+   a. **Parse** each task's title, description, acceptance criteria, and file list.
+   
+   b. **Resolve dependencies:**
+      - Read explicit `blockedBy` fields from the plan.
+      - Compare file lists between all task pairs. If tasks i and j (i < j) share any file, add implicit blockedBy from j to i.
+      - Build execution groups: Group 0 = no dependencies, Group N = depends only on Groups 0..N-1.
+   
+   c. **Report** the execution plan (groups, dependencies, reasons) to the user. Do NOT ask for confirmation.
+   
+   d. **Dispatch** — For each group, spawn one `general-purpose` Agent per task:
+      - `isolation: "worktree"`
+      - `run_in_background: true`
+      - Prompt: self-contained with task description, acceptance criteria, file list, project context, and constraints (only modify listed files, follow existing patterns, self-review, report blockers).
+   
+   e. **Collect results** — Classify as DONE / BLOCKED / FAILED. Update task tracking. Pause dependents of failed/blocked tasks.
+   
+   f. **Merge** worktree branches in dependency order (topological sort). Stop on conflict, report to user.
+   
+   g. **Post-merge** — Run test suite on merged result. Report failures.
+   
+   h. **Skip to Step 4** (Quality Check). Step 3 is not used when orchestrating.
+
 ## Step 3 -- Execute
 
 Follow the **work** skill's Phase 3 (Build) methodology:

--- a/commands/work.md
+++ b/commands/work.md
@@ -102,16 +102,9 @@ Check the current branch from the context above.
 
 ## Step 2.5 -- Orchestration Decision
 
-1. **Count tasks** in the loaded plan. A "task" is any top-level section that describes a discrete, independently completable piece of work -- regardless of heading format or label.
-2. **1-2 tasks:** Sequential execution. Proceed to Step 3.
-3. **3+ tasks:** Parallel orchestration. Follow the **work** skill's Phase 2.5. This REPLACES Step 3 -- skip directly to Step 4.
-
-**Announce your decision immediately after counting:**
-
-```
-Strategy: {sequential | parallel orchestration} ({N} tasks found)
-Reason: {why -- e.g., "2 tasks, below parallel threshold" or "4 tasks with 2 independent groups"}
-```
+Follow the **work** skill's Phase 2.5 to determine sequential vs. parallel execution.
+- **1-2 tasks:** Sequential. Proceed to Step 3.
+- **3+ tasks:** Parallel orchestration. This REPLACES Step 3 -- skip directly to Step 4.
 
 ## Step 3 -- Execute
 

--- a/skills/orchestrate-agents/SKILL.md
+++ b/skills/orchestrate-agents/SKILL.md
@@ -8,6 +8,8 @@ disable-model-invocation: true
 
 Analyze a user's request, discover available agents, assemble an optimal team, and delegate subtasks via the Agent tool. This skill runs in the main agent's context -- it is NOT a subagent.
 
+> **Scope distinction:** This skill handles general-purpose agent team assembly and delegation. For work-specific orchestration (dependency resolution, worktree isolation, merge procedure), see `skills/work/orchestrator.md`.
+
 ---
 
 ## Concepts

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -199,12 +199,12 @@ If Phase 1 identified this as a review-fix plan and the review report was succes
 
    ```
    ## Review Finding Verification
-   | # | Severity | Finding | Status | Notes |
-   |---|----------|---------|--------|-------|
-   | 1 | Critical | SQL injection in auth.py:42 | Addressed | File modified, task completed |
-   | 2 | High     | Missing input validation | Addressed | File modified, task completed |
-   | 3 | Medium   | Inconsistent error handling | Not in scope | No plan step for this finding |
-   | 4 | Low      | Naming convention | Not addressed | File not modified |
+   | ID | Severity | Finding | Status | Notes |
+   |----|----------|---------|--------|-------|
+   | C1 | Critical | SQL injection in auth.py:42 | Addressed | File modified, task completed |
+   | H1 | High     | Missing input validation | Addressed | File modified, task completed |
+   | M1 | Medium   | Inconsistent error handling | Not in scope | No plan step for this finding |
+   | L1 | Low      | Naming convention | Not addressed | File not modified |
    ```
 
 6. **Apply gates:**

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -89,25 +89,11 @@ After setting up the environment, determine the execution strategy.
 | **1-2** | Sequential | Proceed to Phase 3 (Build) as normal. No subagents. |
 | **3+** | Parallel orchestration | Follow the orchestration procedure below. Skip Phase 3 entirely — orchestration replaces it. |
 
-3. **For 3+ tasks — orchestration procedure:**
-
-   Follow the orchestrator reference document (`skills/work/orchestrator.md`) for the full procedure. Summary:
-
-   a. **Parse tasks** — Extract each task's title, description, acceptance criteria, and file list from the plan.
-   
-   b. **Resolve dependencies** — Build the dependency graph using explicit `blockedBy` fields + file overlap detection (see orchestrator.md § Dependency Resolution).
-   
-   c. **Report the execution plan** — Show the user the dependency graph and execution groups before dispatching. Do NOT ask for confirmation — proceed directly (the user invoked /work, that IS the approval).
-   
-   d. **Dispatch subagents** — For each execution group, spawn one `general-purpose` Agent per task with `isolation: "worktree"` and `run_in_background: true`. Each agent gets a self-contained prompt with the task scope, file list, and constraints (see orchestrator.md § Subagent Dispatch).
-   
-   e. **Collect results** — As agents complete, classify results as DONE / BLOCKED / FAILED. Update TaskCreate/TaskUpdate entries. If a task fails or blocks, pause its dependents but allow independent tasks to continue.
-   
-   f. **Merge branches** — After all groups complete, merge worktree branches in dependency order. If a merge conflict occurs, report it to the user and stop merging (see orchestrator.md § Merge Procedure).
-   
-   g. **Post-merge verification** — Run the project's test suite on the merged result. Report any failures.
-   
-   h. **Proceed to Phase 4** (Quality Check) with the merged result. Skip Phase 3 entirely — it was handled by the subagents.
+3. **For 3+ tasks -- orchestration procedure:**
+   Follow `skills/work/orchestrator.md` for the full procedure. In brief: parse tasks,
+   resolve dependencies (explicit + file overlap), report the execution plan, dispatch
+   one worktree-isolated subagent per task, collect results, merge in topological order,
+   run post-merge tests, then proceed to Phase 4.
 
 ### Phase 3: Build
 

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -76,6 +76,39 @@ git branch --show-current
 
 Use a descriptive branch name based on the task (e.g., `feat/user-auth`, `fix/email-validation`).
 
+### Phase 2.5: Orchestration Decision
+
+After setting up the environment, determine the execution strategy.
+
+1. **Count tasks.** Parse the plan and count the number of top-level tasks (### Task N headings or equivalent).
+
+2. **Route by count:**
+
+| Task Count | Strategy | Action |
+|------------|----------|--------|
+| **1-2** | Sequential | Proceed to Phase 3 (Build) as normal. No subagents. |
+| **3+** | Parallel orchestration | Follow the orchestration procedure below. Skip Phase 3 entirely — orchestration replaces it. |
+
+3. **For 3+ tasks — orchestration procedure:**
+
+   Follow the orchestrator reference document (`skills/work/orchestrator.md`) for the full procedure. Summary:
+
+   a. **Parse tasks** — Extract each task's title, description, acceptance criteria, and file list from the plan.
+   
+   b. **Resolve dependencies** — Build the dependency graph using explicit `blockedBy` fields + file overlap detection (see orchestrator.md § Dependency Resolution).
+   
+   c. **Report the execution plan** — Show the user the dependency graph and execution groups before dispatching. Do NOT ask for confirmation — proceed directly (the user invoked /work, that IS the approval).
+   
+   d. **Dispatch subagents** — For each execution group, spawn one `general-purpose` Agent per task with `isolation: "worktree"` and `run_in_background: true`. Each agent gets a self-contained prompt with the task scope, file list, and constraints (see orchestrator.md § Subagent Dispatch).
+   
+   e. **Collect results** — As agents complete, classify results as DONE / BLOCKED / FAILED. Update TaskCreate/TaskUpdate entries. If a task fails or blocks, pause its dependents but allow independent tasks to continue.
+   
+   f. **Merge branches** — After all groups complete, merge worktree branches in dependency order. If a merge conflict occurs, report it to the user and stop merging (see orchestrator.md § Merge Procedure).
+   
+   g. **Post-merge verification** — Run the project's test suite on the merged result. Report any failures.
+   
+   h. **Proceed to Phase 4** (Quality Check) with the merged result. Skip Phase 3 entirely — it was handled by the subagents.
+
 ### Phase 3: Build
 
 #### 3a -- Create task list

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -366,6 +366,10 @@ Small, focused commits are easier to review, easier to revert, and easier to deb
 - **Don't** commit, push, or create a PR without asking the user first via `AskUserQuestion` -- every git action in Phase 5 requires explicit confirmation.
 - **Don't** add AI attribution to commits or PRs (`Co-Authored-By`, `Generated with Claude`, etc.) unless the user explicitly asks for it.
 - **Don't** trigger another review cycle after completing a review-fix plan -- Phase 4c verification is the terminal quality gate. Dispatching review agents on review-fix work creates infinite loops.
+- **Don't** spawn subagents for 1-2 task plans -- the overhead exceeds the benefit. Use sequential execution.
+- **Don't** skip dependency resolution -- always check both explicit `blockedBy` and file overlap before dispatching parallel agents.
+- **Don't** attempt automatic merge conflict resolution -- report conflicts to the user and stop.
+- **Don't** continue dispatching dependent tasks when a dependency has failed or is blocked.
 
 ---
 
@@ -376,6 +380,8 @@ Small, focused commits are easier to review, easier to revert, and easier to deb
 - All TodoWrite tasks completed
 - No uncommitted changes that belong to this work
 - Plan checkboxes updated (if applicable)
+- Post-merge test suite passes (when orchestration was used)
+- All worktree branches merged successfully (no unresolved conflicts)
 
 **WARNING** (review but do not block):
 - Linting warnings present

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -80,16 +80,23 @@ Use a descriptive branch name based on the task (e.g., `feat/user-auth`, `fix/em
 
 After setting up the environment, determine the execution strategy.
 
-1. **Count tasks.** Parse the plan and count the number of top-level tasks (### Task N headings or equivalent).
+1. **Count tasks.** Parse the plan and count top-level work units. A "task" is any top-level section that describes a discrete, independently completable piece of work -- regardless of heading format or label.
 
-2. **Route by count:**
+2. **Announce the decision** to the user before proceeding:
+
+```
+Strategy: {sequential | parallel orchestration} ({N} tasks found)
+Reason: {why -- e.g., "2 tasks, below parallel threshold" or "4 tasks with 2 independent groups"}
+```
+
+3. **Route by count:**
 
 | Task Count | Strategy | Action |
 |------------|----------|--------|
 | **1-2** | Sequential | Proceed to Phase 3 (Build) as normal. No subagents. |
-| **3+** | Parallel orchestration | Follow the orchestration procedure below. Skip Phase 3 entirely — orchestration replaces it. |
+| **3+** | Parallel orchestration | Follow the orchestration procedure below. Skip Phase 3 entirely -- orchestration replaces it. |
 
-3. **For 3+ tasks -- orchestration procedure:**
+4. **For 3+ tasks -- orchestration procedure:**
    Follow `skills/work/orchestrator.md` for the full procedure. In brief: parse tasks,
    resolve dependencies (explicit + file overlap), report the execution plan, dispatch
    one worktree-isolated subagent per task, collect results, merge in topological order,

--- a/skills/work/orchestrator.md
+++ b/skills/work/orchestrator.md
@@ -1,0 +1,257 @@
+# Orchestrator Reference
+
+This document defines the subagent orchestration logic used by the work skill when a plan has 3+ tasks. It is NOT a standalone skill — it is referenced by `skills/work/SKILL.md` Phase 2.5.
+
+---
+
+## 1. Dependency Resolution
+
+Dependency resolution determines the order in which tasks execute. It runs three steps, then builds execution groups.
+
+### Step 1 — Explicit Dependencies
+
+Read each task's `blockedBy` field from the plan. This field lists task numbers that must complete before this task can start.
+
+Example plan fragment:
+
+```yaml
+- id: 1
+  title: Create database schema
+  blockedBy: []
+
+- id: 2
+  title: Build API endpoints
+  blockedBy: [1]
+
+- id: 3
+  title: Add input validation
+  blockedBy: [1]
+
+- id: 4
+  title: Write integration tests
+  blockedBy: [2, 3]
+```
+
+Here, Tasks 2 and 3 both wait for Task 1. Task 4 waits for both 2 and 3.
+
+### Step 2 — File Overlap Detection
+
+Compare each pair of tasks' file lists to detect implicit dependencies. If two tasks modify the same file, the later task (by plan order) implicitly depends on the earlier one.
+
+**Algorithm:**
+
+1. Extract file paths from each task's `Files:` section — include all lines under `Create:`, `Modify:`, and `Test:`.
+2. For each pair `(i, j)` where `i < j`:
+   - Compute the intersection: `files[i] ∩ files[j]`
+   - If the intersection is non-empty AND task `j` does not already depend on task `i` (directly or transitively), add `i` to task `j`'s `blockedBy`.
+3. Transitive check: task `j` already depends on task `i` transitively if there is any chain `j → ... → i` in the existing dependency graph. Do not add redundant edges.
+
+**Example:**
+
+```
+Task 1 — Files: src/models/user.ts, src/db/schema.ts
+Task 2 — Files: src/api/users.ts, src/middleware/auth.ts
+Task 3 — Files: src/api/users.ts, src/api/admin.ts
+```
+
+Tasks 2 and 3 both touch `src/api/users.ts`. Since 2 < 3, Task 3 gets an implicit `blockedBy: [2]`. Tasks 1 and 2 share no files, so no implicit dependency is added between them.
+
+### Step 3 — Build Execution Groups
+
+After resolving all dependencies (explicit + implicit), partition tasks into execution groups:
+
+- **Group 0:** Tasks with no `blockedBy` — these start immediately, in parallel.
+- **Group 1:** Tasks whose `blockedBy` entries are all in Group 0.
+- **Group N:** Tasks whose `blockedBy` entries are all in Groups 0 through N-1.
+
+Tasks within the same group run in parallel. Groups execute sequentially (Group 0 completes before Group 1 starts).
+
+### Reporting the Graph
+
+Before dispatching, print the execution plan so the user can see what will happen:
+
+```
+Dependency Graph:
+  Group 0 (parallel): Task 1 [Create database schema]
+  Group 1 (parallel): Task 2 [Build API endpoints], Task 3 [Add input validation]
+  Group 2 (parallel): Task 4 [Write integration tests]
+
+Dependencies:
+  Task 2 → blocked by Task 1 (explicit)
+  Task 3 → blocked by Task 1 (explicit)
+  Task 4 → blocked by Task 2, Task 3 (explicit)
+
+Dispatching Group 0...
+```
+
+---
+
+## 2. Subagent Dispatch
+
+### Prompt Template
+
+Each subagent receives a self-contained prompt. The orchestrator fills in the template fields from the plan:
+
+```
+# Task: {task_title}
+
+## Description
+{task_description}
+
+## Acceptance Criteria
+{acceptance_criteria}
+
+## Files to Modify
+{file_list — exact paths, one per line, prefixed with Create/Modify/Test}
+
+## Context
+{plan_preamble and architecture notes from the plan header}
+
+## Instructions
+1. Read all files listed above to understand current state and existing patterns.
+2. Implement the changes described, following the codebase's existing conventions.
+3. Run the project's test suite after implementation.
+4. Self-review your changes: check for missing edge cases, naming consistency, and adherence to acceptance criteria.
+5. Summarize what you did, what tests pass, and any concerns.
+
+## Constraints
+- Only modify the files listed above. If you discover a needed change in another file, report it as a blocker instead of making the change.
+- Follow existing code patterns (naming, structure, error handling).
+- Do not add AI attribution comments or generated-by markers.
+- If you encounter an ambiguity or need a decision from the user, report BLOCKED status with a clear description of what you need.
+```
+
+### Dispatch Mechanics
+
+For each execution group, in order:
+
+1. **Create tracking entries:** Call `TaskCreate` for each task in the group, recording task title, status `IN_PROGRESS`, and assigned group number.
+2. **Spawn agents:** For each task, spawn one Agent with:
+   - `subagent_type="general-purpose"`
+   - `isolation="worktree"` (each agent works in its own git worktree)
+   - `run_in_background=true`
+   - The filled-in prompt template as the agent's instructions.
+3. **Wait for group completion:** Wait for all agents in the current group to finish.
+4. **Process results:** Collect each agent's output and determine status (see Result Collection below).
+5. **Update tracking:** Call `TaskUpdate` for each task with its final status.
+6. **Proceed to next group:** If all tasks in the current group are DONE or if independent tasks in the next group are unblocked, move to the next group.
+
+### Result Collection
+
+Each completed subagent maps to one of three statuses:
+
+| Status    | Detection                                          | Action                                         |
+|-----------|----------------------------------------------------|-------------------------------------------------|
+| **DONE**  | All acceptance criteria met, tests pass            | Queue the task's branch for merge               |
+| **BLOCKED** | Agent reports needing info, a decision, or access to a file outside its scope | Pause all tasks that depend on this one, report the blocker to the user |
+| **FAILED** | Unrecoverable error (build failure, test crash, environment issue) | Pause all tasks that depend on this one, report the failure to the user |
+
+**Handling BLOCKED/FAILED tasks:**
+
+- All tasks that have a direct or transitive dependency on a BLOCKED/FAILED task are paused — they do not dispatch.
+- Tasks in the same or later groups that are independent of the failed task continue normally.
+- The orchestrator reports the situation to the user and waits for guidance before retrying paused tasks.
+
+---
+
+## 3. Merge Procedure
+
+### Merge Order
+
+Merge branches in topological order — a task's branch merges only after all of its dependencies have merged. Within the same execution group, merge in plan order (lower task ID first).
+
+### Per-Branch Merge
+
+For each completed task branch, in topological order:
+
+1. Run `git merge <worktree-branch> --no-edit` into the working branch.
+2. **Auto-merge succeeds:** Continue to the next branch. Clean up the worktree.
+3. **Conflict detected:** Stop the merge sequence immediately. Report to the user with:
+   - The conflicting file list (from `git diff --name-only --diff-filter=U`)
+   - Which task branches have merged so far
+   - Which task branches remain unmerged
+
+Do not attempt automatic conflict resolution. The user must resolve conflicts before the merge sequence continues.
+
+### Post-Merge Validation
+
+After all branches have merged successfully:
+
+1. Run the project's full test suite on the merged result.
+2. If tests pass, report success.
+3. If tests fail, report the failures with:
+   - Which tests failed
+   - Likely responsible task (based on which files the failing tests cover)
+   - Suggestion: re-run the responsible task's agent with the test failure as context.
+
+---
+
+## 4. Progress Reporting
+
+### At Start
+
+When orchestration begins, report:
+
+```
+Orchestrating 4 tasks across 3 execution groups.
+
+Dependency Graph:
+  Group 0 (parallel): Task 1 [Create database schema]
+  Group 1 (parallel): Task 2 [Build API endpoints], Task 3 [Add input validation]
+  Group 2 (parallel): Task 4 [Write integration tests]
+
+Dispatching Group 0...
+```
+
+### During Execution
+
+Use `TaskCreate` and `TaskUpdate` calls to maintain real-time status. Each task transitions through:
+
+```
+PENDING → IN_PROGRESS → DONE | BLOCKED | FAILED
+```
+
+When a group completes, announce it before dispatching the next:
+
+```
+Group 0 complete. All tasks DONE.
+Dispatching Group 1 (2 tasks in parallel)...
+```
+
+### At End — Success
+
+When all tasks complete successfully and merge cleanly:
+
+```
+All tasks complete.
+
+| Task | Title                    | Status | Branch                    |
+|------|--------------------------|--------|---------------------------|
+| 1    | Create database schema   | DONE   | work/1-database-schema    |
+| 2    | Build API endpoints      | DONE   | work/2-api-endpoints      |
+| 3    | Add input validation     | DONE   | work/3-input-validation   |
+| 4    | Write integration tests  | DONE   | work/4-integration-tests  |
+
+Merge: All 4 branches merged successfully.
+Tests: 47 passed, 0 failed.
+```
+
+### At End — Partial Failure
+
+When some tasks fail or are blocked:
+
+```
+Orchestration paused — 1 task blocked, 1 task not started.
+
+| Task | Title                    | Status      | Branch                    |
+|------|--------------------------|-------------|---------------------------|
+| 1    | Create database schema   | DONE        | work/1-database-schema    |
+| 2    | Build API endpoints      | DONE        | work/2-api-endpoints      |
+| 3    | Add input validation     | BLOCKED     | work/3-input-validation   |
+| 4    | Write integration tests  | NOT STARTED | —                         |
+
+Blocker (Task 3): "Validation rules not specified in plan — need user input on email format requirements."
+
+Merged so far: Task 1, Task 2.
+Awaiting: Resolve Task 3 blocker, then Task 3 and Task 4 can proceed.
+```

--- a/skills/work/orchestrator.md
+++ b/skills/work/orchestrator.md
@@ -42,7 +42,7 @@ Compare each pair of tasks' file lists to detect implicit dependencies. If two t
 
 1. Extract file paths from each task's `Files:` section — include all lines under `Create:`, `Modify:`, and `Test:`.
 2. For each pair `(i, j)` where `i < j`:
-   - Compute the intersection: `files[i] ∩ files[j]`
+   - Compute the intersection: `intersection(files[i], files[j])`
    - If the intersection is non-empty AND task `j` does not already depend on task `i` (directly or transitively), add `i` to task `j`'s `blockedBy`.
 3. Transitive check: task `j` already depends on task `i` transitively if there is any chain `j → ... → i` in the existing dependency graph. Do not add redundant edges.
 
@@ -193,15 +193,10 @@ After all branches have merged successfully:
 When orchestration begins, report:
 
 ```
-Orchestrating 4 tasks across 3 execution groups.
-
-Dependency Graph:
-  Group 0 (parallel): Task 1 [Create database schema]
-  Group 1 (parallel): Task 2 [Build API endpoints], Task 3 [Add input validation]
-  Group 2 (parallel): Task 4 [Write integration tests]
-
-Dispatching Group 0...
+Orchestrating {N} tasks across {M} execution groups.
 ```
+
+Print the dependency graph using the format shown in "Reporting the Graph" above, then announce dispatching the first group.
 
 ### During Execution
 

--- a/skills/work/orchestrator.md
+++ b/skills/work/orchestrator.md
@@ -2,6 +2,8 @@
 
 This document defines the subagent orchestration logic used by the work skill when a plan has 3+ tasks. It is NOT a standalone skill — it is referenced by `skills/work/SKILL.md` Phase 2.5.
 
+> **Scope distinction:** This document handles work-specific orchestration (dependency resolution, worktree isolation, merge procedure). For general-purpose agent team assembly and delegation, see `skills/orchestrate-agents/SKILL.md`.
+
 ---
 
 ## 1. Dependency Resolution


### PR DESCRIPTION
## Summary

Adds parallel subagent orchestration to the `/work` command, enabling multi-task plans to execute faster by spawning one agent per task in isolated git worktrees.

- **New file:** `skills/work/orchestrator.md` — defines the full orchestration lifecycle: dependency resolution, subagent dispatch with prompt templates, branch merge procedure, and progress reporting
- **Modified:** `skills/work/SKILL.md` — new Phase 2.5 (Orchestration Decision) routes plans with 3+ tasks to parallel execution while preserving sequential behavior for 1-2 task plans
- **Modified:** `commands/work.md` — mirrors Phase 2.5 in the slash command so both entry points support orchestration
- **Updated:** Anti-patterns and quality gates sections with orchestration-specific guidance

### How it works

1. `/work` loads a plan and counts tasks
2. **1-2 tasks →** existing sequential execution (no change)
3. **3+ tasks →** orchestration kicks in:
   - Builds a dependency graph from explicit `blockedBy` fields + automatic file overlap detection
   - Groups tasks into parallel execution waves
   - Spawns one `general-purpose` agent per task in its own git worktree (`isolation: "worktree"`)
   - Collects results (DONE / BLOCKED / FAILED), pauses dependents on failure
   - Merges worktree branches in topological order, stops on conflict
   - Runs post-merge test suite

### Design decisions

| Decision | Choice | Why |
|----------|--------|-----|
| No flags or modes | Auto-decides based on task count + dependencies | Simplicity — the skill should just work |
| Always worktree | Every subagent gets filesystem isolation | Prevents file conflicts between parallel agents |
| File overlap → sequential | Tasks sharing files run in dependency order | Reduces merge conflicts without user configuration |
| Manual conflict resolution | Reports conflicts, doesn't auto-resolve | Auto-resolution is unreliable and risky |
| Self-review only | No separate reviewer agents per task | Users can run `/review` separately if needed |

## Test plan

- [ ] Run `/work` on a plan with 1-2 tasks → verify sequential execution (unchanged behavior)
- [ ] Run `/work` on a plan with 3+ independent tasks → verify parallel dispatch in worktrees
- [ ] Run `/work` on a plan with `blockedBy` dependencies → verify correct group ordering
- [ ] Run `/work` on a plan where tasks share files → verify implicit dependency detection
- [ ] Verify merge completes cleanly for non-overlapping worktree branches