### PR TITLE
feat: add brainstorm command and visual companion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ marketing/
 
 # Claude Code Plugin files
 docs/superpowers/
+docs/
 
 # Git worktrees
 .worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,6 @@ marketing/
 .claude/commands/
 
 # Claude Code Plugin files
-docs/superpowers/
 docs/
 
 # Git worktrees

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Dependencies: `bash`, `claude` CLI.
 ## Architecture
 
 - **`.claude-plugin/`** — Plugin manifest (`plugin.json`) and marketplace listing (`marketplace.json`). Defines name, version, hook/command/skill/agent registration, and MCP servers.
-- **`commands/`** — 11 markdown slash commands. Each file has YAML front-matter (`name`, `description`) and is a self-contained prompt.
+- **`commands/`** — 13 markdown slash commands. Each file has YAML front-matter (`name`, `description`) and is a self-contained prompt.
 - **`skills/`** — 6 skill directories (each contains `SKILL.md`). Skills are prompt-based references that commands and agents can invoke. **Exception:** `visual-companion` also contains `server.py`, a runtime executable -- this is the only skill with non-prompt code.
 - **`agents/`** — 6 agent definitions organized by category (`review/`, `research/`). Agents are persona prompts spawned as subagents.
 - **`hooks/`** — `hooks.json` registers event hooks; `scripts/` holds implementations. Currently one hook: PreCompact (fires before context compaction).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Dependencies: `bash`, `claude` CLI.
 
 - **`.claude-plugin/`** — Plugin manifest (`plugin.json`) and marketplace listing (`marketplace.json`). Defines name, version, hook/command/skill/agent registration, and MCP servers.
 - **`commands/`** — 11 markdown slash commands. Each file has YAML front-matter (`name`, `description`) and is a self-contained prompt.
-- **`skills/`** — 6 skill directories (each contains `SKILL.md`). Skills are prompt-based references that commands and agents can invoke.
+- **`skills/`** — 6 skill directories (each contains `SKILL.md`). Skills are prompt-based references that commands and agents can invoke. **Exception:** `visual-companion` also contains `server.py`, a runtime executable -- this is the only skill with non-prompt code.
 - **`agents/`** — 6 agent definitions organized by category (`review/`, `research/`). Agents are persona prompts spawned as subagents.
 - **`hooks/`** — `hooks.json` registers event hooks; `scripts/` holds implementations. Currently one hook: PreCompact (fires before context compaction).
 - **Storage** — Handover files are written to `<project>/.claude/handovers/`.

--- a/commands/brainstorm.md
+++ b/commands/brainstorm.md
@@ -26,6 +26,14 @@ argument-hint: "<idea or feature description>"
 !`ls .claude/plans/ 2>/dev/null || echo "NOT_FOUND: .claude/plans/"`
 ```
 
+```
+!`ls -1 *.md *.json *.yaml *.yml 2>/dev/null || echo "NOT_FOUND: root config files"`
+```
+
+```
+!`ls src/ lib/ app/ packages/ commands/ components/ 2>/dev/null || echo "NOT_FOUND: source dirs"`
+```
+
 ---
 
 # Instructions
@@ -58,6 +66,37 @@ Buttons: `["Skip brainstorm -- go to /plan", "Brainstorm anyway"]`
 
 If user picks "Skip brainstorm", **stop here** and suggest running `/plan <task>`.
 
+### Decomposition Check
+
+After assessing complexity, evaluate whether the idea is too large for a single spec:
+
+**Trigger signals:**
+- The description contains 3+ independent subsystems (e.g., "chat, file management, billing")
+- Components span different technology layers (backend + frontend + mobile + infra)
+- Estimated affected file count exceeds 20+
+
+If any trigger fires, use `AskUserQuestion`:
+> This idea contains multiple independent subsystems. Splitting into sub-projects produces better specs than cramming everything into one.
+Buttons: `["Split into sub-projects", "Continue as single spec"]`
+
+**If "Split":** List the identified sub-projects with a recommended order. Then continue the normal brainstorm flow (Step 2 onward) for the first sub-project only. At the end (Step 7), note: "Remaining sub-projects: [list]. Run `/brainstorm` for each when ready."
+
+**If "Single spec":** Continue normal flow. User decision takes priority.
+
+## Step 1.5 -- Visual Companion Offer
+
+If the idea involves UI/UX, layout, design, architecture diagrams, or other visual content:
+
+Use `AskUserQuestion`:
+> This topic is well-suited for visual content. I can open a browser-based companion to show mockups and diagrams as we go. Want to try it?
+Buttons: `["Yes, open visual companion", "No, continue with text"]`
+
+**If "Yes":** Read the `visual-companion` skill for setup instructions. Start the companion server and keep it running throughout the brainstorm session. For each step that involves a visual question, write HTML content and direct the user to their browser. For text-only questions, continue in the terminal.
+
+**If "No":** Continue with normal text-only flow.
+
+**If the topic is NOT visual** (pure backend, data model, API design, etc.): Skip this step entirely. Do not offer the companion.
+
 ## Step 2 -- Clarifying Questions
 
 Ask questions to fill gaps in your understanding. Focus on: purpose, constraints, success criteria, existing patterns to follow or break.
@@ -87,6 +126,7 @@ Present 2-3 distinct approaches. Each approach must include:
 **Lead with your recommendation.** Mark it clearly and explain why in 1-2 sentences. Do not be neutral -- take a position.
 
 **Rules:**
+- Approaches must reference actual project structure observed in gather-context. Do not propose patterns that conflict with the project's existing conventions. When evaluating approaches, penalize complexity that does not directly serve the stated requirements.
 - Approaches must be genuinely different strategies, not cosmetic variations of the same idea.
 - Ground approaches in the actual codebase context (existing patterns, frameworks, conventions observed from gather-context).
 - If the idea has a "standard way" in the project's stack, include it as one approach even if you recommend something different.
@@ -162,6 +202,11 @@ Write the validated design as a spec document. Scale section depth to complexity
 
 ## Success Criteria
 [How we know this is done and working correctly]
+
+## Design Principles Applied  <!-- Standard and Deep only -->
+- **YAGNI:** [Features explicitly removed or deferred from this spec, with reasons]
+- **Single Responsibility:** [Each unit's sole responsibility]
+- **Interface Clarity:** [Communication interfaces between units]
 ```
 
 **Rules:**
@@ -169,6 +214,8 @@ Write the validated design as a spec document. Scale section depth to complexity
 - Standard depth: All sections except Alternatives Considered.
 - Deep depth: All sections.
 - No placeholders -- every section must have real content. If you cannot fill a section, remove it.
+- Standard and Deep depth: "Design Principles Applied" section is required. Quick depth: optional.
+- Always write spec documents in English, regardless of the conversation language. Only write in another language if the user explicitly requests it.
 
 ### Save the spec:
 
@@ -215,3 +262,5 @@ Handle each response:
 - **Don't** force questions when the user gave a clear, detailed description -- assess and skip if appropriate.
 - **Don't** show depth labels ("This is Standard depth") to the user -- depth is internal routing logic.
 - **Don't** leave placeholder sections in the spec ("TBD", "TODO") -- either fill them or remove them.
+- **Don't** add features the user didn't ask for -- if it's not in the requirements, it's not in the spec. Ask the user before adding "nice to have" features.
+- **Don't** design for hypothetical future requirements -- solve the problem at hand. If the user says "we might need X later", note it in Open Questions, don't architect for it now.

