### PR TITLE
Reposition Quiver as composable development lifecycle

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
     "email": "dokumaciyago@gmail.com"
   },
   "metadata": {
-    "description": "Session continuity, agent orchestration, and development workflows for Claude Code. Saves and restores conversation context across sessions."
+    "description": "Composable development lifecycle -- brainstorm, plan, execute, review, and hand over from idea to merged PR"
   },
   "plugins": [
     {
       "name": "quiver",
       "source": "./",
-      "description": "Session continuity, agent orchestration, and development workflows for Claude Code",
+      "description": "Composable development lifecycle -- brainstorm, plan, execute, review, and hand over from idea to merged PR",
       "author": {
         "name": "Yilmaz Yagiz Dokumaci"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quiver",
   "version": "1.8.1",
-  "description": "Session continuity, agent orchestration, and development workflows for Claude Code",
+  "description": "Composable development lifecycle -- brainstorm, plan, execute, review, and hand over from idea to merged PR",
   "author": {
     "name": "Yilmaz Yagiz Dokumaci"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 # Quiver
 
-Session continuity, agent orchestration, and development workflows plugin for Claude Code. Saves and restores conversation context across sessions.
+Composable development lifecycle plugin for AI coding CLIs. Expert tools for every development moment -- independently useful, optionally combined.
 Dependencies: `bash`, `claude` CLI.
 
 ## Architecture
@@ -24,6 +24,15 @@ Dependencies: `bash`, `claude` CLI.
 - **SYNC contract** — The 8 handover section headings are defined in two places that must stay identical: `skills/handover/SKILL.md:96` (the marker comment) plus the headings at lines 99-129, and `hooks/scripts/pre-compact-handover.sh:25`. Both files contain a `SYNC:` comment pointing to the other. If you change headings, update both and verify line numbers in the comments.
 
 ## Development Standards
+
+### Feature Admission Test
+
+Every proposed feature must pass both conditions before design begins:
+
+1. **Standalone:** It must be useful when invoked in isolation, without any other Quiver skill having been run.
+2. **Composable:** It must accept input from other skills and/or produce output that other skills can consume.
+
+If a feature only works inside a pipeline (requires prior skill X to have run), redesign it to accept equivalent input from any source. If it produces no output that other skills can use and accepts no input from them, it is a utility -- still valid, but verify it belongs in Quiver rather than in the user's project.
 
 ### Adding a Skill
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,11 @@
 
 [![Version](https://img.shields.io/badge/version-1.8.1-blue)](https://github.com/yagizdo/quiver/releases)
 
-Quiver is a plugin for AI coding CLIs that brings multi-agent code review, end-to-end workflow orchestration, and session continuity -- carry your plans, decisions, and review findings from idea to PR without re-explaining context between sessions.
-
-## What is Quiver?
-
-Quiver coordinates multi-step development workflows and session continuity for your AI coding CLI. You use it to brainstorm feature ideas, produce research-backed implementation plans, execute those plans with continuous testing and incremental commits, and run a suite of specialized agents that review the resulting code for logic bugs, security gaps, architectural drift, and weak test coverage before merging. When work spans sessions, Quiver saves a handover with decisions, blockers, and next steps so you resume exactly where you left off -- no re-investigation, no lost context.
+Quiver is a development lifecycle plugin for AI coding CLIs -- purpose-built skills for brainstorming, planning, execution, code review, and session handover, plus 10 specialized review agents that run in parallel.
 
 ## Typical workflow
 
-A normal feature cycle in Quiver chains the skills below. Each one is self-contained, so skip or substitute steps as needed.
+A normal feature cycle chains these skills. Each one is self-contained and works on its own -- skip steps, reorder them, or use just the ones you need.
 
 1. `/brainstorm` -- turn a vague idea into a validated spec by walking through clarifying questions and trade-off analysis on 2-3 design approaches.
 2. `/plan` -- research the codebase in parallel, then break the chosen approach into verifiable step-by-step tasks with exact file paths.
@@ -41,15 +37,13 @@ Then try `/brainstorm` in any session.
 
 Or browse [cursor.com/marketplace](https://cursor.com/marketplace) and click "Add to Cursor".
 
-### Gemini CLI, OpenAI Codex CLI, Antigravity
-
-Planned in sequential follow-up branches.
-
-## Cursor notes
-
 - The `cursor-agent` CLI does not load plugin skills (IDE-only). Use Cursor IDE for skill-using workflows.
 - `WebFetch` and `WebSearch` are unsupported on Cursor; the included context7 MCP covers documentation lookups.
 - If handover auto-save does not fire after install, Cursor's `preCompact` event may use a different JSON field name than Claude Code. Edit `.cursor/hooks.json` to log raw stdin to a file, trigger context compaction, and inspect the log for the actual field names.
+
+### Gemini CLI, OpenAI Codex CLI, Antigravity
+
+Planned in sequential follow-up branches.
 
 ## Components
 


### PR DESCRIPTION
## Summary

Reframes Quiver's identity from "session continuity + agent orchestration" to "composable development lifecycle" -- reflecting how the plugin actually works today: independent, purpose-built skills that optionally chain together.

- Updated one-liner in plugin.json, marketplace.json, and CLAUDE.md
- Added Feature Admission Test (standalone + composable) to CLAUDE.md development standards
- Simplified README intro and restructured Cursor notes section

## Test plan

- [ ] `plugin.json`, `marketplace.json` descriptions match the new one-liner
- [ ] CLAUDE.md Feature Admission Test section renders correctly
- [ ] README reads coherently top-to-bottom