### PR TITLE
Replace command-template-system with command-rules

### DIFF
--- a/.claude/rules/command-rules.md
+++ b/.claude/rules/command-rules.md
@@ -1,0 +1,71 @@
+# Command Rules
+
+Hard rules and learned lessons for writing Quiver slash commands. Updated whenever a new issue is discovered.
+
+For structural patterns (role framing, decision trees, output format), read existing commands as examples -- `review.md`, `work.md`, `commit.md`. Adapt to the new command's purpose, don't copy mechanically.
+
+---
+
+## Hard Rules
+
+Non-negotiable. Every command must follow all of these. Violations break things.
+
+**R1. Frontmatter required.** YAML frontmatter with `name` + `description`. `name` must match filename without `.md`. Enables prefix-free access (`/handover` not `/quiver:handover`).
+
+**R2. Shell blocks exit 0.** Even when targets don't exist. Use `2>/dev/null || echo "NOT_FOUND: <path>"` or `|| echo "NO_GIT"`. Non-zero exit causes Claude Code to report shell failure before prompt logic runs.
+
+**R3. No shell logic.** No `$()` substitution, variable assignment, `if/else`, or logic-bearing pipes in `!` blocks. Claude Code blocks these in marketplace plugins.
+
+**R4. No `CLAUDE_PLUGIN_ROOT`.** Unavailable in command markdown files (only available in hooks).
+
+**R5. User decisions via `AskUserQuestion`.** Use action buttons, not plain text questions. Plain text loses button UI and degrades user experience.
+
+**R6. Confirm before destructive ops.** `rm`, file overwrite, `git push` require explicit user confirmation via `AskUserQuestion` before execution.
+
+**R7. Silent decision logic.** Don't show "Branch B selected" or mode labels to the user. Internal routing is implementation detail.
+
+**R8. ASCII-only.** No Unicode characters or emoji in command files and output templates. Project-wide constraint unless the file already contains Unicode.
+
+**R9. No AI attribution.** No `Co-authored-by` or similar in commits/PRs unless the user explicitly requests it.
+
+---
+
+## Learned Lessons
+
+Each lesson comes from a real failure. Add new entries when issues are discovered.
+
+**L1. Non-git CLI tools break with `||` in shell blocks.**
+`gh auth status 2>/dev/null || echo "NO_GH"` fails in marketplace sandbox. The permission parser splits `||` and evaluates each part independently. `git` commands are pre-approved, but `gh`, `curl`, `jq` are not.
+*Prevention:* For non-git tools, use `2>&1` redirection only. Detect errors from output text in prompt logic. Never use `||`, `&&`, `;` with non-git commands in `!` blocks.
+
+**L2. Step 0 git check must define fallback behavior.**
+Commands that depend on git but don't check for it fail silently or crash in non-git directories.
+*Prevention:* Every git-dependent command starts with `NO_GIT` check. Explicitly state what happens: "Stop here" (for git-required commands like `commit`) or "degrade gracefully" (for commands like `handover` that can work without git).
+
+**L3. Verify after every file write/delete.**
+Without verification, Claude assumes success. Silent write failures corrupt handover state, plans, or reports.
+*Prevention:* After every `Write`, `Edit`, or `rm`: read back the file (or re-list the directory) to confirm the operation succeeded. All existing commands do this -- new commands must too.
+
+**L4. Output placeholders left unfilled.**
+Claude sometimes outputs `{placeholder}` text verbatim instead of filling it with real values.
+*Prevention:* Verification step should confirm no raw `{...}` placeholder text remains in user-facing output.
+
+**L5. Anti-patterns must come from observed LLM failures.**
+Theoretical "don't" lists don't prevent real mistakes. Effective anti-patterns describe what Claude actually does wrong and why.
+*Prevention:* Each anti-pattern entry should state the bad behavior AND why it happens. Add new anti-patterns only when a real failure is observed.
+
+**L6. Cross-command references only when logical.**
+Old template forced `**Tip:** /quiver:x` lines on every command. Most were irrelevant and cluttered output.
+*Prevention:* Only add cross-command tips when the referenced command is a genuine next step in the user's workflow. If the command is self-contained, no tip needed.
+
+**L7. Multiple `AskUserQuestion` calls need independent flow control.**
+When a command has multiple user decision points, each must have its own stop/continue logic. "Asked but didn't use the answer" is a bug.
+*Prevention:* Each `AskUserQuestion` call must handle all its options (including Cancel) with explicit routing. No dangling decision points.
+
+**L8. Thorough first pass, not incremental discovery.**
+Shallow audits that miss issues force multiple "check again" rounds.
+*Prevention:* When a command performs any audit or validation (quality gates, verification), trace every data flow path end-to-end in one pass. Don't declare done until all categories are checked.
+
+**L9. Rules are mandatory, patterns are not.**
+Hard rules (this document) must be followed. But command structure (role framing format, decision tree layout, output template style) is not prescribed.
+*Prevention:* Learn structure from existing good commands. Read `review.md`, `work.md`, `commit.md` for examples. Don't copy them mechanically -- adapt to the new command's purpose.