--- a/commands/brainstorm.md
+++ b/commands/brainstorm.md
@@ -1,0 +1,217 @@
+---
+name: brainstorm
+description: Explore ideas, compare approaches, and produce a validated spec before planning.
+argument-hint: "<idea or feature description>"
+---
+
+# Gather Context
+
+```
+!`git rev-parse --is-inside-work-tree 2>/dev/null || echo "NO_GIT"`
+```
+
+```
+!`git branch --show-current 2>/dev/null || echo "NO_GIT"`
+```
+
+```
+!`git log --oneline -5 2>/dev/null || echo "NO_GIT"`
+```
+
+```
+!`ls docs/brainstorms/ 2>/dev/null || echo "NOT_FOUND: docs/brainstorms/"`
+```
+
+```
+!`ls .claude/plans/ 2>/dev/null || echo "NOT_FOUND: .claude/plans/"`
+```
+
+---
+
+# Instructions
+
+You are a brainstorming partner. Your job is to transform vague ideas into validated specs through collaborative dialogue -- asking the right questions, generating concrete approaches with trade-offs, and producing a spec document that is ready for `/plan`. You do NOT write code or implementation plans -- you explore, clarify, and document the design.
+
+## Step 0 -- Validate Input
+
+If any gather-context block returned `NO_GIT`, this directory is not a git repository.
+Print: `> No git repository detected -- skipping branch/commit context.`
+Proceed to Step 1. Treat all git-sourced fields as empty.
+
+If `$ARGUMENTS` is empty and the conversation has no obvious pending idea:
+> No idea to brainstorm. Usage: `/brainstorm <describe your idea or challenge>`
+**Stop here.**
+
+## Step 1 -- Understand and Assess Complexity
+
+Restate the idea in one sentence, then assess its complexity silently (do not show the assessment label to the user).
+
+| Depth | Signals | Behavior |
+|-------|---------|----------|
+| **Quick** | 1-3 files, single layer, well-understood domain, clear scope | 0-1 clarifying questions, 2 short approaches, brief spec (~50 lines) |
+| **Standard** | 3-10 files, 2+ layers, some ambiguity or design choices | 2-3 clarifying questions, 2-3 detailed approaches, standard spec (~100-150 lines) |
+| **Deep** | 10+ files, architectural impact, new domain, security/auth/payments | 3-4 clarifying questions, 3 comprehensive approaches with alternatives considered, full spec (~200+ lines) |
+
+**Quick-exit for trivial ideas:** If the idea is trivial (single file, obvious implementation), use `AskUserQuestion`:
+> This is straightforward enough to plan directly without a brainstorm session.
+Buttons: `["Skip brainstorm -- go to /plan", "Brainstorm anyway"]`
+
+If user picks "Skip brainstorm", **stop here** and suggest running `/plan <task>`.
+
+## Step 2 -- Clarifying Questions
+
+Ask questions to fill gaps in your understanding. Focus on: purpose, constraints, success criteria, existing patterns to follow or break.
+
+**Rules:**
+- Use `AskUserQuestion` with action buttons -- never ask as plain text.
+- Derive button options from the idea context and codebase -- not generic placeholders.
+- Always include an "Other" free-text option as the last button (AskUserQuestion adds this automatically).
+- **Question count follows depth:** Quick = 0-1, Standard = 2-3, Deep = 3-4.
+- **Group independent questions.** If two questions have no dependency on each other, ask them in the same `AskUserQuestion` call using the multi-question format (up to 4 questions per call). Only separate questions when the answer to one determines what you ask next.
+- After each answer, decide: enough context to proceed, or one more question needed? Do not ask questions for the sake of filling a quota.
+
+**When to skip questions entirely:**
+- The user provided a detailed description with clear scope, constraints, and success criteria
+- The idea is a well-known pattern (CRUD, auth, API endpoint) with obvious implementation paths
+- The user explicitly said "just brainstorm approaches" without wanting scope refinement
+
+## Step 3 -- Generate Approaches
+
+Present 2-3 distinct approaches. Each approach must include:
+
+1. **Name** -- short, descriptive (e.g., "Event-driven pipeline", "Simple polling loop")
+2. **How it works** -- 3-5 sentences describing the approach
+3. **Trade-offs** -- explicit pros and cons
+4. **Best for** -- when this approach shines
+
+**Lead with your recommendation.** Mark it clearly and explain why in 1-2 sentences. Do not be neutral -- take a position.
+
+**Rules:**
+- Approaches must be genuinely different strategies, not cosmetic variations of the same idea.
+- Ground approaches in the actual codebase context (existing patterns, frameworks, conventions observed from gather-context).
+- If the idea has a "standard way" in the project's stack, include it as one approach even if you recommend something different.
+- For Quick depth: 2 approaches, concise (3-4 lines each). For Deep: 3 approaches, detailed (8-12 lines each).
+
+Present approaches and use `AskUserQuestion`:
+> Which approach do you want to go with?
+Buttons: approach names as labels, one-line summaries as descriptions.
+
+## Step 4 -- Executive Summary Gate
+
+After the user selects an approach, present a concise executive summary. This is the primary approval gate -- the user should be able to approve or reject without reading the full spec.
+
+```
+## Executive Summary
+
+**What:** [1 sentence -- what we are building/changing]
+**Approach:** [selected approach name] -- [1 sentence why]
+**Key decisions:**
+- [decision 1]
+- [decision 2]
+- [decision 3 if needed]
+
+**Scope:**
+- Touches: [modules/areas affected]
+- Out of scope: [what we are NOT doing]
+```
+
+Use `AskUserQuestion`:
+> Does this direction look right?
+Buttons: `["Approve -- write the spec", "Adjust -- I want to change something", "Restart -- pick a different approach"]`
+
+Handle each response:
+- **Approve** -- proceed to Step 5.
+- **Adjust** -- ask what to change, revise the summary, and re-present.
+- **Restart** -- go back to Step 3 with the adjustment context.
+
+## Step 5 -- Write Spec Document
+
+Write the validated design as a spec document. Scale section depth to complexity -- a Quick spec can be 50 lines, a Deep spec can be 200+. Not every section is required for every depth.
+
+**Document structure:**
+
+```markdown
+# [Feature/Idea Name] -- Brainstorm Spec
+
+**Date:** YYYY-MM-DD
+**Status:** Draft
+**Depth:** Quick | Standard | Deep
+
+## Executive Summary
+[Copy from Step 4 -- this is the approved summary]
+
+## Context
+[Why this idea exists. What problem it solves. Any prior art or existing patterns.]
+
+## Design
+
+### Chosen Approach: [Name]
+[Detailed description of the selected approach]
+
+### Key Decisions
+[Numbered list of design decisions with brief rationale for each]
+
+### Affected Areas
+[File paths, modules, or system boundaries that will be touched]
+
+## Alternatives Considered  <!-- Deep only -->
+[Other approaches from Step 3, with why they were not chosen]
+
+## Open Questions  <!-- if any remain -->
+[Questions that surfaced during brainstorming but were deferred to planning phase]
+
+## Success Criteria
+[How we know this is done and working correctly]
+```
+
+**Rules:**
+- Quick depth: Executive Summary + Design + Success Criteria. Skip Context, Alternatives, Open Questions unless they add value.
+- Standard depth: All sections except Alternatives Considered.
+- Deep depth: All sections.
+- No placeholders -- every section must have real content. If you cannot fill a section, remove it.
+
+### Save the spec:
+
+1. Create `docs/brainstorms/` if it does not exist.
+2. Write the spec as `docs/brainstorms/YYYY-MM-DD-<descriptive-name>.md` (use `date '+%Y-%m-%d'` for the date prefix).
+3. **Verify:** Read the file back and confirm it was written correctly. Confirm no raw `{...}` placeholder text remains.
+
+## Step 6 -- Spec Self-Review
+
+After writing, review with fresh eyes:
+
+1. **Placeholder scan:** Any "TBD", "TODO", unfilled sections, or vague requirements like "add appropriate handling"? Fix them inline.
+2. **Internal consistency:** Do sections contradict each other? Does the design match the executive summary?
+3. **Scope check:** Is this focused enough for a single `/plan` session, or should it be decomposed into sub-specs?
+4. **Ambiguity check:** Could any requirement be interpreted two different ways? Pick one interpretation and make it explicit.
+
+Fix any issues by editing the saved file. No need to re-review after fixes.
+
+## Step 7 -- User Review Gate
+
+After self-review passes, present the user with the opportunity to review:
+
+Use `AskUserQuestion`:
+- **question:** "Spec saved to `docs/brainstorms/{filename}`. You can review it now or move forward. What would you like to do?"
+- Buttons:
+  1. `"Looks good -- move to planning"` / "Invoke /plan with this spec as input"
+  2. `"Let me review first"` / "I want to read the spec and may request changes"
+  3. `"Save and stop"` / "Keep the spec, I will plan later"
+
+Handle each response:
+- **Looks good -- move to planning** -- invoke the `plan` skill with the spec path as context: "Plan the implementation based on the brainstorm spec at `docs/brainstorms/{filename}`"
+- **Let me review first** -- say: "Take your time. When you are ready, let me know if you want changes or if we should move to `/plan`." **Stop here** and wait.
+- **Save and stop** -- stop here.
+
+---
+
+## Anti-Patterns
+
+- **Don't** skip the executive summary gate -- it exists so users do not have to read 200-line specs to approve direction.
+- **Don't** write implementation details or code -- that is `/plan`'s job. Specs describe WHAT and WHY, not HOW at the code level.
+- **Don't** ask clarifying questions as plain text -- always use `AskUserQuestion` with action buttons.
+- **Don't** present more than 3 approaches -- decision fatigue kills momentum. 2-3 is the sweet spot.
+- **Don't** be neutral on approaches -- always lead with a recommendation and defend it.
+- **Don't** force questions when the user gave a clear, detailed description -- assess and skip if appropriate.
+- **Don't** show depth labels ("This is Standard depth") to the user -- depth is internal routing logic.
+- **Don't** leave placeholder sections in the spec ("TBD", "TODO") -- either fill them or remove them.

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -234,12 +234,38 @@ Using the synthesized research, draft the plan following this document structure
 | **Standard** | Standard | + Context (with agent findings), Risks, File Map |
 | **Comprehensive** | Deep | + Alternatives Considered, Phased Rollout, Rollback Strategy, Architectural Constraints |
 
+**File structure mapping (before defining tasks):**
+Map out which files will be created, modified, or deleted. This locks in decomposition decisions before task writing begins.
+- Create: `exact/path/to/new-file.ext` -- one-line purpose
+- Modify: `exact/path/to/existing.ext` -- what changes and why
+- Test: `tests/path/to/test-file.ext` -- which test files are new or updated
+- Delete: `exact/path/to/removed.ext` -- only if applicable
+
 **Task granularity:**
 - Each step: 2-10 minutes, independently verifiable
 - Pattern: what to do, which file(s), expected outcome
 - Include exact file paths from Explore findings
 - Incorporate best practices into step design
 - Respect architectural boundaries from architecture-strategist
+
+**TDD task structure (when the project has tests):**
+If the Explore agent found an existing test framework, structure each task following the TDD cycle:
+1. Write the failing test (show exact test code)
+2. Run the test -- confirm it fails with the expected error
+3. Write the minimal implementation to make it pass
+4. Run the test -- confirm it passes
+5. Commit
+
+Not every task requires TDD (e.g., config changes, docs, migrations). Apply it to tasks that produce testable behavior.
+
+**No placeholders rule:**
+Every step must contain actionable content. These are plan failures -- never write them:
+- "TBD", "TODO", "implement later", "fill in details"
+- "Add appropriate error handling" / "add validation" / "handle edge cases"
+- "Write tests for the above" (without actual test code or at minimum the test scenario description)
+- "Similar to Task N" (repeat the relevant details -- the implementer may read tasks out of order)
+- Steps that describe what to do without showing how (include code blocks, commands, or exact file paths)
+- References to types, functions, or methods not defined in any task (if a step calls `processItems()`, some task must define it)
 
 **Research integration (mandatory):**
 - If best-practices-researcher flagged a deprecation, the plan must avoid the deprecated pattern
@@ -260,7 +286,18 @@ review_iteration: 1  # increments for each fix plan targeting the same review
 - Add a verification criterion (e.g., "flutter analyze passes clean")
 - These criteria become the Definition of Done -- the work skill uses them to determine when the review-fix cycle is COMPLETE and to prevent infinite re-review loops
 
