### PR TITLE
feat(work): project-wide plan discovery with fuzzy matching

### DIFF
--- a/commands/work.md
+++ b/commands/work.md
@@ -23,11 +23,11 @@ argument-hint: "<plan file path or task description>"
 ```
 
 ```
-!`ls -1 .claude/plans/ 2>/dev/null || echo "NOT_FOUND: .claude/plans/"`
+!`find . -maxdepth 4 -type d -name "plans" 2>/dev/null || echo "NOT_FOUND: plans dirs"`
 ```
 
 ```
-!`ls -1 plans/ 2>/dev/null || echo "NOT_FOUND: plans/"`
+!`ls -1 .claude/plans/ 2>/dev/null || echo "NOT_FOUND: .claude/plans/"`
 ```
 
 ---
@@ -53,28 +53,39 @@ If `$ARGUMENTS` is a file path (ends in `.md` or contains `/`):
 
 ### Case B: No arguments
 
-If `$ARGUMENTS` is empty, scan for existing plans from the gather-context output above (`.claude/plans/` and `plans/` directories).
+If `$ARGUMENTS` is empty, collect all `.md` files from every `plans/` directory discovered by the `find` block, plus the `.claude/plans/` listing from the `ls` block.
 
 **Plans found:**
-- If exactly one plan exists, read it and use `AskUserQuestion`:
-  > Found one plan: `{filename}`
+- If exactly one plan exists across all directories, read it and use `AskUserQuestion`:
+  > Found one plan: `{relative path}` (in `{directory}`)
   > **Goal:** {goal from plan}
   > **Steps:** {step count}
   Buttons: `["Execute this plan", "Other -- I'll provide a path or description"]`
-- If multiple plans exist, present them via `AskUserQuestion` with plan filenames as buttons (most recent first), plus an "Other -- I'll provide a path or description" option.
+- If multiple plans exist, present them via `AskUserQuestion` with full relative paths as buttons (most recent first), plus an "Other -- I'll provide a path or description" option. Show the directory in each label so the user can distinguish plans in different locations.
 - If the user picks "Other", ask for a path or task description.
 
 **No plans found:**
-> No plans found in `.claude/plans/` or `plans/`. Usage:
+> No plans found in any `plans/` directory. Usage:
 > - `/work <path-to-plan.md>` -- execute a specific plan
+> - `/work <plan-name>` -- search for a plan by name
 > - `/work <task description>` -- work on a task directly
 > - `/plan <task>` -- create a plan first
 **Stop here.**
 
-### Case C: Description provided
+### Case C: Name or description provided
 
-If `$ARGUMENTS` is a description (not a file path):
-- Check `.claude/plans/` and `plans/` for plans whose goal matches the description. If one matches, use it. If multiple match, present options via `AskUserQuestion`. If none match, treat the description as an inline task spec.
+If `$ARGUMENTS` is not a file path (does not end in `.md` and does not contain `/`) and is not empty:
+
+**Step C1 -- Discover plan files.** From the `find` output above, read every discovered `plans/` directory. For each directory, list its `.md` files. Combine with the `.claude/plans/` listing from the `ls` block. This gives you the full set of plan files across the project.
+
+**Step C2 -- Match by filename.** Compare `$ARGUMENTS` against each plan file's name (stem without `.md` extension):
+- **Exact match:** The stem equals `$ARGUMENTS` (case-insensitive). E.g., input `test-feature` matches `test-feature.md`.
+- **Partial match:** The stem contains `$ARGUMENTS` as a substring (case-insensitive). E.g., input `feature` matches `test-feature.md` and `test-feature-v2.md`.
+
+**Step C3 -- Rank and select.** Rank exact matches above partial matches.
+- **1 match** -- Read the plan file, print `> Executing plan: {filename} from {directory}`, proceed to Step 2. No confirmation needed.
+- **Multiple matches** -- Use `AskUserQuestion` to present candidates. Show full relative paths as button labels (e.g., `superpowers/plans/test-feature-v2.md`). Add a `"None of these -- treat as task description"` button.
+- **0 matches** -- Treat `$ARGUMENTS` as an inline task description. Print `> No matching plan found for "{$ARGUMENTS}". Treating as task description.` Proceed to Step 2 with the description as the work specification.
 
 ### After loading the plan
 

--- a/commands/work.md
+++ b/commands/work.md
@@ -166,7 +166,7 @@ Before shipping:
 2. After committing, use `AskUserQuestion`:
    > All work is committed on `{branch}`. What next?
    Buttons: `["Create a pull request", "Done -- I'll handle the rest"]`
-3. If creating a PR, draft title and summary, present for confirmation, then create via `gh pr create`.
+3. If creating a PR, delegate to `/quiver:create-pr`. It handles title generation, body formatting, push, and confirmation.
 4. Update plan frontmatter `status: active` to `status: completed` if applicable.
 5. Summarize: what was completed, PR link (if any), remaining follow-ups.
 

--- a/tests/commands/test-work-plan-discovery.sh
+++ b/tests/commands/test-work-plan-discovery.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+# test-work-plan-discovery.sh
+# Validates plan discovery: directory finding, filename matching, and edge cases.
+# Covers test cases 1-11 from the spec.
+
+set -e
+
+TEST_DIR="/tmp/quiver-plan-test"
+EXIT=0
+
+# --- Helpers ---
+
+pass() { echo "  PASS: $1"; }
+fail() { echo "  FAIL: $1"; EXIT=1; }
+
+assert_found() {
+  if echo "$1" | grep -qi "$2"; then
+    pass "$3"
+  else
+    fail "$3"
+  fi
+}
+
+assert_not_found() {
+  if echo "$1" | grep -qi "$2"; then
+    fail "$3"
+  else
+    pass "$3"
+  fi
+}
+
+# --- Setup ---
+
+rm -rf "$TEST_DIR"
+mkdir -p "$TEST_DIR/plans"
+mkdir -p "$TEST_DIR/.claude/plans"
+mkdir -p "$TEST_DIR/superpowers/plans"
+mkdir -p "$TEST_DIR/nested/deep/plans"
+mkdir -p "$TEST_DIR/a/b/c/d/e/plans"  # depth 5 -- should be excluded
+
+cat > "$TEST_DIR/plans/test-feature.md" << 'PLAN'
+---
+goal: Test feature plan
+steps: 3
+---
+## Steps
+- [ ] Step 1
+- [ ] Step 2
+- [ ] Step 3
+PLAN
+
+cat > "$TEST_DIR/superpowers/plans/test-feature-v2.md" << 'PLAN'
+---
+goal: Test feature v2
+steps: 2
+---
+## Steps
+- [ ] Step 1
+- [ ] Step 2
+PLAN
+
+cat > "$TEST_DIR/.claude/plans/review-fix-plan.md" << 'PLAN'
+---
+goal: Fix review findings
+steps: 4
+---
+## Steps
+- [ ] Step 1
+- [ ] Step 2
+- [ ] Step 3
+- [ ] Step 4
+PLAN
+
+cat > "$TEST_DIR/nested/deep/plans/deep-plan.md" << 'PLAN'
+---
+goal: Deep nested plan
+steps: 1
+---
+## Steps
+- [ ] Step 1
+PLAN
+
+cat > "$TEST_DIR/plans/another-thing.md" << 'PLAN'
+---
+goal: Another thing
+steps: 2
+---
+## Steps
+- [ ] Step 1
+- [ ] Step 2
+PLAN
+
+cat > "$TEST_DIR/a/b/c/d/e/plans/too-deep.md" << 'PLAN'
+---
+goal: Too deep to find
+steps: 1
+---
+## Steps
+- [ ] Step 1
+PLAN
+
+cd "$TEST_DIR"
+
+# --- Directory Discovery Tests ---
+
+echo "=== Directory Discovery ==="
+DIRS=$(find . -maxdepth 4 -type d -name "plans" 2>/dev/null)
+
+assert_found "$DIRS" "./plans" "Root plans/ discovered"
+assert_found "$DIRS" "./superpowers/plans" "superpowers/plans/ discovered"
+assert_found "$DIRS" "./nested/deep/plans" "nested/deep/plans/ discovered"
+assert_found "$DIRS" "./.claude/plans" ".claude/plans/ discovered via find"
+assert_not_found "$DIRS" "./a/b/c/d/e/plans" "Depth 5 excluded (maxdepth 4)"
+
+# --- .claude/plans/ ls block ---
+
+echo ""
+echo "=== .claude/plans/ ls block ==="
+LS_OUT=$(ls -1 .claude/plans/ 2>/dev/null || echo "NOT_FOUND")
+assert_found "$LS_OUT" "review-fix-plan.md" ".claude/plans/ contents listed via ls"
+
+# --- Collect all plan files (simulates prompt logic aggregation) ---
+
+ALL_PLANS=""
+for dir in $DIRS; do
+  FILES=$(ls -1 "$dir"/*.md 2>/dev/null || true)
+  ALL_PLANS="$ALL_PLANS
+$FILES"
+done
+
+echo ""
+echo "=== Test 1: Exact match in root plans/ ==="
+assert_found "$ALL_PLANS" "plans/test-feature.md" "Exact match: plans/test-feature.md"
+
+echo ""
+echo "=== Test 2: Exact match in .claude/plans/ ==="
+assert_found "$ALL_PLANS" ".claude/plans/review-fix-plan.md" "Exact match: .claude/plans/review-fix-plan.md"
+
+echo ""
+echo "=== Test 3: Partial match ==="
+PARTIAL=$(echo "$ALL_PLANS" | grep -i "feature" || true)
+assert_found "$PARTIAL" "test-feature.md" "Partial match finds test-feature.md"
+assert_found "$PARTIAL" "test-feature-v2.md" "Partial match finds test-feature-v2.md"
+
+echo ""
+echo "=== Test 4: Case-insensitive match ==="
+CASE_MATCH=$(echo "$ALL_PLANS" | grep -i "Test-Feature" || true)
+assert_found "$CASE_MATCH" "test-feature" "Case-insensitive match works"
+
+echo ""
+echo "=== Test 5: Nested directory discovery ==="
+assert_found "$ALL_PLANS" "nested/deep/plans/deep-plan.md" "Nested dir: deep-plan.md found"
+
+echo ""
+echo "=== Test 6: Superpowers directory ==="
+assert_found "$ALL_PLANS" "superpowers/plans/test-feature-v2.md" "superpowers/plans/ file found"
+
+echo ""
+echo "=== Test 7: Multiple matches across dirs ==="
+MULTI=$(echo "$ALL_PLANS" | grep -i "test" || true)
+COUNT=$(echo "$MULTI" | grep -c "." || true)
+if [ "$COUNT" -ge 2 ]; then
+  pass "Multiple matches found ($COUNT files match 'test')"
+else
+  fail "Expected 2+ matches for 'test', got $COUNT"
+fi
+
+echo ""
+echo "=== Test 8: No match ==="
+NO_MATCH=$(echo "$ALL_PLANS" | grep -i "nonexistent-xyz" || true)
+if [ -z "$NO_MATCH" ]; then
+  pass "No match for 'nonexistent-xyz' -- falls back to inline task"
+else
+  fail "Unexpected match for 'nonexistent-xyz'"
+fi
+
+echo ""
+echo "=== Test 9: Path input (Case A) ==="
+if [ -f "plans/test-feature.md" ]; then
+  pass "Direct path plans/test-feature.md exists and is readable"
+else
+  fail "Direct path plans/test-feature.md not found"
+fi
+
+echo ""
+echo "=== Test 10: No args lists all plans ==="
+TOTAL=$(echo "$ALL_PLANS" | grep -c "\.md$" || true)
+if [ "$TOTAL" -ge 5 ]; then
+  pass "All plans discovered ($TOTAL .md files across all dirs)"
+else
+  fail "Expected 5+ plans, found $TOTAL"
+fi
+
+echo ""
+echo "=== Test 11: Beyond depth limit ==="
+assert_not_found "$ALL_PLANS" "too-deep.md" "Depth 5 file excluded from results"
+
+# --- Cleanup ---
+
+rm -rf "$TEST_DIR"
+
+echo ""
+echo "================================"
+if [ $EXIT -eq 0 ]; then
+  echo "All tests passed."
+else
+  echo "Some tests FAILED."
+fi
+exit $EXIT


### PR DESCRIPTION
## Summary

- Replace hardcoded `.claude/plans/` and `plans/` scanning with `find`-based discovery of all `plans/` directories (maxdepth 4)
- Rewrite Case B (no args) to list plans from all discovered directories
- Rewrite Case C to support filename-based substring matching with exact > partial ranking

## Test plan

- [x] Self-contained test script (`tests/commands/test-work-plan-discovery.sh`) covers 11 test cases
- [x] All tests pass: directory discovery, exact/partial/case-insensitive matching, depth limits, edge cases
- [x] `work.md` verified against all command rules (R1-R9)