### PR TITLE
feat(plan): add Plan Guard validation with inline checks and plan-reviewer agent

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -27,7 +27,8 @@
     "./agents/debug/log-analyzer.md",
     "./agents/debug/regression-finder.md",
     "./agents/debug/environment-checker.md",
-    "./agents/debug/fix-reviewer.md"
+    "./agents/debug/fix-reviewer.md",
+    "./agents/workflow/plan-reviewer.md"
   ],
   "mcpServers": {
     "context7": {

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Then try `/brainstorm` in any session.
 |-----------|-------|
 | Hooks | 1 |
 | Skills | 18 |
-| Agents | 16 |
+| Agents | 17 |
 
 ## Skills
 
@@ -230,6 +230,15 @@ These skills back the slash-invocable skills above. They are not invoked directl
 | `fix-reviewer` (`quiver:fix-reviewer`) | Reviews every proposed fix for overengineering, workarounds, and architectural consistency |
 
 <!-- agents:debug-end -->
+
+### Workflow
+<!-- agents:workflow-start -->
+
+| Agent | What it does |
+|-------|--------------|
+| `plan-reviewer` (`quiver:plan-reviewer`) | Reviews implementation plans for logical coherence, dependency ordering, coverage completeness, and spec alignment |
+
+<!-- agents:workflow-end -->
 <!-- agents-end -->
 
 ## External Dependencies

--- a/agents/workflow/plan-reviewer.md
+++ b/agents/workflow/plan-reviewer.md
@@ -1,0 +1,92 @@
+---
+name: plan-reviewer
+description: "Reviews implementation plans for logical coherence, dependency ordering, coverage completeness, and spec alignment."
+model: inherit
+---
+
+<examples>
+<example>
+Context: A plan has Task 3 reading a config file that Task 5 creates
+user: "Review this implementation plan for issues"
+assistant: "I'll review the plan for dependency and ordering issues. Task 3 reads `config/auth.yml` but Task 5 is the one that creates it -- Task 3 must move after Task 5 or the implementer will hit a missing-file error."
+<commentary>REORDER finding with concrete task numbers and the specific file that creates the dependency. The agent traces task inputs/outputs to find the ordering bug.</commentary>
+</example>
+<example>
+Context: A clean, well-structured plan with correct ordering and full spec coverage
+user: "Check this plan before I start building"
+assistant: "Plan reviewed: 8 tasks, all dependencies resolve correctly, every spec requirement maps to at least one task, no placeholders found. Zero findings -- ready to execute."
+<commentary>Zero findings is a valid outcome. The agent does not manufacture issues to appear thorough.</commentary>
+</example>
+</examples>
+
+You are a plan quality reviewer. You review implementation plans as a reader who will execute them -- checking whether the tasks are ordered correctly, whether dependencies resolve, whether the spec is fully covered, and whether the plan contains enough detail to build from. You did not write this plan. You evaluate it.
+
+## Plan Review Discipline
+
+These rules override all phase-specific guidance. Violating them produces noise, not value.
+
+1. **Concrete evidence required.** Every finding must cite specific task numbers, file paths, or spec requirements. "The ordering seems off" is not a finding. "Task 3 reads `src/auth/config.ts` but Task 5 creates it" is a finding.
+
+2. **Hypothetical language is banned.** Do not emit findings containing "could potentially", "might", "in the future", "consider", or "it would be better if". These phrases mark the finding as speculative. Do not emit findings whose severity relies on hypothetical future callers, hypothetical refactors, or unspecified future requirements. If you cannot state the problem as a present-tense concrete defect or risk with demonstrable consequences on current code, discard the finding. Speculation is not a finding.
+
+3. **One-pass thoroughness.** Trace all tasks in a single pass. Do not declare the review complete until every task has been checked for dependency resolution, file path validity, and spec coverage. Shallow passes that miss issues force rework.
+
+4. **Zero findings is success.** A well-written plan deserves a clean review. Do not manufacture findings to appear thorough. Many plans are correct.
+
+5. **Findings must be actionable.** Every finding must include an action verb (FIX, ADD, REORDER, NOTE) and enough context for the plan author to act without re-reading the full plan. A finding without a clear action is not a finding.
+
+6. **Plan scope only.** Do not evaluate code quality, architecture decisions, naming conventions, or implementation approaches described in the plan. You review the plan's structure, ordering, and coverage -- not the technical choices it makes.
+
+## Phase 1 -- Structural Scan
+
+Read the full plan and build a mental model:
+
+1. **Task inventory.** List every task with its target file(s) and expected outcome.
+2. **Dependency graph.** For each task, identify what it reads, creates, modifies, or deletes. Map producer-consumer relationships: if Task A creates a file that Task B modifies, B depends on A.
+3. **Spec mapping.** If a source specification or brainstorm doc was provided, map each spec requirement to the task(s) that implement it.
+4. **Acceptance criteria.** Note all acceptance criteria. These are verified in Phase 2.
+
+## Phase 2 -- Semantic Review
+
+Evaluate the plan against 5 dimensions:
+
+1. **Dependency ordering.** Walk the dependency graph from Phase 1. Flag any task that reads or modifies a file before the task that creates it. Flag any task that references a symbol, type, or function defined in a later task.
+2. **Spec coverage (bidirectional).** Forward: does every spec requirement have at least one implementing task? Reverse: does every task trace back to a spec requirement or explicit infrastructure need? Forward gaps get ADD. Reverse gaps get NOTE (potential scope creep).
+3. **Completeness.** Flag tasks with missing file paths, missing expected outcomes, placeholder text (TBD, TODO, "implement later", "handle edge cases", "similar to Task N"), or vague instructions that do not specify what to build.
+4. **Naming consistency.** Extract symbol names (functions, types, variables, file names) across all tasks. Flag any symbol that appears with different spellings in different tasks.
+5. **Acceptance criteria coverage.** For each acceptance criterion, verify at least one task produces the outcome it describes. Flag criteria with no implementing task.
+
+## Phase 3 -- Report
+
+### Findings
+
+Present findings in a table. If zero findings, state "Zero findings -- plan is ready to execute." and skip the table.
+
+```
+| ID | Action | Target | Description |
+|----|--------|--------|-------------|
+| 1  | REORDER | Task 3, Task 5 | Task 3 reads `config/auth.yml` created by Task 5 -- move Task 3 after Task 5 |
+| 2  | ADD | Spec R2 | Spec requires rate limiting but no task implements it |
+| 3  | FIX | Task 4 | Missing file path -- "update the config" does not specify which file |
+| 4  | NOTE | Task 7 | No spec requirement maps to this task -- verify it is intentional infrastructure |
+```
+
+**Action taxonomy:**
+- **FIX** -- Concrete error in the plan (missing file path, placeholder text, broken cross-reference)
+- **ADD** -- Missing task or acceptance criterion required by the spec
+- **REORDER** -- Tasks in wrong dependency order
+- **NOTE** -- Observation that does not block execution (potential scope creep, unusually large task)
+
+### Details
+
+For each finding, expand with:
+- The specific task numbers or spec requirements involved
+- Why this is a problem (what breaks during execution)
+- The suggested resolution
+
+### Verdict
+
+State one of:
+- **Ready** -- Zero findings, or only NOTE findings. Plan can be executed as-is.
+- **Fixable** -- FIX/ADD/REORDER findings exist but are straightforward to resolve.
+- **Needs rework** -- Structural issues (major dependency cycles, large spec gaps) that require significant plan revision.

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -288,16 +288,94 @@ review_iteration: 1  # increments for each fix plan targeting the same review
 - Add a verification criterion (e.g., "flutter analyze passes clean")
 - These criteria become the Definition of Done -- the work skill uses them to determine when the review-fix cycle is COMPLETE and to prevent infinite re-review loops
 
-## Step 6 -- Plan Self-Review
+## Step 6 -- Plan Guard: Inline Validation
 
-After drafting the plan, review it before presenting to the user. This is an internal check -- do not show it as a separate section to the user.
+After drafting the plan, run these 6 checks before presenting to the user. This is an internal quality gate -- do not show it as a separate section to the user.
 
-1. **Spec coverage:** If the task originated from a brainstorm spec or review report, skim each requirement. Can you point to a task that implements it? Add missing tasks.
-2. **Placeholder scan:** Search for "TBD", "TODO", "implement later", vague steps without file paths or code. Fix them.
-3. **Naming consistency:** Do function names, type names, and variable names match across tasks? A function called `clearLayers()` in Task 3 but `clearFullLayers()` in Task 7 is a bug in the plan.
-4. **Test coverage:** Does every task that produces testable behavior have a corresponding test step? If the project has tests, missing test steps are plan gaps.
+### Check 1: Placeholder scan
 
-Fix issues inline. No need to re-review after fixes -- just fix and move on.
+Search the plan for: "TBD", "TODO", "implement later", "fill in details", "add appropriate", "handle edge cases", "similar to Task N", raw `{...}` template text, and steps without file paths or expected outcomes. Replace every match with concrete content. (FIX)
+
+### Check 2: Naming consistency
+
+Extract all symbol names (functions, types, variables, file names) from every task. Flag any symbol appearing in 2+ tasks with different spellings. Normalize to the first-used spelling. (FIX)
+
+### Check 3: Spec coverage (bidirectional)
+
+If the plan has a brainstorm spec reference (Context section referencing `docs/brainstorms/*.md`) or a review source (frontmatter `review_source`), read the source and verify:
+- **Forward:** each spec requirement maps to at least one plan task. Add a task for any gap. (ADD)
+- **Reverse:** each plan task maps to a spec requirement or explicit infrastructure need. Flag tasks that do not trace back. (NOTE -- potential scope creep)
+
+### Check 4: Task granularity
+
+Flag tasks that: modify more than 3 files, have more than 5 sub-steps, lack an expected outcome, or reference no file paths. (NOTE)
+
+### Check 5: Reference validity
+
+Probe file paths mentioned in the plan:
+- **Modify/Delete** targets must exist on disk. (FIX if missing)
+- **Create** targets must NOT exist on disk. (NOTE if collision)
+- Internal cross-references ("as defined in Task N") must resolve to an actual task. (FIX if dangling)
+
+### Check 6: File map completeness
+
+If the plan has a "File Map" section: every map entry must appear in at least one task, and every task file must appear in the map. (FIX for orphans, ADD for missing entries)
+
+### Action routing
+
+After running all 6 checks:
+- **FIX:** auto-fix by editing the plan content inline.
+- **ADD:** draft and insert missing content (tasks, acceptance criteria, file map entries).
+- **REORDER:** move affected tasks to satisfy dependency ordering.
+- **NOTE:** accumulate silently. If any NOTE findings exist, insert a `### Plan Guard Notes` subsection in the plan's Context section before the user sees the plan.
+
+After applying fixes, proceed to Step 6.5. No re-run of checks. The human review gate (Step 7) is the convergence anchor.
+
+## Step 6.5 -- Plan Guard: Agent Semantic Review
+
+**Skip conditions (check in order -- if any match, proceed directly to Step 7):**
+1. Complexity is **Light** (assessed in Step 1).
+2. This is a **review-fix plan** (detected in Step 1 via review report reference).
+
+If neither skip condition matches, dispatch the plan-reviewer agent:
+
+### Agent dispatch
+
+Spawn a single `quiver:plan-reviewer` agent with a self-contained prompt containing:
+
+```
+Agent(
+  subagent_type="quiver:plan-reviewer",
+  description="Semantic review of implementation plan",
+  prompt="Review this implementation plan for logical coherence, dependency ordering,
+  coverage completeness, and spec alignment.
+
+  ## Plan
+
+  {full plan content with Step 6 fixes already applied}
+
+  ## Source Specification
+
+  {spec content if available from the plan's Context section or spec_source frontmatter,
+   otherwise: 'No source specification provided.'}
+
+  ## Project Context
+
+  {relevant directory listings for file paths mentioned in the plan}
+
+  Report findings using the action taxonomy: FIX, ADD, REORDER, NOTE.
+  If zero findings, state that explicitly.",
+)
+```
+
+### Post-agent flow
+
+1. Parse the agent's structured findings.
+2. **Zero findings** -- proceed to Step 7.
+3. **Findings exist** -- apply edits:
+   - **FIX/ADD/REORDER:** edit the plan content inline.
+   - **NOTE:** append to the `### Plan Guard Notes` subsection in the plan's Context section (create it if it does not exist from Step 6).
+4. Do NOT re-dispatch the agent. One pass only. Proceed to Step 7.
 
 ## Step 7 -- Review Gate
 
@@ -389,6 +467,10 @@ After saving the plan file:
 - [ ] Review-fix detection produces frontmatter with `review_source` and `review_iteration`.
 - [ ] No raw `{placeholder}` strings remain in the saved plan.
 - [ ] The Step 7 and Step 8 user gates appear as `AskUserQuestion` calls, not plain-text prompts.
+- [ ] Step 6 runs 6 inline checks (placeholder, naming, spec coverage, granularity, reference validity, file map) on every plan.
+- [ ] Step 6.5 dispatches `plan-reviewer` agent only for Standard/Deep non-review-fix plans.
+- [ ] Light plans and review-fix plans skip Step 6.5 entirely.
+- [ ] Plan Guard Notes subsection appears in the plan's Context section only when NOTE findings exist.
 
 **Known gotchas:**
 - The Explore agent prompt embeds the full Code Navigation Strategy block; updates to that block must keep the skill body in sync with `skills/code-navigation/SKILL.md`.


### PR DESCRIPTION
## Summary

- Adds a 6-check inline validation gate (Step 6 - Plan Guard) that runs on every plan: placeholder scan, naming consistency, spec coverage, task granularity, reference validity, and file map completeness
- Adds a `plan-reviewer` agent (Step 6.5) for semantic review of Standard/Deep plans -- dispatched after inline checks, skipped for Light and review-fix plans
- Registers the new `agents/workflow/plan-reviewer.md` in plugin.json and updates README agent count to 17

## Test plan

- [ ] Run `/plan` on a Standard-complexity task and verify Step 6 inline checks execute before presenting the plan
- [ ] Verify Step 6.5 dispatches `plan-reviewer` agent for Standard/Deep plans
- [ ] Run `/plan` on a Light-complexity task and verify Step 6.5 is skipped
- [ ] Run `/plan` on a review-fix plan (from a review report) and verify Step 6.5 is skipped
- [ ] Verify NOTE findings appear in a `Plan Guard Notes` subsection
- [ ] Verify FIX/ADD/REORDER findings are auto-applied inline