-## Step 6 -- Review Gate
+## Step 6 -- Plan Self-Review
+
+After drafting the plan, review it before presenting to the user. This is an internal check -- do not show it as a separate section to the user.
+
+1. **Spec coverage:** If the task originated from a brainstorm spec or review report, skim each requirement. Can you point to a task that implements it? Add missing tasks.
+2. **Placeholder scan:** Search for "TBD", "TODO", "implement later", vague steps without file paths or code. Fix them.
+3. **Naming consistency:** Do function names, type names, and variable names match across tasks? A function called `clearLayers()` in Task 3 but `clearFullLayers()` in Task 7 is a bug in the plan.
+4. **Test coverage:** Does every task that produces testable behavior have a corresponding test step? If the project has tests, missing test steps are plan gaps.
+
+Fix issues inline. No need to re-review after fixes -- just fix and move on.
+
+## Step 7 -- Review Gate
 
 Present the full plan to the user. Then call the `AskUserQuestion` tool with these parameters:
 
@@ -275,11 +312,11 @@ Present the full plan to the user. Then call the `AskUserQuestion` tool with the
 If the plan exceeds 15 steps, append to the question: " Consider splitting into sub-plans or phasing the work."
 
 Handle each response:
-- **Approve** -- move to Step 7. Do NOT stop after approval.
+- **Approve** -- move to Step 8. Do NOT stop after approval.
 - **Modify** -- ask which steps to change, revise the plan, and re-present with `AskUserQuestion` again.
 - **Reject** -- abandon the plan. **Stop here.**
 
-## Step 7 -- Save and Follow-up
+## Step 8 -- Save and Follow-up
 
 **This step has TWO mandatory parts. Do NOT stop after saving.**
 

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -267,6 +267,8 @@ Every step must contain actionable content. These are plan failures -- never wri
 - Steps that describe what to do without showing how (include code blocks, commands, or exact file paths)
 - References to types, functions, or methods not defined in any task (if a step calls `processItems()`, some task must define it)
 
+**Language rule:** Always write plan documents in English, regardless of the conversation language. Only write in another language if the user explicitly requests it.
+
 **Research integration (mandatory):**
 - If best-practices-researcher flagged a deprecation, the plan must avoid the deprecated pattern
 - If architecture-strategist identified boundary constraints, steps must respect them

