### PR TITLE
feat(codex): add Codex CLI support via overlay

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "quiver",
+  "version": "1.8.1",
+  "description": "Composable development lifecycle -- brainstorm, plan, execute, review, and hand over from idea to merged PR",
+  "author": {
+    "name": "Yilmaz Yagiz Dokumaci"
+  },
+  "homepage": "https://github.com/yagizdo/quiver",
+  "repository": "https://github.com/yagizdo/quiver",
+  "license": "MIT",
+  "skills": "./skills/",
+  "hooks": "./hooks/hooks-codex.json",
+  "rules": "./.codex-plugin/rules/",
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    }
+  },
+  "interface": {
+    "displayName": "Quiver",
+    "shortDescription": "Composable development lifecycle -- brainstorm, plan, execute, review, and hand over",
+    "category": "Productivity"
+  }
+}

--- a/.codex-plugin/rules/quiver-codex-compat.md
+++ b/.codex-plugin/rules/quiver-codex-compat.md
@@ -1,0 +1,74 @@
+# Quiver on Codex: Interpretation Rules
+
+Quiver's agents and skills were originally written for Claude Code. When you (the Codex agent) load any file under `agents/` or `skills/` and execute the workflow it describes, follow these substitution rules.
+
+## Inline shell-block syntax
+
+Quiver skills contain blocks like:
+
+    !`git status`
+
+In Claude Code, the harness pre-executes these and injects the output into the prompt. Codex does not do this. When you see one of these blocks in a skill body:
+
+1. Execute the command yourself via shell execution.
+2. Read the output.
+3. Continue with the rest of the skill body, treating the output as if the harness had injected it.
+
+## Tool-name substitutions
+
+When a Quiver agent or skill references a Claude Code tool name, use the Codex equivalent.
+
+| Claude Code | Codex | Notes |
+|-------------|-------|-------|
+| Bash | Shell execution | Identical semantics. |
+| Read | File read | Built-in file reading capability. |
+| Write | apply_patch (full file) | Use apply_patch with the full file content, or shell redirection for new files. |
+| Edit | apply_patch (partial) | Apply a unified diff patch to modify specific lines. |
+| Grep | Shell grep | Run `grep` via shell execution. |
+| Glob | Shell find | Run `find` via shell execution. Codex does not expose a Glob tool. |
+| Agent | spawn_agent | See the Agent dispatch section below. |
+| AskUserQuestion | (polyfill) | See the AskUserQuestion section below. |
+| WebFetch | (unsupported) | Use the context7 MCP for documentation lookups. |
+| WebSearch | Web search | Codex has native web search. |
+| TaskCreate / TaskUpdate | update_plan | Codex exposes plan tracking; the agent uses it naturally. |
+
+## Agent dispatch
+
+Quiver skills dispatch specialized agents using the Agent tool with a `subagent_type` parameter (e.g., `subagent_type: "quiver:security-audit"`). Codex does not have a named agent registry in the plugin manifest. When a skill asks you to dispatch a named agent:
+
+1. Parse the agent name from the subagent_type (strip the `quiver:` prefix if present).
+2. Find the corresponding `.md` file in the plugin's `agents/` directory:
+   - Review agents: `agents/review/<name>.md`
+   - Research agents: `agents/research/<name>.md`
+3. Read the full file content -- the YAML frontmatter plus the markdown body is the agent's persona prompt.
+4. Spawn a worker agent with the persona prompt plus the task-specific context (diff, file list, etc.) that the skill provides:
+   - `spawn_agent(agent_type="worker", message=<persona prompt + task context>)`
+5. The `model` field in the agent's YAML frontmatter is advisory -- use whatever model is available.
+
+When a skill dispatches multiple agents in parallel (e.g., `/review` dispatches up to 10 agents), spawn them as parallel workers. Collect all results before continuing to the synthesis step.
+
+## AskUserQuestion substitution
+
+Codex does not expose an action-button question API. When a Quiver skill says `AskUserQuestion(...)` or asks you to present action-button prompts, render a numbered text prompt and wait for the user's reply.
+
+Format:
+
+    <one-sentence question>
+
+    1. <Option A label> -- <one-line description>
+    2. <Option B label> -- <one-line description>
+    3. <Option C label> -- <one-line description>
+    4. Other -- describe your choice
+
+    Reply with the number, or describe your choice.
+
+Rules:
+
+1. Always include "Other -- describe" as the last option, mirroring Claude Code's free-text fallback.
+2. Number options 1-N; do not letter them.
+3. Do not collapse multiple decisions into a single prompt unless the original AskUserQuestion call did so. One question per polyfill prompt is the default.
+4. After the user replies with a number, restate the choice in one sentence ("Going with option 2: ...") before continuing. This catches misclicks visible to the user before the action runs.
+
+## Stop hook
+
+Codex does not have a PreCompact event. The handover auto-save hook is mapped to the Stop event (turn completion) with a time-based guard. The guard skips saving if a handover was already saved within the last 10 minutes. This means handovers are saved less frequently than on Claude Code, but the manual `/handover` skill always works regardless of the hook.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,20 @@ Or browse [cursor.com/marketplace](https://cursor.com/marketplace) and click "Ad
 - `WebFetch` and `WebSearch` are unsupported on Cursor; the included context7 MCP covers documentation lookups.
 - If handover auto-save does not fire after install, Cursor's `preCompact` event may use a different JSON field name than Claude Code. Edit `.cursor/hooks.json` to log raw stdin to a file, trigger context compaction, and inspect the log for the actual field names.
 
-### Gemini CLI, OpenAI Codex CLI, Antigravity
+### OpenAI Codex CLI
+
+```text
+codex plugin marketplace add yagizdo/quiver
+```
+
+Then try `/brainstorm` in any session.
+
+- The handover auto-save hook maps to Codex's `Stop` event with a 10-minute cooldown. For on-demand handovers, use `/handover` directly.
+- `AskUserQuestion` is polyfilled as numbered text prompts -- reply with the option number.
+- Agent dispatch uses `spawn_agent(worker)` with the agent's persona prompt read from `agents/`. The `/review` skill dispatches up to 10 agents in parallel this way.
+- The hook script uses `claude -p` for transcript summarization. If the `claude` CLI is not installed, the auto-save hook will silently skip (manual `/handover` still works).
+
+### Gemini CLI, Antigravity
 
 Planned in sequential follow-up branches.
 

--- a/hooks/hooks-codex.json
+++ b/hooks/hooks-codex.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/codex-stop-handover.sh",
+            "timeout": 180
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/scripts/codex-stop-handover.sh
+++ b/hooks/scripts/codex-stop-handover.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Codex Stop-event wrapper for handover auto-save.
+# Guards against excessive saves (Stop fires every turn; PreCompact fires rarely).
+# Delegates to the canonical pre-compact-handover.sh after the guard passes.
+set -euo pipefail
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+HANDOVER_DIR="${PROJECT_DIR}/.claude/handovers"
+
+# Guard: skip if a handover was saved in the last 10 minutes (600 seconds).
+if [[ -d "$HANDOVER_DIR" ]]; then
+  LAST_HANDOVER=$(ls -1t "${HANDOVER_DIR}"/*.md 2>/dev/null | head -1)
+  if [[ -n "$LAST_HANDOVER" ]]; then
+    if [[ "$(uname)" == "Darwin" ]]; then
+      LAST_MOD=$(stat -f %m "$LAST_HANDOVER" 2>/dev/null || echo 0)
+    else
+      LAST_MOD=$(stat -c %Y "$LAST_HANDOVER" 2>/dev/null || echo 0)
+    fi
+    NOW=$(date +%s)
+    ELAPSED=$(( NOW - LAST_MOD ))
+    if (( ELAPSED < 600 )); then
+      exit 0
+    fi
+  fi
+fi
+
+# Delegate to the canonical hook script.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec bash "${SCRIPT_DIR}/pre-compact-handover.sh"

--- a/hooks/scripts/codex-stop-handover.sh
+++ b/hooks/scripts/codex-stop-handover.sh
@@ -9,7 +9,7 @@ HANDOVER_DIR="${PROJECT_DIR}/.claude/handovers"
 
 # Guard: skip if a handover was saved in the last 10 minutes (600 seconds).
 if [[ -d "$HANDOVER_DIR" ]]; then
-  LAST_HANDOVER=$(ls -1t "${HANDOVER_DIR}"/*.md 2>/dev/null | head -1)
+  LAST_HANDOVER=$(ls -1t "${HANDOVER_DIR}"/*.md 2>/dev/null | head -1 || true)
   if [[ -n "$LAST_HANDOVER" ]]; then
     if [[ "$(uname)" == "Darwin" ]]; then
       LAST_MOD=$(stat -f %m "$LAST_HANDOVER" 2>/dev/null || echo 0)

--- a/marketplace.json
+++ b/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "quiver-marketplace",
+  "interface": {
+    "displayName": "Quiver"
+  },
+  "plugins": [
+    {
+      "name": "quiver",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE"
+      },
+      "category": "Productivity"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add OpenAI Codex CLI support to Quiver via a `.codex-plugin/` overlay that references the shared canonical skills, agents, and hooks -- following the same pattern established by the Cursor overlay. No canonical files are modified (OR1 invariant preserved).

- **New:** `.codex-plugin/plugin.json` -- Codex manifest registering shared skills and context7 MCP
- **New:** `.codex-plugin/rules/quiver-codex-compat.md` -- Tool mapping, shell-block interpretation, agent dispatch, and AskUserQuestion polyfill
- **New:** `hooks/hooks-codex.json` -- Stop event hook config for handover auto-save
- **New:** `hooks/scripts/codex-stop-handover.sh` -- Guard wrapper with 10-minute cooldown
- **Modified:** `README.md` -- Codex CLI install section with caveats

### How it works

1. The Codex manifest registers the shared `skills/` directory and context7 MCP server, with hooks pointing to a Codex-specific config.
2. A compatibility rules file bridges Claude Code tool names (Bash, Read, Edit, Agent, AskUserQuestion) to Codex equivalents (shell execution, file read, apply_patch, spawn_agent, numbered text prompts).
3. Agent dispatch uses runtime injection: skills read agent `.md` files from `agents/` and pass the persona prompt to `spawn_agent(worker)`.
4. The Stop-event hook wraps the canonical `pre-compact-handover.sh` with a 10-minute cooldown guard, since Codex's Stop fires every turn (unlike Claude Code's PreCompact which fires rarely).

### Design decisions

| Decision | Choice | Why |
|----------|--------|-----|
| Agent registration | Runtime injection via `spawn_agent(worker)` | Codex has no plugin-level agent registry; avoids external TOML tooling |
| Rules approach | Single global compat file | One translation layer for all 16 skills vs. duplicating per-skill references |
| Hook event | Stop with 10-min guard | Codex lacks PreCompact; guard prevents excessive saves |
| Canonical files | Untouched | OR1/OR2 invariants preserved -- overlay only |

## Test plan

- [ ] Verify `codex plugin marketplace add yagizdo/quiver` installs the plugin
- [ ] Verify all 16 skills appear in Codex's slash menu
- [ ] Verify tool mapping works: skills using Read/Edit/Write produce correct behavior
- [ ] Verify agent dispatch: `/review` can spawn review agents via `spawn_agent(worker)`
- [ ] Verify AskUserQuestion renders as numbered text prompts
- [ ] Verify Stop hook fires with guard (no excessive saves)
- [ ] Verify OR1: `git diff --stat master...HEAD -- agents/ skills/ hooks/hooks.json .claude-plugin/` returns empty