### PR TITLE
feat(gemini): add Gemini CLI support overlay

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,54 @@
+# Quiver on Gemini CLI: Interpretation Rules
+
+Quiver's agents and skills were originally written for Claude Code. When you (the Gemini CLI agent) load any file under `agents/` or `skills/` and execute the workflow it describes, follow these substitution rules.
+
+## Inline shell-block syntax
+
+Quiver skills contain blocks like:
+
+    !`git status`
+
+In Claude Code, the harness pre-executes these and injects the output into the prompt. Gemini CLI does not do this. When you see one of these blocks in a skill body:
+
+1. Execute the command yourself via `run_shell_command`.
+2. Read the output.
+3. Continue with the rest of the skill body, treating the output as if the harness had injected it.
+
+## Tool-name substitutions
+
+When a Quiver agent or skill references a Claude Code tool name, use the Gemini CLI equivalent.
+
+| Claude Code | Gemini CLI | Notes |
+|-------------|-----------|-------|
+| Bash | run_shell_command | Identical semantics. |
+| Read | read_file | Identical semantics. |
+| Write | write_file | Identical semantics. |
+| Edit | replace | Same old_string/new_string semantics. |
+| Grep | grep_search | Gemini has native regex grep. |
+| Glob | glob | Gemini has native glob. |
+| Agent | (runtime injection) | See the Agent dispatch section below. |
+| AskUserQuestion | ask_user | Native -- map the tool name. |
+| WebSearch | google_web_search | Native. |
+| WebFetch | web_fetch | Native. |
+| TaskCreate / TaskUpdate | write_todos | Gemini's task tracking. |
+| EnterPlanMode | enter_plan_mode | Native. |
+| ExitPlanMode | exit_plan_mode | Native. |
+| Skill | activate_skill | Native. |
+
+## Agent dispatch
+
+Quiver skills dispatch specialized agents using the Agent tool with a `subagent_type` parameter (e.g., `subagent_type: "quiver:security-audit"`). Gemini CLI does not have a named agent registry in the extension manifest. When a skill asks you to dispatch a named agent:
+
+1. Parse the agent name from the subagent_type (strip the `quiver:` prefix if present).
+2. Find the corresponding `.md` file in the extension's `agents/` directory:
+   - Review agents: `agents/review/<name>.md`
+   - Research agents: `agents/research/<name>.md`
+3. Read the full file content -- the YAML frontmatter plus the markdown body is the agent's persona prompt.
+4. Execute the persona prompt inline, treating the agent's instructions as your own for the duration of that task. Apply the persona's methodology to the diff or file set the skill provides.
+5. The `model` field in the agent's YAML frontmatter is advisory -- use whatever model is available.
+
+When a skill dispatches multiple agents in parallel, execute them sequentially. Collect all results before continuing to the synthesis step.
+
+## PreCompress hook
+
+The handover auto-save hook maps to Gemini CLI's PreCompress event via `hooks/hooks-gemini.json`. PreCompress fires before history compression -- the same trigger point as Claude Code's PreCompact. No guard condition is needed. The hook script uses `claude -p` for transcript summarization. If the `claude` CLI is not installed, the auto-save hook will silently skip (manual `/handover` still works).

--- a/README.md
+++ b/README.md
@@ -54,9 +54,18 @@ Then try `/brainstorm` in any session.
 - Agent dispatch uses `spawn_agent(worker)` with the agent's persona prompt read from `agents/`. The `/review` skill dispatches up to 10 agents in parallel this way.
 - The hook script uses `claude -p` for transcript summarization. If the `claude` CLI is not installed, the auto-save hook will silently skip (manual `/handover` still works).
 
-### Gemini CLI, Antigravity
+### Gemini CLI
 
-Planned in sequential follow-up branches.
+```text
+gemini extensions install quiver
+```
+
+Then try `/brainstorm` in any session.
+
+- `ask_user` is native on Gemini CLI -- interactive prompts render with full fidelity.
+- The handover auto-save hook maps to Gemini CLI's `PreCompress` event. Unlike Codex's Stop event, no cooldown guard is needed -- PreCompress fires only before history compression.
+- Agent dispatch reads agent persona prompts from `agents/` and executes them inline. The `/review` skill dispatches up to 10 agents this way.
+- The hook script uses `claude -p` for transcript summarization. If the `claude` CLI is not installed, the auto-save hook will silently skip (manual `/handover` still works).
 
 ## Components
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,12 @@
+{
+  "name": "quiver",
+  "version": "1.8.1",
+  "description": "Composable development lifecycle -- brainstorm, plan, execute, review, and hand over from idea to merged PR",
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    }
+  },
+  "contextFileName": "GEMINI.md"
+}

--- a/hooks/hooks-gemini.json
+++ b/hooks/hooks-gemini.json
@@ -1,0 +1,18 @@
+{
+  "hooks": {
+    "PreCompress": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${extensionPath}/hooks/scripts/pre-compact-handover.sh",
+            "name": "Quiver Handover Auto-Save",
+            "timeout": 180000,
+            "description": "Saves an 8-section handover note before history compression"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Add `gemini-extension.json` manifest at repo root with context7 MCP server and `GEMINI.md` context file reference
- Add `GEMINI.md` compatibility rules: inline shell-block interpretation, tool-name substitutions (14 mappings), agent dispatch via runtime injection, PreCompress hook description
- Add `hooks/hooks-gemini.json` mapping PreCompress event to the shared handover script (180000ms timeout, no guard needed)
- Update README: replace "Gemini CLI, Antigravity" placeholder with a proper install subsection, remove all Antigravity references

## Invariants verified

- **OR1**: no canonical files modified (`agents/`, `skills/`, `hooks/hooks.json`, `hooks/hooks-codex.json`, `hooks/scripts/`, `.claude-plugin/`, `.cursor-plugin/`, `.codex-plugin/`)
- **OR2**: no canonical files reference Gemini-specific files
- **Version**: all 4 manifests at 1.8.1

## Test plan

- [ ] Verify `gemini-extension.json` and `hooks/hooks-gemini.json` are valid JSON
- [ ] Verify GEMINI.md has 4 sections: shell blocks, tool map, agent dispatch, PreCompress hook
- [ ] Verify README install order: Claude Code -> Cursor -> Codex -> Gemini CLI
- [ ] Verify no Antigravity references remain in README
- [ ] Verify OR1/OR2 invariants pass
- [ ] Verify version consistency across all manifests