--- a/.claude/rules/readme-structure.md
+++ b/.claude/rules/readme-structure.md
@@ -1,0 +1,114 @@
+# README Structure Template
+
+Reference: https://github.com/EveryInc/compound-engineering-plugin/tree/main/plugins/compound-engineering
+
+## Structure Order
+
+1. **Title + one-liner** — what the plugin does in one sentence
+2. **Status note** (optional) — development status callout via blockquote
+3. **Quick Start** — marketplace add + plugin install + first command example
+4. **Installation** — Plugin Install (recommended) as standalone section
+5. **Components table** — inventory of all component types with counts
+6. **Commands** — grouped by category (not one flat list)
+7. **Hooks** — table with hook name, event, and description
+8. **Skills** (when added) — grouped by category
+9. **Agents** (when added) — grouped by category (e.g. Review, Research, Workflow)
+10. **MCP Servers** (when added) — table with server name and description, plus tool details
+11. **How It Works** — bullet list of key features/mechanics
+12. **Setup** (optional) — any required config like .gitignore entries
+13. **Known Issues** (optional)
+14. **Uninstall**
+15. **License**
+
+## Formatting Rules
+
+### Component Inventory Table
+
+Always at the top, shows what the plugin contains at a glance:
+
+```markdown
+## Components
+
+| Component | Count |
+|-----------|-------|
+| Commands | 11 |
+| Hooks | 1 |
+| Skills | 6 |
+| Agents | 6 |
+```
+
+- Only list component types that exist
+- Update counts when adding new components
+
+### Grouping Commands/Skills/Agents
+
+Never use a single flat table for all items. Group by category with H3 headings:
+
+```markdown
+## Commands
+
+### Session Handover
+
+| Command | Description |
+|---------|-------------|
+| `/quiver:handover` | ... |
+| `/quiver:load-handover` | ... |
+
+### Git
+
+| Command | Description |
+|---------|-------------|
+| `/quiver:commit` | ... |
+```
+
+### Hooks Table
+
+Include three columns — name, event trigger, and description:
+
+```markdown
+## Hooks
+
+| Hook | Event | Description |
+|------|-------|-------------|
+| `pre-compact-handover` | PreCompact | ... |
+```
+
+### Agent Categories
+
+Group agents by role. Current categories:
+- **Review** — code review, security, performance
+- **Research** — docs, git history, best practices
+- **Workflow** — automation, linting, bug reproduction
+
+```markdown
+## Agents
+
+### Review
+
+| Agent | Description |
+|-------|-------------|
+| `agent-name` | ... |
+```
+
+### Skills Categories
+
+Group by domain:
+
+```markdown
+## Skills
+
+### Category Name
+
+| Skill | Description |
+|-------|-------------|
+| `skill-name` | ... |
+```
+
+## Checklist — When Updating README
+
+- [ ] Component inventory counts match actual files
+- [ ] All commands in `commands/` are listed
+- [ ] All hooks in `hooks/hooks.json` are listed
+- [ ] Commands/skills/agents are grouped by category, not flat
+- [ ] Descriptions are concise (one line)
+- [ ] No placeholder entries for components that have shipped

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,6 @@ marketing/
 .claude/reviews/
 .claude/plans/
 .claude/commands/
