### PR TITLE
Repair visual-companion routing/lifetime + drop invalid PreCompress hook

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -11,20 +11,6 @@
           }
         ]
       }
-    ],
-    "PreCompress": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ${extensionPath}/hooks/scripts/pre-compact-handover.sh",
-            "name": "Quiver Handover Auto-Save",
-            "timeout": 180000,
-            "description": "Saves an 8-section handover note before history compression"
-          }
-        ]
-      }
     ]
   }
 }

--- a/skills/visual-companion/SKILL.md
+++ b/skills/visual-companion/SKILL.md
@@ -150,9 +150,10 @@ Each line is a JSON object appended by the server. The agent reads this file to 
 
 ## 5. Cleaning Up
 
-The server self-terminates in two cases:
-- **Idle timeout:** No HTTP requests for 30 minutes.
+The server self-terminates in three cases:
+- **Idle timeout:** No real HTTP activity (page loads, click events, agent updates) for 30 minutes. SSE keepalives and auto-reconnects do NOT reset this timer -- if they did, an open browser tab would keep the server alive forever through any network blip.
 - **Owner PID death:** The `--owner-pid` process no longer exists (checked every 0.5s).
+- **Max lifetime:** 8 hours since startup, regardless of activity. Override with `--max-lifetime <seconds>`; set to 0 to disable.
 
 To stop manually:
 ```
@@ -190,3 +191,4 @@ cp <temp-dir>/final-layout.html docs/brainstorms/YYYY-MM-DD-<name>-mockups/
 - This is the only Quiver skill that ships a runtime executable (`server.py`); never assume skill dirs are prompt-only.
 - Stopping the server depends on the PID file; if the temp dir is deleted before the kill, manual `pkill -f server.py` is needed.
 - Root request (`/` or `/index.html`) on an empty serve dir returns a built-in "waiting" landing page that subscribes to SSE; this lets the agent announce the URL before any HTML exists. Specific paths (e.g. `/foo.html`) still 404 when missing -- do not rely on the landing page to mask broken links.
+- The 8h hard ceiling and SSE-immune idle timer exist because a server was once found alive 29 days after start. Browser SSE auto-reconnects (WiFi switch / sleep / VPN) used to reset the idle timer indefinitely. Do not "simplify" `log_request` back to unconditional reset; do not remove `--max-lifetime`.

--- a/skills/visual-companion/SKILL.md
+++ b/skills/visual-companion/SKILL.md
@@ -58,8 +58,8 @@ A question about a UI topic is not automatically a visual question. "Should we u
 For each visual step in the brainstorm:
 
 1. **Write an HTML fragment** to `<temp-dir>` with a semantic filename (e.g., `layout-options.html`). Write body content only -- the server wraps fragments automatically.
-2. **Never reuse filenames.** Each screen gets a fresh file. For iterations, append a version suffix: `layout-options-v2.html`.
-3. **Browser auto-reloads** via SSE when a new or changed `.html` file is detected. No manual refresh needed.
+2. **Never reuse filenames.** Each screen gets a fresh file. For iterations, append a version suffix: `layout-options-v2.html`. Older files stay on disk so the agent can copy them out at the end of the session.
+3. **Browser stays on `/` and auto-shows the newest file.** The server routes the root URL to the most recently modified `.html` file in the temp dir; SSE reload triggers whenever any HTML file changes. The user opens the URL once and never has to navigate manually -- each new file replaces the previous view automatically.
 
 ### Pick ONE input mode per step
 
@@ -190,5 +190,5 @@ cp <temp-dir>/final-layout.html docs/brainstorms/YYYY-MM-DD-<name>-mockups/
 **Known gotchas:**
 - This is the only Quiver skill that ships a runtime executable (`server.py`); never assume skill dirs are prompt-only.
 - Stopping the server depends on the PID file; if the temp dir is deleted before the kill, manual `pkill -f server.py` is needed.
-- Root request (`/` or `/index.html`) on an empty serve dir returns a built-in "waiting" landing page that subscribes to SSE; this lets the agent announce the URL before any HTML exists. Specific paths (e.g. `/foo.html`) still 404 when missing -- do not rely on the landing page to mask broken links.
+- Root request (`/` or `/index.html`) routes to the most recently modified HTML file in the serve dir; if none exists, it returns a built-in "waiting" landing page that subscribes to SSE. Both responses inject the SSE client, so the browser auto-reloads when the agent writes or updates any HTML. Specific paths (e.g. `/foo.html`) still 404 when missing -- do not rely on root routing to mask broken links.
 - The 8h hard ceiling and SSE-immune idle timer exist because a server was once found alive 29 days after start. Browser SSE auto-reconnects (WiFi switch / sleep / VPN) used to reset the idle timer indefinitely. Do not "simplify" `log_request` back to unconditional reset; do not remove `--max-lifetime`.

--- a/skills/visual-companion/SKILL.md
+++ b/skills/visual-companion/SKILL.md
@@ -51,7 +51,7 @@ A question about a UI topic is not automatically a visual question. "Should we u
    - If the loop completes with no output, the server failed to launch. Do NOT announce a URL. Inspect `<temp-dir>/.vc-meta/` and the background-process output, fix the underlying issue, and retry step 2.
 
 4. Tell the user (only after step 3 prints a URL):
-   > Visual companion running at {url}. It auto-refreshes when I update content.
+   > Visual companion running at {url}. Open it now -- you'll see a "waiting" page until I push the first visual, then it refreshes automatically.
 
 ## 3. The Loop
 
@@ -189,3 +189,4 @@ cp <temp-dir>/final-layout.html docs/brainstorms/YYYY-MM-DD-<name>-mockups/
 **Known gotchas:**
 - This is the only Quiver skill that ships a runtime executable (`server.py`); never assume skill dirs are prompt-only.
 - Stopping the server depends on the PID file; if the temp dir is deleted before the kill, manual `pkill -f server.py` is needed.
+- Root request (`/` or `/index.html`) on an empty serve dir returns a built-in "waiting" landing page that subscribes to SSE; this lets the agent announce the URL before any HTML exists. Specific paths (e.g. `/foo.html`) still 404 when missing -- do not rely on the landing page to mask broken links.

--- a/skills/visual-companion/server.py
+++ b/skills/visual-companion/server.py
@@ -102,6 +102,27 @@ MAX_SSE_CLIENTS = 20
 MAX_EVENTS_SIZE = 1_000_000  # 1MB
 
 
+def _find_latest_html(directory):
+    try:
+        candidates = []
+        for name in os.listdir(directory):
+            if not (name.endswith('.html') or name.endswith('.htm')):
+                continue
+            full = os.path.join(directory, name)
+            if not os.path.isfile(full):
+                continue
+            try:
+                candidates.append((os.path.getmtime(full), full))
+            except OSError:
+                pass
+        if not candidates:
+            return None
+        candidates.sort(reverse=True)
+        return candidates[0][1]
+    except OSError:
+        return None
+
+
 def register_sse_client():
     with sse_lock:
         if len(sse_clients) >= MAX_SSE_CLIENTS:
@@ -163,14 +184,20 @@ class Handler(BaseHTTPRequestHandler):
             self.send_error(403)
             return
         if not os.path.isfile(filepath):
-            # Root request with no index.html: serve a waiting page that
-            # subscribes to SSE and auto-reloads the moment the first HTML
-            # fragment lands. Avoids the "URL announced -> user opens ->
-            # 404" race when the agent has not written content yet.
+            # Root request with no explicit index.html: serve the most recently
+            # modified HTML file in the dir, or a waiting page if none exists.
+            # This keeps a single browser tab on `/` continuously useful as the
+            # agent writes new versioned files (layout-v1.html, layout-v2.html);
+            # SSE reload pulls the newest file each time without manual
+            # navigation. Specific paths still 404 so broken links stay visible.
             if is_root_request:
-                return self._serve_waiting_page()
-            self.send_error(404)
-            return
+                latest = _find_latest_html(serve_dir)
+                if latest is None:
+                    return self._serve_waiting_page()
+                filepath = latest
+            else:
+                self.send_error(404)
+                return
         MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
         if os.path.getsize(filepath) > MAX_FILE_SIZE:
             self.send_error(413, "File too large")

--- a/skills/visual-companion/server.py
+++ b/skills/visual-companion/server.py
@@ -137,7 +137,14 @@ class Handler(BaseHTTPRequestHandler):
 
     def log_request(self, code='-', size='-'):
         global last_request_time
-        last_request_time = time.time()
+        # SSE traffic must NOT reset the idle timer. EventSource auto-reconnects
+        # on every network blip (WiFi switch, VPN, sleep/wake), so counting SSE
+        # requests as activity makes the idle timeout effectively unreachable
+        # while a browser tab is open -- a server was found alive 29 days after
+        # start because of this. Real user/agent activity (HTML GET, POST
+        # /event, DELETE /events) still resets the timer below.
+        if self.path != '/sse':
+            last_request_time = time.time()
 
     def do_GET(self):
         path = self.path.lstrip('/')
@@ -325,7 +332,7 @@ class ThreadingServer(ThreadingMixIn, HTTPServer):
 # Directory polling thread
 # ---------------------------------------------------------------------------
 
-def poll_directory(directory, owner_pid, server):
+def poll_directory(directory, owner_pid, server, max_lifetime):
     snapshot = {}
     for name in os.listdir(directory):
         full = os.path.join(directory, name)
@@ -335,8 +342,17 @@ def poll_directory(directory, owner_pid, server):
             except OSError:
                 pass
 
+    start_time = time.time()
     while True:
         time.sleep(POLL_INTERVAL)
+
+        # Hard lifetime ceiling -- final safety net regardless of idle/owner state.
+        if max_lifetime > 0 and time.time() - start_time > max_lifetime:
+            sys.stderr.write("visual-companion: shutting down (max lifetime {}s reached)\n".format(int(max_lifetime)))
+            if _cleanup_fn:
+                _cleanup_fn()
+            threading.Thread(target=server.shutdown, daemon=True).start()
+            return
 
         # Idle timeout
         if time.time() - last_request_time > IDLE_TIMEOUT:
@@ -397,6 +413,9 @@ def main():
     parser.add_argument('--dir', required=True, help='Directory to serve HTML from')
     parser.add_argument('--owner-pid', type=int, default=None, help='Parent process PID for lifecycle tracking')
     parser.add_argument('--verbose', action='store_true', help='Enable HTTP request logging to stderr')
+    parser.add_argument('--max-lifetime', type=float, default=28800,
+                        help='Hard ceiling on server lifetime in seconds (default: 28800 = 8h). '
+                             'Server exits no matter what once exceeded. Set to 0 to disable.')
     args = parser.parse_args()
 
     global verbose
@@ -433,7 +452,7 @@ def main():
     signal.signal(signal.SIGTERM, sigterm_handler)
 
     # Start polling thread
-    t = threading.Thread(target=poll_directory, args=(serve_dir, args.owner_pid, server), daemon=True)
+    t = threading.Thread(target=poll_directory, args=(serve_dir, args.owner_pid, server, args.max_lifetime), daemon=True)
     t.start()
 
     url = info['url']

--- a/skills/visual-companion/server.py
+++ b/skills/visual-companion/server.py
@@ -143,6 +143,7 @@ class Handler(BaseHTTPRequestHandler):
         path = self.path.lstrip('/')
         if path == 'sse':
             return self._handle_sse()
+        is_root_request = not path or path == 'index.html'
         if not path:
             path = 'index.html'
         # Block access to .vc-meta directory
@@ -155,6 +156,12 @@ class Handler(BaseHTTPRequestHandler):
             self.send_error(403)
             return
         if not os.path.isfile(filepath):
+            # Root request with no index.html: serve a waiting page that
+            # subscribes to SSE and auto-reloads the moment the first HTML
+            # fragment lands. Avoids the "URL announced -> user opens ->
+            # 404" race when the agent has not written content yet.
+            if is_root_request:
+                return self._serve_waiting_page()
             self.send_error(404)
             return
         MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
@@ -236,6 +243,29 @@ class Handler(BaseHTTPRequestHandler):
                 pass  # nothing to truncate
         self.send_response(204)
         self.end_headers()
+
+    def _serve_waiting_page(self):
+        body = (
+            '<div style="display:flex;align-items:center;justify-content:center;'
+            'height:100vh;font-family:system-ui;color:#666;text-align:center">'
+            '<div><h1 style="font-size:1.25rem;margin-bottom:0.5rem">'
+            'Visual companion ready</h1>'
+            '<p>Waiting for the first visual to arrive. This page will refresh '
+            'automatically.</p></div></div>'
+        )
+        wrapped = (
+            '<!DOCTYPE html>\n<html lang="en">\n<head>\n'
+            '<meta charset="utf-8">\n'
+            '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
+            '<style>\n' + FRAME_CSS + '\n</style>\n'
+            '</head>\n<body>\n' + body + '\n' + CLIENT_JS + '\n</body>\n</html>'
+        ).encode('utf-8')
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/html; charset=utf-8')
+        self.send_header('Cache-Control', 'no-store')
+        self.send_header('Content-Length', str(len(wrapped)))
+        self.end_headers()
+        self.wfile.write(wrapped)
 
     def _process_html(self, raw):
         text = raw.decode('utf-8', errors='replace')


### PR DESCRIPTION
## Summary

- **Route visual-companion `/` to the latest HTML.** Previously, `/` only served a waiting page until an `index.html` existed; subsequent versioned files (`layout-v1.html`, `layout-v2.html`) were written to disk but the user's tab never advanced because SSE reload re-fetched the same waiting URL. Root requests now resolve to the most recently modified `.html` in the serve dir, so a single browser tab automatically follows the agent's writes. Specific paths still 404 to keep broken links visible.
- **Harden visual-companion server lifetime.** SSE traffic no longer resets the idle timer (browser auto-reconnects on every WiFi/VPN/sleep blip used to make the 30 min idle timeout effectively unreachable). New `--max-lifetime` flag (default 28800s = 8h) acts as a hard ceiling regardless of idle/owner state. A debug server was found alive 29 days after start; both compounding defects are now closed.
- **Repair visual-companion startup race.** Root requests on an empty serve dir now return a built-in waiting page that includes the SSE client, so the browser auto-reloads as soon as the first visual lands instead of sitting on a 404 until manual reload.
- **Drop invalid `PreCompress` hook entry from `hooks.json`.** Claude Code does not implement `PreCompress`; the entry produced load-time warnings.

## Test plan

- [ ] Trigger `/brainstorm` on a UI topic, accept the visual companion, watch the same tab auto-advance through multiple versioned HTML files without manual navigation
- [ ] Leave the companion idle 30+ min with a tab open; confirm the server still terminates (SSE keepalives no longer reset the timer)
- [ ] Confirm `hooks.json` loads with no warning about `PreCompress`
- [ ] Open the URL with an empty serve dir, then write the first HTML; browser should auto-reload to the new content without the user touching reload