--- a/skills/visual-companion/SKILL.md
+++ b/skills/visual-companion/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: visual-companion
+description: Browser-based visual brainstorming companion for showing mockups, diagrams, and visual options. Use when brainstorm topics involve UI/UX, layout, architecture diagrams, or any content better understood visually.
+---
+
+# Visual Companion
+
+A browser-based companion for displaying mockups, wireframes, architecture diagrams, and side-by-side visual comparisons during brainstorm sessions.
+
+## 1. When to Use
+
+Decide **per question** whether to show content in the browser or keep it in the terminal.
+
+**Use the browser for:**
+- UI mockups and wireframes
+- Architecture diagrams and system maps
+- Side-by-side visual comparisons (layout A vs. layout B)
+- Spatial relationships (grid layouts, navigation flows, screen transitions)
+- Color palettes, typography samples, component galleries
+
+**Use the terminal for:**
+- Requirements questions and conceptual choices
+- Tradeoff lists and technical decisions
+- Clarifying questions about scope or constraints
+- API design, data models, algorithm selection
+
+A question about a UI topic is not automatically a visual question. "Should we use tabs or accordion?" is a terminal question. "Here are two tab layouts -- which one?" is a browser question.
+
+## 2. Starting a Session
+
+1. Create a temporary directory for HTML files:
+   ```
+   mktemp -d /tmp/visual-companion-XXXXXX
+   ```
+
+2. Start a local server in the background:
+   ```
+   python3 -m http.server 8432 --directory <temp-dir> &
+   ```
+
+3. Save the server PID for cleanup:
+   ```
+   echo $! > <temp-dir>/.server-pid
+   ```
+
+4. Tell the user:
+   > Visual companion is running. Open http://localhost:8432 in your browser.
+   > I will tell you when to refresh for new content.
+
+## 3. The Loop
+
+For each visual step in the brainstorm:
+
+1. **Write an HTML file** to the temp directory with a semantic filename (e.g., `layout-options.html`, `navigation-flow.html`).
+2. **Never reuse filenames.** Each screen gets a fresh file. For iterations, append a version suffix: `layout-options-v2.html`.
+3. **Tell the user** to open the specific file URL: `http://localhost:8432/layout-options.html`
+4. **User provides feedback** in the terminal. There is no client-side event system -- all communication happens through the normal conversation.
+5. **When returning to terminal-only questions:** Push a placeholder page so the user knows the visual step is done:
+   ```html
+   <div style="display:flex;align-items:center;justify-content:center;height:100vh;font-family:system-ui;color:#666">
+     <p>Continuing in terminal...</p>
+   </div>
+   ```
+
+## 4. HTML Content Guide
+
+Write content fragments, not full documents. Each HTML file should be self-contained with inline styles.
+
+### Frame Template
+
+Use this base structure for all visual pages:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{Page Title}</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: system-ui, -apple-system, sans-serif; padding: 2rem; background: #fafafa; color: #1a1a1a; }
+  h1 { font-size: 1.5rem; margin-bottom: 1.5rem; }
+  h2 { font-size: 1.1rem; margin-bottom: 1rem; color: #444; }
+
+  /* Options grid -- side-by-side approach comparison */
+  .options { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1.5rem; }
+  .option { background: #fff; border: 2px solid #e0e0e0; border-radius: 8px; padding: 1.5rem; }
+  .option.recommended { border-color: #2563eb; }
+  .option h3 { margin-bottom: 0.75rem; }
+
+  /* Cards -- feature or component gallery */
+  .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; }
+  .card { background: #fff; border: 1px solid #e5e5e5; border-radius: 6px; padding: 1rem; }
+
+  /* Mockup container -- wireframe wrapper */
+  .mockup { background: #fff; border: 1px solid #ddd; border-radius: 8px; padding: 1rem; max-width: 800px; margin: 0 auto; }
+
+  /* Split view -- two-panel comparison */
+  .split { display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; }
+
+  /* Pros and cons */
+  .pros-cons { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+  .pros-cons .pros { color: #16a34a; }
+  .pros-cons .cons { color: #dc2626; }
+
+  /* Mock UI elements for wireframes */
+  .mock-nav { background: #f3f4f6; padding: 0.75rem 1rem; border-bottom: 1px solid #e5e5e5; display: flex; gap: 1rem; align-items: center; }
+  .mock-sidebar { background: #f9fafb; padding: 1rem; border-right: 1px solid #e5e5e5; min-width: 200px; }
+  .mock-content { padding: 1.5rem; flex: 1; }
+  .mock-button { display: inline-block; background: #2563eb; color: #fff; padding: 0.5rem 1rem; border-radius: 4px; font-size: 0.875rem; }
+  .mock-input { display: block; width: 100%; padding: 0.5rem; border: 1px solid #d1d5db; border-radius: 4px; background: #fff; margin-bottom: 0.5rem; }
+</style>
+</head>
+<body>
+  <!-- Content here -->
+</body>
+</html>
+```
+
+### Layout Patterns
+
+- **Options grid:** Use `.options` + `.option` for comparing 2-3 approaches visually. Mark the recommended option with `.recommended`.
+- **Cards:** Use `.cards` + `.card` for component galleries or feature inventories.
+- **Mockup:** Use `.mockup` with `.mock-nav`, `.mock-sidebar`, `.mock-content` for wireframes.
+- **Split view:** Use `.split` for before/after or A/B comparisons.
+- **Pros/cons:** Use `.pros-cons` for tradeoff visualization.
+
+## 5. Cleaning Up
+
+When the brainstorm session ends:
+
+1. Kill the server:
+   ```
+   kill $(cat <temp-dir>/.server-pid) 2>/dev/null
+   ```
+
+2. HTML files remain in the temp directory for reference.
+
+3. Optionally copy key mockups to `docs/brainstorms/` alongside the spec:
+   ```
+   cp <temp-dir>/final-layout.html docs/brainstorms/YYYY-MM-DD-<name>-mockups/
+   ```

--- a/skills/visual-companion/SKILL.md
+++ b/skills/visual-companion/SKILL.md
@@ -39,9 +39,9 @@ A question about a UI topic is not automatically a visual question. "Should we u
    ```
    `<skill-dir>` is resolved by the invoking agent to the absolute path of `skills/visual-companion/`.
 
-3. Read `server-info.json` from `<temp-dir>` to get the URL and port:
+3. Read `server-info.json` from the `.vc-meta` subdirectory to get the URL and port:
    ```
-   cat <temp-dir>/server-info.json
+   cat <temp-dir>/.vc-meta/server-info.json
    ```
    Returns `{"port": N, "pid": N, "url": "http://localhost:N"}`.
 
@@ -56,7 +56,7 @@ For each visual step in the brainstorm:
 2. **Never reuse filenames.** Each screen gets a fresh file. For iterations, append a version suffix: `layout-options-v2.html`.
 3. **Browser auto-reloads** via SSE when a new or changed `.html` file is detected. No manual refresh needed.
 4. **For clickable options:** Use `data-choice` attributes on elements. The client JS handles selection toggling and event capture.
-5. **Read events:** Before the next question, read `<temp-dir>/events.jsonl` to check for user clicks.
+5. **Read events:** Before the next question, read `<temp-dir>/.vc-meta/events.jsonl` to check for user clicks.
 6. **Clear events:** `DELETE /events` before presenting a new visual question to clear prior selections.
 7. **Terminal-only steps:** No browser action needed. Optionally push a placeholder page:
    ```html
@@ -100,7 +100,7 @@ Add `data-choice` attributes to elements that users can click to make selections
 When a user clicks a `[data-choice]` element:
 - The `.selected` class is added (blue border + light blue background)
 - Previous selections within the same parent are deselected
-- A JSON event is appended to `events.jsonl`:
+- A JSON event is appended to `.vc-meta/events.jsonl`:
   ```
   {"type":"choice","choice":"grid","text":"Grid Layout Content arranged in a responsive grid","timestamp":"2026-04-09T14:30:00.000Z"}
   ```
@@ -121,7 +121,7 @@ The server self-terminates in two cases:
 
 To stop manually:
 ```
-kill $(cat <temp-dir>/server-info.json | python3 -c "import sys,json; print(json.load(sys.stdin)['pid'])") 2>/dev/null
+kill $(cat <temp-dir>/.vc-meta/server-info.json | python3 -c "import sys,json; print(json.load(sys.stdin)['pid'])") 2>/dev/null
 ```
 
 HTML files remain in the temp directory for reference. Optionally copy key mockups to `docs/brainstorms/` alongside the spec:

--- a/skills/visual-companion/SKILL.md
+++ b/skills/visual-companion/SKILL.md
@@ -33,29 +33,32 @@ A question about a UI topic is not automatically a visual question. "Should we u
    mktemp -d /tmp/visual-companion-XXXXXX
    ```
 
-2. Start a local server in the background:
+2. Start the visual companion server in the background:
    ```
-   python3 -m http.server 8432 --directory <temp-dir> &
+   python3 <skill-dir>/server.py --dir <temp-dir> --owner-pid $$ &
    ```
+   `<skill-dir>` is resolved by the invoking agent to the absolute path of `skills/visual-companion/`.
 
-3. Save the server PID for cleanup:
+3. Read `server-info.json` from `<temp-dir>` to get the URL and port:
    ```
-   echo $! > <temp-dir>/.server-pid
+   cat <temp-dir>/server-info.json
    ```
+   Returns `{"port": N, "pid": N, "url": "http://localhost:N"}`.
 
 4. Tell the user:
-   > Visual companion is running. Open http://localhost:8432 in your browser.
-   > I will tell you when to refresh for new content.
+   > Visual companion running at {url}. It auto-refreshes when I update content.
 
 ## 3. The Loop
 
 For each visual step in the brainstorm:
 
-1. **Write an HTML file** to the temp directory with a semantic filename (e.g., `layout-options.html`, `navigation-flow.html`).
+1. **Write an HTML fragment** to `<temp-dir>` with a semantic filename (e.g., `layout-options.html`). Write body content only -- the server wraps fragments automatically.
 2. **Never reuse filenames.** Each screen gets a fresh file. For iterations, append a version suffix: `layout-options-v2.html`.
-3. **Tell the user** to open the specific file URL: `http://localhost:8432/layout-options.html`
-4. **User provides feedback** in the terminal. There is no client-side event system -- all communication happens through the normal conversation.
-5. **When returning to terminal-only questions:** Push a placeholder page so the user knows the visual step is done:
+3. **Browser auto-reloads** via SSE when a new or changed `.html` file is detected. No manual refresh needed.
+4. **For clickable options:** Use `data-choice` attributes on elements. The client JS handles selection toggling and event capture.
+5. **Read events:** Before the next question, read `<temp-dir>/events.jsonl` to check for user clicks.
+6. **Clear events:** `DELETE /events` before presenting a new visual question to clear prior selections.
+7. **Terminal-only steps:** No browser action needed. Optionally push a placeholder page:
    ```html
    <div style="display:flex;align-items:center;justify-content:center;height:100vh;font-family:system-ui;color:#666">
      <p>Continuing in terminal...</p>
@@ -64,59 +67,9 @@ For each visual step in the brainstorm:
 
 ## 4. HTML Content Guide
 
-Write content fragments, not full documents. Each HTML file should be self-contained with inline styles.
+Write body content only. The server wraps fragments with DOCTYPE, CSS, and client JS automatically.
 
-### Frame Template
-
-Use this base structure for all visual pages:
-
-```html
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>{Page Title}</title>
-<style>
-  * { margin: 0; padding: 0; box-sizing: border-box; }
-  body { font-family: system-ui, -apple-system, sans-serif; padding: 2rem; background: #fafafa; color: #1a1a1a; }
-  h1 { font-size: 1.5rem; margin-bottom: 1.5rem; }
-  h2 { font-size: 1.1rem; margin-bottom: 1rem; color: #444; }
-
-  /* Options grid -- side-by-side approach comparison */
-  .options { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1.5rem; }
-  .option { background: #fff; border: 2px solid #e0e0e0; border-radius: 8px; padding: 1.5rem; }
-  .option.recommended { border-color: #2563eb; }
-  .option h3 { margin-bottom: 0.75rem; }
-
-  /* Cards -- feature or component gallery */
-  .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; }
-  .card { background: #fff; border: 1px solid #e5e5e5; border-radius: 6px; padding: 1rem; }
-
-  /* Mockup container -- wireframe wrapper */
-  .mockup { background: #fff; border: 1px solid #ddd; border-radius: 8px; padding: 1rem; max-width: 800px; margin: 0 auto; }
-
-  /* Split view -- two-panel comparison */
-  .split { display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; }
-
-  /* Pros and cons */
-  .pros-cons { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
-  .pros-cons .pros { color: #16a34a; }
-  .pros-cons .cons { color: #dc2626; }
-
-  /* Mock UI elements for wireframes */
-  .mock-nav { background: #f3f4f6; padding: 0.75rem 1rem; border-bottom: 1px solid #e5e5e5; display: flex; gap: 1rem; align-items: center; }
-  .mock-sidebar { background: #f9fafb; padding: 1rem; border-right: 1px solid #e5e5e5; min-width: 200px; }
-  .mock-content { padding: 1.5rem; flex: 1; }
-  .mock-button { display: inline-block; background: #2563eb; color: #fff; padding: 0.5rem 1rem; border-radius: 4px; font-size: 0.875rem; }
-  .mock-input { display: block; width: 100%; padding: 0.5rem; border: 1px solid #d1d5db; border-radius: 4px; background: #fff; margin-bottom: 0.5rem; }
-</style>
-</head>
-<body>
-  <!-- Content here -->
-</body>
-</html>
-```
+A file is treated as a fragment if its first 256 bytes (stripped, case-insensitive) do not start with `<!DOCTYPE` or `<html>`. Full HTML documents are served as-is, with client JS injected before `</body>`.
 
 ### Layout Patterns
 
@@ -125,19 +78,53 @@ Use this base structure for all visual pages:
 - **Mockup:** Use `.mockup` with `.mock-nav`, `.mock-sidebar`, `.mock-content` for wireframes.
 - **Split view:** Use `.split` for before/after or A/B comparisons.
 - **Pros/cons:** Use `.pros-cons` for tradeoff visualization.
+- **Mock UI:** `.mock-button`, `.mock-input` for wireframe form elements.
+
+### Clickable Options with `data-choice`
+
+Add `data-choice` attributes to elements that users can click to make selections:
+
+```html
+<div class="options">
+  <div class="option" data-choice="grid">
+    <h3>Grid Layout</h3>
+    <p>Content arranged in a responsive grid</p>
+  </div>
+  <div class="option" data-choice="list">
+    <h3>List Layout</h3>
+    <p>Content in a vertical list</p>
+  </div>
+</div>
+```
+
+When a user clicks a `[data-choice]` element:
+- The `.selected` class is added (blue border + light blue background)
+- Previous selections within the same parent are deselected
+- A JSON event is appended to `events.jsonl`:
+  ```
+  {"type":"choice","choice":"grid","text":"Grid Layout Content arranged in a responsive grid","timestamp":"2026-04-09T14:30:00.000Z"}
+  ```
+
+### events.jsonl Format
+
+Each line is a JSON object appended by the server. The agent reads this file to see what the user clicked:
+```
+{"type":"choice","choice":"option-a","text":"Option A","timestamp":"..."}
+{"type":"choice","choice":"option-b","text":"Option B","timestamp":"..."}
+```
 
 ## 5. Cleaning Up
 
-When the brainstorm session ends:
+The server self-terminates in two cases:
+- **Idle timeout:** No HTTP requests for 30 minutes.
+- **Owner PID death:** The `--owner-pid` process no longer exists (checked every 0.5s).
 
-1. Kill the server:
-   ```
-   kill $(cat <temp-dir>/.server-pid) 2>/dev/null
-   ```
+To stop manually:
+```
+kill $(cat <temp-dir>/server-info.json | python3 -c "import sys,json; print(json.load(sys.stdin)['pid'])") 2>/dev/null
+```
 
-2. HTML files remain in the temp directory for reference.
-
-3. Optionally copy key mockups to `docs/brainstorms/` alongside the spec:
-   ```
-   cp <temp-dir>/final-layout.html docs/brainstorms/YYYY-MM-DD-<name>-mockups/
-   ```
+HTML files remain in the temp directory for reference. Optionally copy key mockups to `docs/brainstorms/` alongside the spec:
+```
+cp <temp-dir>/final-layout.html docs/brainstorms/YYYY-MM-DD-<name>-mockups/
+```

--- a/skills/visual-companion/server.py
+++ b/skills/visual-companion/server.py
@@ -12,6 +12,7 @@ elements are captured to events.jsonl.
 import argparse
 import atexit
 import json
+import mimetypes
 import os
 import signal
 import sys
@@ -91,6 +92,7 @@ POLL_INTERVAL = 0.5  # seconds
 last_request_time = time.time()
 sse_clients = []  # list of threading.Event objects, one per SSE connection
 sse_lock = threading.Lock()
+_events_lock = threading.Lock()
 serve_dir = ""
 verbose = False
 _cleanup_fn = None  # set by main(), called before os._exit
@@ -165,7 +167,10 @@ class Handler(BaseHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(content)
         else:
+            ctype, _ = mimetypes.guess_type(filepath)
             self.send_response(200)
+            self.send_header('Content-Type', ctype or 'application/octet-stream')
+            self.send_header('X-Content-Type-Options', 'nosniff')
             self.send_header('Content-Length', str(len(content)))
             self.end_headers()
             self.wfile.write(content)
@@ -193,11 +198,17 @@ class Handler(BaseHTTPRequestHandler):
             self.send_response(204)
             self.end_headers()
             return
+        try:
+            parsed = json.loads(body_text)
+        except (json.JSONDecodeError, ValueError):
+            self.send_error(400, 'Invalid JSON')
+            return
         meta_dir = os.path.join(serve_dir, '.vc-meta')
         os.makedirs(meta_dir, exist_ok=True)
         events_path = os.path.join(meta_dir, 'events.jsonl')
-        with open(events_path, 'a') as f:
-            f.write(body_text + '\n')
+        with _events_lock:
+            with open(events_path, 'a') as f:
+                f.write(json.dumps(parsed, separators=(',', ':')) + '\n')
         self.send_response(204)
         self.end_headers()
 
@@ -207,11 +218,12 @@ class Handler(BaseHTTPRequestHandler):
             self.send_error(404)
             return
         events_path = os.path.join(serve_dir, '.vc-meta', 'events.jsonl')
-        try:
-            with open(events_path, 'w') as f:
-                pass  # truncate
-        except FileNotFoundError:
-            pass  # nothing to truncate
+        with _events_lock:
+            try:
+                with open(events_path, 'w') as f:
+                    pass  # truncate
+            except FileNotFoundError:
+                pass  # nothing to truncate
         self.send_response(204)
         self.end_headers()
 

--- a/skills/visual-companion/server.py
+++ b/skills/visual-companion/server.py
@@ -195,7 +195,7 @@ class Handler(BaseHTTPRequestHandler):
             self.send_error(400)
             return
         if length > MAX_EVENT_SIZE:
-            self.send_error(413)
+            self.send_error(413, "Event too large")
             return
         body = self.rfile.read(length) if length else b''
         body_text = body.decode('utf-8', errors='replace').strip()
@@ -295,7 +295,7 @@ class ThreadingServer(ThreadingMixIn, HTTPServer):
 # Directory polling thread
 # ---------------------------------------------------------------------------
 
-def poll_directory(directory, owner_pid):
+def poll_directory(directory, owner_pid, server):
     snapshot = {}
     for name in os.listdir(directory):
         full = os.path.join(directory, name)
@@ -313,7 +313,8 @@ def poll_directory(directory, owner_pid):
             sys.stderr.write("visual-companion: shutting down (idle timeout)\n")
             if _cleanup_fn:
                 _cleanup_fn()
-            sys.exit(0)
+            threading.Thread(target=server.shutdown, daemon=True).start()
+            return
 
         # Owner PID check
         if owner_pid is not None:
@@ -323,7 +324,8 @@ def poll_directory(directory, owner_pid):
                 sys.stderr.write("visual-companion: shutting down (owner process exited)\n")
                 if _cleanup_fn:
                     _cleanup_fn()
-                sys.exit(0)
+                threading.Thread(target=server.shutdown, daemon=True).start()
+                return
 
         # Check for changes in HTML files
         try:
@@ -339,7 +341,8 @@ def poll_directory(directory, owner_pid):
             sys.stderr.write("visual-companion: shutting down (serve directory gone)\n")
             if _cleanup_fn:
                 _cleanup_fn()
-            sys.exit(0)
+            threading.Thread(target=server.shutdown, daemon=True).start()
+            return
 
         changed = False
         for name, mtime in current.items():
@@ -400,7 +403,7 @@ def main():
     signal.signal(signal.SIGTERM, sigterm_handler)
 
     # Start polling thread
-    t = threading.Thread(target=poll_directory, args=(serve_dir, args.owner_pid), daemon=True)
+    t = threading.Thread(target=poll_directory, args=(serve_dir, args.owner_pid, server), daemon=True)
     t.start()
 
     url = info['url']

--- a/skills/visual-companion/server.py
+++ b/skills/visual-companion/server.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Visual companion HTTP server with SSE auto-reload and click event capture.
+
+Usage: python3 server.py --dir <path> [--owner-pid <pid>]
+
+Serves HTML files from --dir. Fragments (no <!DOCTYPE or <html>) are wrapped
+with a full document template including frame CSS and client JS. File changes
+trigger SSE reload in connected browsers. Click events on [data-choice]
+elements are captured to events.jsonl.
+"""
+
+import argparse
+import atexit
+import json
+import os
+import socket
+import threading
+import time
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from socketserver import ThreadingMixIn
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+FRAME_CSS = """\
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { font-family: system-ui, -apple-system, sans-serif; padding: 2rem; background: #fafafa; color: #1a1a1a; }
+h1 { font-size: 1.5rem; margin-bottom: 1.5rem; }
+h2 { font-size: 1.1rem; margin-bottom: 1rem; color: #444; }
+.options { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1.5rem; }
+.option { background: #fff; border: 2px solid #e0e0e0; border-radius: 8px; padding: 1.5rem; cursor: pointer; transition: border-color 0.15s, background 0.15s; }
+.option.recommended { border-color: #2563eb; }
+.option h3 { margin-bottom: 0.75rem; }
+.cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; }
+.card { background: #fff; border: 1px solid #e5e5e5; border-radius: 6px; padding: 1rem; }
+.mockup { background: #fff; border: 1px solid #ddd; border-radius: 8px; padding: 1rem; max-width: 800px; margin: 0 auto; }
+.split { display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; }
+.pros-cons { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+.pros-cons .pros { color: #16a34a; }
+.pros-cons .cons { color: #dc2626; }
+.mock-nav { background: #f3f4f6; padding: 0.75rem 1rem; border-bottom: 1px solid #e5e5e5; display: flex; gap: 1rem; align-items: center; }
+.mock-sidebar { background: #f9fafb; padding: 1rem; border-right: 1px solid #e5e5e5; min-width: 200px; }
+.mock-content { padding: 1.5rem; flex: 1; }
+.mock-button { display: inline-block; background: #2563eb; color: #fff; padding: 0.5rem 1rem; border-radius: 4px; font-size: 0.875rem; }
+.mock-input { display: block; width: 100%; padding: 0.5rem; border: 1px solid #d1d5db; border-radius: 4px; background: #fff; margin-bottom: 0.5rem; }
+.selected { border-color: #2563eb; background: #f0f7ff; }"""
+
+CLIENT_JS = """\
+<script>
+(function() {
+  // Click delegation for [data-choice] elements
+  document.body.addEventListener('click', function(e) {
+    var el = e.target.closest('[data-choice]');
+    if (!el) return;
+    // Toggle selection: remove .selected from siblings, add to clicked
+    var parent = el.parentElement;
+    if (parent) {
+      var siblings = parent.querySelectorAll('[data-choice]');
+      for (var i = 0; i < siblings.length; i++) {
+        siblings[i].classList.remove('selected');
+      }
+    }
+    el.classList.add('selected');
+    // Post event to server
+    fetch('/event', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({
+        type: 'choice',
+        choice: el.dataset.choice,
+        text: el.textContent.trim(),
+        timestamp: new Date().toISOString()
+      })
+    });
+  });
+  // SSE auto-reload
+  var es = new EventSource('/sse');
+  es.onmessage = function() { location.reload(); };
+})();
+</script>"""
+
+IDLE_TIMEOUT = 1800  # 30 minutes
+POLL_INTERVAL = 0.5  # seconds
+
+# ---------------------------------------------------------------------------
+# Server state (module-level, shared across threads)
+# ---------------------------------------------------------------------------
+
+last_request_time = time.time()
+sse_clients = []  # list of threading.Event objects, one per SSE connection
+sse_lock = threading.Lock()
+serve_dir = ""
+
+
+def register_sse_client():
+    ev = threading.Event()
+    with sse_lock:
+        sse_clients.append(ev)
+    return ev
+
+
+def unregister_sse_client(ev):
+    with sse_lock:
+        try:
+            sse_clients.remove(ev)
+        except ValueError:
+            pass
+
+
+def notify_sse_clients():
+    with sse_lock:
+        for ev in sse_clients:
+            ev.set()
+
+
+# ---------------------------------------------------------------------------
+# Request handler
+# ---------------------------------------------------------------------------
+
+class Handler(BaseHTTPRequestHandler):
+
+    def log_message(self, format, *args):
+        pass  # suppress default stderr logging
+
+    def log_request(self, code='-', size='-'):
+        global last_request_time
+        last_request_time = time.time()
+
+    def do_GET(self):
+        path = self.path.lstrip('/')
+        if path == 'sse':
+            return self._handle_sse()
+        if not path:
+            path = 'index.html'
+        filepath = os.path.join(serve_dir, path)
+        if not os.path.isfile(filepath):
+            self.send_error(404)
+            return
+        with open(filepath, 'rb') as f:
+            content = f.read()
+        # Serve HTML with potential wrapping
+        if path.endswith('.html') or path.endswith('.htm'):
+            content = self._process_html(content)
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/html; charset=utf-8')
+            self.send_header('Content-Length', str(len(content)))
+            self.end_headers()
+            self.wfile.write(content)
+        else:
+            self.send_response(200)
+            self.send_header('Content-Length', str(len(content)))
+            self.end_headers()
+            self.wfile.write(content)
+
+    def do_POST(self):
+        path = self.path.lstrip('/')
+        if path != 'event':
+            self.send_error(404)
+            return
+        length = int(self.headers.get('Content-Length', 0))
+        body = self.rfile.read(length) if length else b''
+        events_path = os.path.join(serve_dir, 'events.jsonl')
+        with open(events_path, 'a') as f:
+            f.write(body.decode('utf-8', errors='replace').strip() + '\n')
+        self.send_response(204)
+        self.end_headers()
+
+    def do_DELETE(self):
+        path = self.path.lstrip('/')
+        if path != 'events':
+            self.send_error(404)
+            return
+        events_path = os.path.join(serve_dir, 'events.jsonl')
+        with open(events_path, 'w') as f:
+            pass  # truncate
+        self.send_response(204)
+        self.end_headers()
+
+    def _process_html(self, raw):
+        text = raw.decode('utf-8', errors='replace')
+        prefix = text[:256].strip().lower()
+        is_full = prefix.startswith('<!doctype') or prefix.startswith('<html')
+        if is_full:
+            # Inject client JS before </body> if not already present
+            if '/sse' not in text:
+                text = text.replace('</body>', CLIENT_JS + '\n</body>')
+            return text.encode('utf-8')
+        # Fragment: wrap with full document
+        wrapped = (
+            '<!DOCTYPE html>\n<html lang="en">\n<head>\n'
+            '<meta charset="utf-8">\n'
+            '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
+            '<style>\n' + FRAME_CSS + '\n</style>\n'
+            '</head>\n<body>\n' + text + '\n' + CLIENT_JS + '\n</body>\n</html>'
+        )
+        return wrapped.encode('utf-8')
+
+    def _handle_sse(self):
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/event-stream')
+        self.send_header('Cache-Control', 'no-cache')
+        self.send_header('Connection', 'keep-alive')
+        self.end_headers()
+        ev = register_sse_client()
+        try:
+            while True:
+                ev.wait(timeout=30)
+                if ev.is_set():
+                    self.wfile.write(b'data: reload\n\n')
+                    self.wfile.flush()
+                    ev.clear()
+                else:
+                    # Keepalive comment
+                    self.wfile.write(b': keepalive\n\n')
+                    self.wfile.flush()
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            pass
+        finally:
+            unregister_sse_client(ev)
+
+
+# ---------------------------------------------------------------------------
+# Threading server
+# ---------------------------------------------------------------------------
+
+class ThreadingServer(ThreadingMixIn, HTTPServer):
+    daemon_threads = True
+
+
+# ---------------------------------------------------------------------------
+# Directory polling thread
+# ---------------------------------------------------------------------------
+
+def poll_directory(directory, owner_pid):
+    snapshot = {}
+    for name in os.listdir(directory):
+        full = os.path.join(directory, name)
+        if os.path.isfile(full):
+            try:
+                snapshot[name] = os.path.getmtime(full)
+            except OSError:
+                pass
+
+    while True:
+        time.sleep(POLL_INTERVAL)
+
+        # Idle timeout
+        if time.time() - last_request_time > IDLE_TIMEOUT:
+            os._exit(0)
+
+        # Owner PID check
+        if owner_pid is not None:
+            try:
+                os.kill(owner_pid, 0)
+            except OSError:
+                os._exit(0)
+
+        # Check for changes in HTML files
+        current = {}
+        for name in os.listdir(directory):
+            full = os.path.join(directory, name)
+            if os.path.isfile(full):
+                try:
+                    current[name] = os.path.getmtime(full)
+                except OSError:
+                    pass
+
+        changed = False
+        for name, mtime in current.items():
+            if name.endswith(('.html', '.htm')):
+                if name not in snapshot or snapshot[name] != mtime:
+                    changed = True
+                    break
+
+        snapshot = current
+        if changed:
+            notify_sse_clients()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    global serve_dir
+
+    parser = argparse.ArgumentParser(description='Visual companion server')
+    parser.add_argument('--dir', required=True, help='Directory to serve HTML from')
+    parser.add_argument('--owner-pid', type=int, default=None, help='Parent process PID for lifecycle tracking')
+    args = parser.parse_args()
+
+    serve_dir = os.path.abspath(args.dir)
+    if not os.path.isdir(serve_dir):
+        os.makedirs(serve_dir, exist_ok=True)
+
+    # Find a free ephemeral port
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(('127.0.0.1', 0))
+    port = sock.getsockname()[1]
+    sock.close()
+
+    server = ThreadingServer(('127.0.0.1', port), Handler)
+
+    # Write server-info.json
+    info = {'port': port, 'pid': os.getpid(), 'url': 'http://localhost:{}'.format(port)}
+    info_path = os.path.join(serve_dir, 'server-info.json')
+    with open(info_path, 'w') as f:
+        json.dump(info, f)
+
+    def cleanup():
+        try:
+            os.remove(info_path)
+        except OSError:
+            pass
+
+    atexit.register(cleanup)
+
+    # Start polling thread
+    t = threading.Thread(target=poll_directory, args=(serve_dir, args.owner_pid), daemon=True)
+    t.start()
+
+    url = info['url']
+    print(url)
+
+    server.serve_forever()
+
+
+if __name__ == '__main__':
+    main()

--- a/skills/visual-companion/server.py
+++ b/skills/visual-companion/server.py
@@ -207,8 +207,11 @@ class Handler(BaseHTTPRequestHandler):
             self.send_error(404)
             return
         events_path = os.path.join(serve_dir, '.vc-meta', 'events.jsonl')
-        with open(events_path, 'w') as f:
-            pass  # truncate
+        try:
+            with open(events_path, 'w') as f:
+                pass  # truncate
+        except FileNotFoundError:
+            pass  # nothing to truncate
         self.send_response(204)
         self.end_headers()
 
@@ -364,8 +367,7 @@ def main():
     atexit.register(cleanup)
 
     def sigterm_handler(signum, frame):
-        cleanup()
-        sys.exit(0)
+        threading.Thread(target=server.shutdown, daemon=True).start()
 
     signal.signal(signal.SIGTERM, sigterm_handler)
 
@@ -377,6 +379,7 @@ def main():
     print('visual-companion: {}'.format(url))
 
     server.serve_forever()
+    cleanup()
 
 
 if __name__ == '__main__':

--- a/skills/visual-companion/server.py
+++ b/skills/visual-companion/server.py
@@ -95,10 +95,11 @@ sse_lock = threading.Lock()
 _events_lock = threading.Lock()
 serve_dir = ""
 verbose = False
-_cleanup_fn = None  # set by main(), called before os._exit
+_cleanup_fn = None  # set by main(), called before exit
 
 
 MAX_SSE_CLIENTS = 20
+MAX_EVENTS_SIZE = 1_000_000  # 1MB
 
 
 def register_sse_client():
@@ -156,6 +157,10 @@ class Handler(BaseHTTPRequestHandler):
         if not os.path.isfile(filepath):
             self.send_error(404)
             return
+        MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
+        if os.path.getsize(filepath) > MAX_FILE_SIZE:
+            self.send_error(413, "File too large")
+            return
         with open(filepath, 'rb') as f:
             content = f.read()
         # Serve HTML with potential wrapping
@@ -207,6 +212,11 @@ class Handler(BaseHTTPRequestHandler):
         os.makedirs(meta_dir, exist_ok=True)
         events_path = os.path.join(meta_dir, 'events.jsonl')
         with _events_lock:
+            if os.path.exists(events_path) and os.path.getsize(events_path) > MAX_EVENTS_SIZE:
+                with open(events_path, 'r') as f:
+                    lines = f.readlines()
+                with open(events_path, 'w') as f:
+                    f.writelines(lines[-100:])
             with open(events_path, 'a') as f:
                 f.write(json.dumps(parsed, separators=(',', ':')) + '\n')
         self.send_response(204)
@@ -233,7 +243,7 @@ class Handler(BaseHTTPRequestHandler):
         is_full = prefix.startswith('<!doctype') or prefix.startswith('<html')
         if is_full:
             # Inject client JS before </body> if not already present
-            if '/sse' not in text:
+            if 'new EventSource' not in text:
                 text = text.replace('</body>', CLIENT_JS + '\n</body>')
             return text.encode('utf-8')
         # Fragment: wrap with full document
@@ -249,7 +259,7 @@ class Handler(BaseHTTPRequestHandler):
     def _handle_sse(self):
         ev = register_sse_client()
         if ev is None:
-            self.send_error(503)
+            self.send_error(503, "Too many SSE clients (max 20)")
             return
         self.send_response(200)
         self.send_header('Content-Type', 'text/event-stream')
@@ -303,7 +313,7 @@ def poll_directory(directory, owner_pid):
             sys.stderr.write("visual-companion: shutting down (idle timeout)\n")
             if _cleanup_fn:
                 _cleanup_fn()
-            os._exit(0)
+            sys.exit(0)
 
         # Owner PID check
         if owner_pid is not None:
@@ -313,17 +323,23 @@ def poll_directory(directory, owner_pid):
                 sys.stderr.write("visual-companion: shutting down (owner process exited)\n")
                 if _cleanup_fn:
                     _cleanup_fn()
-                os._exit(0)
+                sys.exit(0)
 
         # Check for changes in HTML files
-        current = {}
-        for name in os.listdir(directory):
-            full = os.path.join(directory, name)
-            if os.path.isfile(full):
-                try:
-                    current[name] = os.path.getmtime(full)
-                except OSError:
-                    pass
+        try:
+            current = {}
+            for name in os.listdir(directory):
+                full = os.path.join(directory, name)
+                if os.path.isfile(full):
+                    try:
+                        current[name] = os.path.getmtime(full)
+                    except OSError:
+                        pass
+        except OSError:
+            sys.stderr.write("visual-companion: shutting down (serve directory gone)\n")
+            if _cleanup_fn:
+                _cleanup_fn()
+            sys.exit(0)
 
         changed = False
         for name, mtime in current.items():

--- a/skills/visual-companion/server.py
+++ b/skills/visual-companion/server.py
@@ -13,7 +13,8 @@ import argparse
 import atexit
 import json
 import os
-import socket
+import signal
+import sys
 import threading
 import time
 from http.server import HTTPServer, BaseHTTPRequestHandler
@@ -91,11 +92,18 @@ last_request_time = time.time()
 sse_clients = []  # list of threading.Event objects, one per SSE connection
 sse_lock = threading.Lock()
 serve_dir = ""
+verbose = False
+_cleanup_fn = None  # set by main(), called before os._exit
+
+
+MAX_SSE_CLIENTS = 20
 
 
 def register_sse_client():
-    ev = threading.Event()
     with sse_lock:
+        if len(sse_clients) >= MAX_SSE_CLIENTS:
+            return None
+        ev = threading.Event()
         sse_clients.append(ev)
     return ev
 
@@ -121,7 +129,8 @@ def notify_sse_clients():
 class Handler(BaseHTTPRequestHandler):
 
     def log_message(self, format, *args):
-        pass  # suppress default stderr logging
+        if verbose:
+            super().log_message(format, *args)
 
     def log_request(self, code='-', size='-'):
         global last_request_time
@@ -133,7 +142,15 @@ class Handler(BaseHTTPRequestHandler):
             return self._handle_sse()
         if not path:
             path = 'index.html'
-        filepath = os.path.join(serve_dir, path)
+        # Block access to .vc-meta directory
+        if path.startswith('.vc-meta/') or path == '.vc-meta':
+            self.send_error(404)
+            return
+        filepath = os.path.realpath(os.path.join(serve_dir, path))
+        real_serve = os.path.realpath(serve_dir)
+        if not (filepath == real_serve or filepath.startswith(real_serve + os.sep)):
+            self.send_error(403)
+            return
         if not os.path.isfile(filepath):
             self.send_error(404)
             return
@@ -154,15 +171,33 @@ class Handler(BaseHTTPRequestHandler):
             self.wfile.write(content)
 
     def do_POST(self):
+        MAX_EVENT_SIZE = 65536  # 64 KB
         path = self.path.lstrip('/')
         if path != 'event':
             self.send_error(404)
             return
-        length = int(self.headers.get('Content-Length', 0))
+        try:
+            length = int(self.headers.get('Content-Length', 0))
+        except (ValueError, TypeError):
+            self.send_error(400)
+            return
+        if length < 0:
+            self.send_error(400)
+            return
+        if length > MAX_EVENT_SIZE:
+            self.send_error(413)
+            return
         body = self.rfile.read(length) if length else b''
-        events_path = os.path.join(serve_dir, 'events.jsonl')
+        body_text = body.decode('utf-8', errors='replace').strip()
+        if not body_text:
+            self.send_response(204)
+            self.end_headers()
+            return
+        meta_dir = os.path.join(serve_dir, '.vc-meta')
+        os.makedirs(meta_dir, exist_ok=True)
+        events_path = os.path.join(meta_dir, 'events.jsonl')
         with open(events_path, 'a') as f:
-            f.write(body.decode('utf-8', errors='replace').strip() + '\n')
+            f.write(body_text + '\n')
         self.send_response(204)
         self.end_headers()
 
@@ -171,7 +206,7 @@ class Handler(BaseHTTPRequestHandler):
         if path != 'events':
             self.send_error(404)
             return
-        events_path = os.path.join(serve_dir, 'events.jsonl')
+        events_path = os.path.join(serve_dir, '.vc-meta', 'events.jsonl')
         with open(events_path, 'w') as f:
             pass  # truncate
         self.send_response(204)
@@ -197,12 +232,15 @@ class Handler(BaseHTTPRequestHandler):
         return wrapped.encode('utf-8')
 
     def _handle_sse(self):
+        ev = register_sse_client()
+        if ev is None:
+            self.send_error(503)
+            return
         self.send_response(200)
         self.send_header('Content-Type', 'text/event-stream')
         self.send_header('Cache-Control', 'no-cache')
         self.send_header('Connection', 'keep-alive')
         self.end_headers()
-        ev = register_sse_client()
         try:
             while True:
                 ev.wait(timeout=30)
@@ -247,6 +285,9 @@ def poll_directory(directory, owner_pid):
 
         # Idle timeout
         if time.time() - last_request_time > IDLE_TIMEOUT:
+            sys.stderr.write("visual-companion: shutting down (idle timeout)\n")
+            if _cleanup_fn:
+                _cleanup_fn()
             os._exit(0)
 
         # Owner PID check
@@ -254,6 +295,9 @@ def poll_directory(directory, owner_pid):
             try:
                 os.kill(owner_pid, 0)
             except OSError:
+                sys.stderr.write("visual-companion: shutting down (owner process exited)\n")
+                if _cleanup_fn:
+                    _cleanup_fn()
                 os._exit(0)
 
         # Check for changes in HTML files
@@ -288,23 +332,24 @@ def main():
     parser = argparse.ArgumentParser(description='Visual companion server')
     parser.add_argument('--dir', required=True, help='Directory to serve HTML from')
     parser.add_argument('--owner-pid', type=int, default=None, help='Parent process PID for lifecycle tracking')
+    parser.add_argument('--verbose', action='store_true', help='Enable HTTP request logging to stderr')
     args = parser.parse_args()
 
+    global verbose
+    verbose = args.verbose
     serve_dir = os.path.abspath(args.dir)
     if not os.path.isdir(serve_dir):
         os.makedirs(serve_dir, exist_ok=True)
 
-    # Find a free ephemeral port
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.bind(('127.0.0.1', 0))
-    port = sock.getsockname()[1]
-    sock.close()
+    # Bind directly to port 0 to avoid TOCTOU race
+    server = ThreadingServer(('127.0.0.1', 0), Handler)
+    port = server.server_address[1]
 
-    server = ThreadingServer(('127.0.0.1', port), Handler)
-
-    # Write server-info.json
+    # Write server-info.json to .vc-meta (not directly served)
+    meta_dir = os.path.join(serve_dir, '.vc-meta')
+    os.makedirs(meta_dir, exist_ok=True)
     info = {'port': port, 'pid': os.getpid(), 'url': 'http://localhost:{}'.format(port)}
-    info_path = os.path.join(serve_dir, 'server-info.json')
+    info_path = os.path.join(meta_dir, 'server-info.json')
     with open(info_path, 'w') as f:
         json.dump(info, f)
 
@@ -314,14 +359,22 @@ def main():
         except OSError:
             pass
 
+    global _cleanup_fn
+    _cleanup_fn = cleanup
     atexit.register(cleanup)
+
+    def sigterm_handler(signum, frame):
+        cleanup()
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, sigterm_handler)
 
     # Start polling thread
     t = threading.Thread(target=poll_directory, args=(serve_dir, args.owner_pid), daemon=True)
     t.start()
 
     url = info['url']
-    print(url)
+    print('visual-companion: {}'.format(url))
 
     server.serve_forever()
 

--- a/tests/visual-companion/test-server.sh
+++ b/tests/visual-companion/test-server.sh
@@ -59,6 +59,10 @@ echo "=== File Serving ==="
 STATUS=$(curl -s -o /dev/null -w '%{http_code}' "$BASE/index.html")
 [ "$STATUS" = "200" ] && pass "normal file serving (200)" || fail "normal serving returned $STATUS, expected 200"
 
+BODY=$(curl -s "$BASE/index.html")
+echo "$BODY" | grep -q "<h1>test</h1>" && pass "response contains original content" || fail "original content missing"
+echo "$BODY" | grep -q "EventSource" && pass "client JS injected" || fail "client JS not injected"
+
 # --- Test 3: .vc-meta not accessible via GET ---
 
 STATUS=$(curl -s -o /dev/null -w '%{http_code}' "$BASE/.vc-meta/server-info.json")
@@ -85,6 +89,13 @@ if [ -f "$EVENTS_FILE" ]; then
 else
   pass "no blank line in events.jsonl (file not created)"
 fi
+
+# --- Test 5b: Valid POST persists event ---
+
+EVENT='{"type":"choice","choice":"A","text":"Option A"}'
+STATUS=$(curl -s -o /dev/null -w '%{http_code}' -X POST -H "Content-Type: application/json" -d "$EVENT" "$BASE/event")
+[ "$STATUS" = "204" ] && pass "valid POST accepted (204)" || fail "valid POST returned $STATUS, expected 204"
+grep -q '"choice":"A"' "$SERVE_DIR/.vc-meta/events.jsonl" && pass "event persisted to events.jsonl" || fail "event not found in events.jsonl"
 
 # --- Test 6: Invalid Content-Length returns 400 ---
 

--- a/tests/visual-companion/test-server.sh
+++ b/tests/visual-companion/test-server.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# test-server.sh
+# Tests for skills/visual-companion/server.py covering security, validation,
+# SSE, and cleanup behavior.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SERVER="$REPO_ROOT/skills/visual-companion/server.py"
+
+PASS=0
+FAIL=0
+SERVER_PID=""
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+  if [ -n "$SERVER_PID" ]; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$SERVE_DIR"
+}
+trap cleanup EXIT
+
+# --- Setup ---
+
+SERVE_DIR=$(mktemp -d /tmp/vc-test-XXXXXX)
+echo "<h1>test</h1>" > "$SERVE_DIR/index.html"
+
+python3 "$SERVER" --dir "$SERVE_DIR" &
+SERVER_PID=$!
+sleep 1
+
+# Read port from .vc-meta/server-info.json
+INFO_FILE="$SERVE_DIR/.vc-meta/server-info.json"
+if [ ! -f "$INFO_FILE" ]; then
+  echo "FATAL: server-info.json not created at $INFO_FILE"
+  exit 1
+fi
+PORT=$(python3 -c "import json; print(json.load(open('$INFO_FILE'))['port'])")
+BASE="http://127.0.0.1:$PORT"
+
+echo "Server running on port $PORT (PID $SERVER_PID)"
+echo ""
+
+# --- Test 1: Path traversal returns 403 ---
+
+echo "=== Security ==="
+STATUS=$(curl -s -o /dev/null -w '%{http_code}' --path-as-is "$BASE/../../etc/passwd")
+[ "$STATUS" = "403" ] && pass "path traversal blocked (403)" || fail "path traversal returned $STATUS, expected 403"
+
+# --- Test 2: Normal file serving returns 200 ---
+
+echo ""
+echo "=== File Serving ==="
+STATUS=$(curl -s -o /dev/null -w '%{http_code}' "$BASE/index.html")
+[ "$STATUS" = "200" ] && pass "normal file serving (200)" || fail "normal serving returned $STATUS, expected 200"
+
+# --- Test 3: .vc-meta not accessible via GET ---
+
+STATUS=$(curl -s -o /dev/null -w '%{http_code}' "$BASE/.vc-meta/server-info.json")
+[ "$STATUS" = "404" ] && pass ".vc-meta blocked (404)" || fail ".vc-meta returned $STATUS, expected 404"
+
+# --- Test 4: Oversized POST returns 413 ---
+
+echo ""
+echo "=== POST Validation ==="
+LARGE_BODY=$(python3 -c "print('x' * 70000)")
+STATUS=$(curl -s -o /dev/null -w '%{http_code}' -X POST -d "$LARGE_BODY" "$BASE/event")
+[ "$STATUS" = "413" ] && pass "POST size limit (413)" || fail "oversized POST returned $STATUS, expected 413"
+
+# --- Test 5: Empty POST returns 204 ---
+
+STATUS=$(curl -s -o /dev/null -w '%{http_code}' -X POST -H "Content-Length: 0" "$BASE/event")
+[ "$STATUS" = "204" ] && pass "empty POST body (204)" || fail "empty POST returned $STATUS, expected 204"
+
+# Verify no blank line written to events.jsonl
+EVENTS_FILE="$SERVE_DIR/.vc-meta/events.jsonl"
+if [ -f "$EVENTS_FILE" ]; then
+  LINES=$(wc -l < "$EVENTS_FILE" | tr -d ' ')
+  [ "$LINES" = "0" ] && pass "no blank line in events.jsonl" || fail "events.jsonl has $LINES lines after empty POST"
+else
+  pass "no blank line in events.jsonl (file not created)"
+fi
+
+# --- Test 6: Invalid Content-Length returns 400 ---
+
+STATUS=$(curl -s -o /dev/null -w '%{http_code}' -X POST -H "Content-Length: abc" -H "Transfer-Encoding: identity" --data-raw "" "$BASE/event")
+[ "$STATUS" = "400" ] && pass "invalid content-length (400)" || fail "invalid CL returned $STATUS, expected 400"
+
+# --- Test 7: SSE endpoint returns event-stream ---
+
+echo ""
+echo "=== SSE ==="
+HEADERS=$(curl -sD - -o /dev/null --max-time 2 "$BASE/sse" 2>/dev/null || true)
+echo "$HEADERS" | grep -qi "text/event-stream" && pass "SSE content type" || fail "SSE content type not found in: $HEADERS"
+
+# --- Test 8: Cleanup on shutdown ---
+
+echo ""
+echo "=== Cleanup ==="
+kill "$SERVER_PID" 2>/dev/null
+wait "$SERVER_PID" 2>/dev/null || true
+SERVER_PID=""
+sleep 1
+[ ! -f "$INFO_FILE" ] && pass "cleanup on shutdown (server-info.json removed)" || fail "server-info.json not cleaned up"
+
+# --- Results ---
+
+echo ""
+echo "================================"
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/tests/visual-companion/test-server.sh
+++ b/tests/visual-companion/test-server.sh
@@ -104,6 +104,11 @@ STATUS=$(curl -s -o /dev/null -w '%{http_code}' -X POST -H "Content-Type: applic
 [ "$STATUS" = "204" ] && pass "valid POST accepted (204)" || fail "valid POST returned $STATUS, expected 204"
 grep -q '"choice":"A"' "$SERVE_DIR/.vc-meta/events.jsonl" && pass "event persisted to events.jsonl" || fail "event not found in events.jsonl"
 
+# --- Test 5b2: POST invalid JSON returns 400 ---
+
+INVALID_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" -X POST -d 'not-valid-json' "$BASE/event")
+[ "$INVALID_RESPONSE" = "400" ] && pass "POST invalid JSON rejected (400)" || fail "POST invalid JSON returned $INVALID_RESPONSE, expected 400"
+
 # --- Test 5c: DELETE after events exist truncates file ---
 
 STATUS=$(curl -s -o /dev/null -w '%{http_code}' -X DELETE "$BASE/events")

--- a/tests/visual-companion/test-server.sh
+++ b/tests/visual-companion/test-server.sh
@@ -68,6 +68,13 @@ echo "$BODY" | grep -q "EventSource" && pass "client JS injected" || fail "clien
 STATUS=$(curl -s -o /dev/null -w '%{http_code}' "$BASE/.vc-meta/server-info.json")
 [ "$STATUS" = "404" ] && pass ".vc-meta blocked (404)" || fail ".vc-meta returned $STATUS, expected 404"
 
+# --- Test 3b: DELETE before events exist returns 204 ---
+
+echo ""
+echo "=== DELETE ==="
+STATUS=$(curl -s -o /dev/null -w '%{http_code}' -X DELETE "$BASE/events")
+[ "$STATUS" = "204" ] && pass "DELETE before events exist (204)" || fail "DELETE pre-events returned $STATUS, expected 204"
+
 # --- Test 4: Oversized POST returns 413 ---
 
 echo ""
@@ -96,6 +103,12 @@ EVENT='{"type":"choice","choice":"A","text":"Option A"}'
 STATUS=$(curl -s -o /dev/null -w '%{http_code}' -X POST -H "Content-Type: application/json" -d "$EVENT" "$BASE/event")
 [ "$STATUS" = "204" ] && pass "valid POST accepted (204)" || fail "valid POST returned $STATUS, expected 204"
 grep -q '"choice":"A"' "$SERVE_DIR/.vc-meta/events.jsonl" && pass "event persisted to events.jsonl" || fail "event not found in events.jsonl"
+
+# --- Test 5c: DELETE after events exist truncates file ---
+
+STATUS=$(curl -s -o /dev/null -w '%{http_code}' -X DELETE "$BASE/events")
+[ "$STATUS" = "204" ] && pass "DELETE clears events (204)" || fail "DELETE returned $STATUS, expected 204"
+[ ! -s "$SERVE_DIR/.vc-meta/events.jsonl" ] && pass "events.jsonl truncated" || fail "events.jsonl not empty after DELETE"
 
 # --- Test 6: Invalid Content-Length returns 400 ---
 

--- a/tests/visual-companion/test-server.sh
+++ b/tests/visual-companion/test-server.sh
@@ -138,7 +138,33 @@ STATUS=$(curl -s -o /dev/null -w '%{http_code}' -X DELETE "$BASE/events")
 STATUS=$(curl -s -o /dev/null -w '%{http_code}' -X POST -H "Content-Length: abc" -H "Transfer-Encoding: identity" --data-raw "" "$BASE/event")
 [ "$STATUS" = "400" ] && pass "invalid content-length (400)" || fail "invalid CL returned $STATUS, expected 400"
 
-# --- Test 7: SSE endpoint returns event-stream ---
+# --- Test 7a: GET returns 413 for files exceeding 10MB ---
+
+echo ""
+echo "=== File Size Limit ==="
+dd if=/dev/zero of="$SERVE_DIR/huge.bin" bs=1024 count=10241 2>/dev/null
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/huge.bin")
+[ "$STATUS" = "413" ] && pass "GET huge file returns 413" || fail "GET huge file returned $STATUS, expected 413"
+rm -f "$SERVE_DIR/huge.bin"
+
+# --- Test 7b: events.jsonl truncates to 100 lines when exceeding 1MB ---
+
+echo ""
+echo "=== Events Truncation ==="
+META_DIR="$SERVE_DIR/.vc-meta"
+mkdir -p "$META_DIR"
+LARGE_VALUE=$(python3 -c "print('x' * 8000)")
+for i in $(seq 1 150); do
+    echo "{\"type\":\"pad\",\"data\":\"$LARGE_VALUE\"}" >> "$META_DIR/events.jsonl"
+done
+# POST one more event to trigger truncation
+curl -s -X POST -H "Content-Type: application/json" -d '{"type":"trigger"}' "$BASE/event" > /dev/null
+LINE_COUNT=$(wc -l < "$META_DIR/events.jsonl" | tr -d ' ')
+test "$LINE_COUNT" -le 101
+[ "$?" = "0" ] && pass "events.jsonl truncated to <=101 lines after exceeding 1MB (got $LINE_COUNT)" || fail "events.jsonl has $LINE_COUNT lines, expected <=101"
+rm -f "$META_DIR/events.jsonl"
+
+# --- Test 7c: SSE endpoint returns event-stream ---
 
 echo ""
 echo "=== SSE ==="

--- a/tests/visual-companion/test-server.sh
+++ b/tests/visual-companion/test-server.sh
@@ -32,7 +32,14 @@ echo "<h1>test</h1>" > "$SERVE_DIR/index.html"
 
 python3 "$SERVER" --dir "$SERVE_DIR" &
 SERVER_PID=$!
-sleep 1
+
+# Wait for server to start (max 10 seconds)
+for i in $(seq 1 20); do
+    if [ -f "$SERVE_DIR/.vc-meta/server-info.json" ]; then
+        break
+    fi
+    sleep 0.5
+done
 
 # Read port from .vc-meta/server-info.json
 INFO_FILE="$SERVE_DIR/.vc-meta/server-info.json"
@@ -62,6 +69,17 @@ STATUS=$(curl -s -o /dev/null -w '%{http_code}' "$BASE/index.html")
 BODY=$(curl -s "$BASE/index.html")
 echo "$BODY" | grep -q "<h1>test</h1>" && pass "response contains original content" || fail "original content missing"
 echo "$BODY" | grep -q "EventSource" && pass "client JS injected" || fail "client JS not injected"
+
+# --- Test 2b: Full HTML document serves with JS injection before </body> ---
+
+echo "<html><head></head><body><h1>full doc</h1></body></html>" > "$SERVE_DIR/full.html"
+FULL_BODY=$(curl -s "$BASE/full.html")
+echo "$FULL_BODY" | grep -q "<h1>full doc</h1>" && pass "full doc contains original content" || fail "full doc original content missing"
+echo "$FULL_BODY" | grep -q "new EventSource" && pass "full doc has JS injected" || fail "full doc JS not injected"
+# Verify JS appears before </body> by checking the order in output
+JS_LINE=$(echo "$FULL_BODY" | grep -n "new EventSource" | head -1 | cut -d: -f1)
+BODY_LINE=$(echo "$FULL_BODY" | grep -n "</body>" | head -1 | cut -d: -f1)
+[ -n "$JS_LINE" ] && [ -n "$BODY_LINE" ] && [ "$JS_LINE" -lt "$BODY_LINE" ] && pass "full doc JS injected before </body>" || fail "full doc JS not before </body>"
 
 # --- Test 3: .vc-meta not accessible via GET ---
 


### PR DESCRIPTION
## Summary
- Add `/brainstorm` command with adaptive depth (Quick/Standard/Deep), clarifying questions via AskUserQuestion, approach comparison, executive summary gate, and spec generation to `docs/brainstorms/`
- Enhance `/plan` command with TDD task structure, file structure mapping, no-placeholders rule, self-review step, and English-language requirement
- Add visual companion skill with SSE-powered Python server for browser-based mockups, auto-reload on file changes, and click event capture via `data-choice` attributes

## Test plan
- [ ] Run `/brainstorm <idea>` and verify full flow: complexity assessment, clarifying questions, approaches, executive summary gate, spec output
- [ ] Run `/brainstorm` with a trivial idea and verify Quick-exit offer
- [ ] Run `/brainstorm` with a visual topic and verify visual companion offer
- [ ] Start `server.py` manually and confirm SSE reload, fragment wrapping, and click events work
- [ ] Run `/plan <task>` and verify new TDD structure, self-review step, and no-placeholders rule appear in output
- [ ] Verify `.gitignore` entry for `docs/` is present