-.claude/templates/
 
 # Git worktrees
 .worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Dependencies: `bash`, `claude` CLI.
 - **`agents/`** — 6 agent definitions organized by category (`review/`, `research/`). Agents are persona prompts spawned as subagents.
 - **`hooks/`** — `hooks.json` registers event hooks; `scripts/` holds implementations. Currently one hook: PreCompact (fires before context compaction).
 - **Storage** — Handover files are written to `<project>/.claude/handovers/`.
-- **Templates** — `.claude/templates/` contains `command-template-system.md` (structural patterns for commands) and `readme-structure.md`.
+- **Rules** — `.claude/rules/` contains `command-rules.md` (hard rules and learned lessons for commands) and `readme-structure.md`.
 - **External MCP** — Context7 MCP server (`plugin.json` > `mcpServers`) provides real-time library documentation lookups for review agents.
 
 ## System Behavior
@@ -32,7 +32,7 @@ Dependencies: `bash`, `claude` CLI.
 2. Commands are **prompts**, not scripts. `` !`…` `` blocks gather raw data; the rest of the file is a prompt that tells Claude how to interpret the data, make decisions, and take actions with its own tools. Never write a bare code block without accompanying prompt guidance — marketplace users need commands that work out of the box.
 3. Do not use `$()` command substitution, variable assignment, `if/else`, or logic-bearing pipes in `` !`…` `` blocks — Claude Code blocks these in marketplace plugins.
 4. Do not reference `CLAUDE_PLUGIN_ROOT` — it is unavailable in commands.
-5. Follow the structural patterns defined in `.claude/templates/command-template-system.md` — role framing, decision trees, output templates, anti-patterns, quality gates, verification steps, and cross-command references.
+5. Follow the hard rules and learned lessons in `.claude/rules/command-rules.md`. For structural patterns (role framing, decision trees, output format), read existing commands (`review.md`, `work.md`, `commit.md`) as examples -- adapt to the new command's purpose, don't copy mechanically.
 6. Every `` !`…` `` block must exit 0 even when the target file or directory does not exist. Use the `|| echo "NOT_FOUND: <path>"` pattern (like the existing `|| echo "NO_GIT"` pattern for git commands) so the prompt receives actionable context instead of a silent failure. Reserve `|| true` only when no downstream logic needs to know the path was missing.
 
 ### Adding an Agent


### PR DESCRIPTION
## Summary

Migrates from the monolithic command-template-system to a leaner command-rules approach. Hard rules and learned lessons now live in `.claude/rules/command-rules.md`, while structural patterns are learned from existing commands rather than prescribed by a template. The README structure template moves to `.claude/rules/readme-structure.md`.

- **New:** `.claude/rules/command-rules.md` -- 9 hard rules (R1-R9) and 9 learned lessons (L1-L9)
- **New:** `.claude/rules/readme-structure.md` -- README formatting guidelines moved from templates
- **Modified:** `CLAUDE.md` -- references updated from `.claude/templates/` to `.claude/rules/`
- **Modified:** `.gitignore` -- removed `.claude/templates/` ignore entry

## Test plan

- [ ] Verify `.claude/rules/` files are loaded as project instructions
- [ ] Run a command-creating workflow to confirm rules are applied
- [ ] Confirm no remaining references to `.claude/templates/`