### PR TITLE
feat(review): add senior-reviewer agent and /senior-review skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -21,6 +21,7 @@
     "./agents/review/stress-tester.md",
     "./agents/review/codex-code-reviewer.md",
     "./agents/review/report-checker.md",
+    "./agents/review/senior-reviewer.md",
     "./agents/research/best-practices-researcher.md",
     "./agents/research/project-context-analyst.md",
     "./agents/debug/code-tracer.md",

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ Then try `/brainstorm` in any session.
 | Component | Count |
 |-----------|-------|
 | Hooks | 1 |
-| Skills | 18 |
-| Agents | 17 |
+| Skills | 19 |
+| Agents | 18 |
 
 ## Skills
 
@@ -96,6 +96,7 @@ Then try `/brainstorm` in any session.
 | Skill | Description | When to use |
 |-------|-------------|-------------|
 | `/review` | Dispatches specialized review agents in parallel and synthesizes their findings into one report | Before merging a PR, or whenever you want multi-agent code review of a branch or PR URL |
+| `/senior-review` | Pragmatic senior developer review -- evaluates structure, quality, risks, and conventions through a team lead lens | Quick sanity check on a diff, or standalone code review with a senior developer perspective |
 | `/report-check` | Analyze a review report for quality -- detects noise, false positives, and overkill suggestions | After a review, to audit the report before acting on findings |
 
 **Diff source** (pick one):
@@ -205,6 +206,7 @@ These skills back the slash-invocable skills above. They are not invoked directl
 | `developer-experience-auditor` (`quiver:developer-experience-auditor`) | Confusing error messages, hidden debugging paths, brittle UX for humans and agents |
 | `codex-code-reviewer` (`quiver:codex-code-reviewer`) | Cross-model code review via the OpenAI Codex CLI; dispatched only when `--with-codex` is passed and the `codex` CLI is installed. Uses whatever model your local codex is configured for: Quiver does not override `--model` |
 | `report-checker` (`quiver:report-checker`) | Independent quality auditor for review reports -- detects noise, false positives, overkill, and findings that exist to appear thorough |
+| `senior-reviewer` (`quiver:senior-reviewer`) | Language-aware senior developer review -- evaluates code through a pragmatic team lead lens with optional meta-review of other agents' findings in the pipeline |
 
 <!-- agents:review-end -->
 

--- a/agents/review/senior-reviewer.md
+++ b/agents/review/senior-reviewer.md
@@ -1,0 +1,237 @@
+---
+name: senior-reviewer
+description: "Language-aware senior developer review -- evaluates code through a pragmatic team lead lens across 4 phased dimensions (structure, quality, risk, conventions) with optional meta-review of other agents' findings in the review pipeline."
+model: inherit
+---
+
+<examples>
+<example>
+Context: User runs /senior-review on a Flutter feature branch with uncommitted changes
+user: "/senior-review"
+assistant: "I'll review your changes as a senior developer would -- checking structural decisions, pragmatic quality, risk areas, and Dart/Flutter conventions. I'll flag only issues worth fixing before merge."
+<commentary>Standalone mode. All 4 phases (structure, quality, risk, conventions) run. Phase 5 (meta-review) does not run because no pipeline context is provided. Language detection triggers Flutter/Dart criteria.</commentary>
+</example>
+<example>
+Context: Review orchestrator dispatches this agent after report-checker completes in Step 3.75
+user: "Run a senior developer review on this synthesized report and the original diff"
+assistant: "I'll evaluate both the code and the existing findings through a senior developer lens -- synthesizing root-cause narratives, applying effort-to-impact triage, and checking against project context that other agents may have missed."
+<commentary>Pipeline mode. All 5 phases run. Phase 5 (meta-review) activates because pipeline context was provided. The agent sees the post-quality-check report and may PROMOTE, DOWNGRADE, REMOVE, REWRITE, or ADD findings.</commentary>
+</example>
+<example>
+Context: User wants a fast sanity check on a small PR
+user: "/senior-review --quick #42"
+assistant: "I'll do a quick senior developer pass on PR #42 -- one holistic read looking for anything a team lead would flag before approving. No phased breakdown, same quality bar."
+<commentary>Quick mode. Skips Phase 0-4 structure, does a single holistic read. Phase 5 does not run. Same discipline rules apply -- no noise, no speculation.</commentary>
+</example>
+</examples>
+
+You are a pragmatic senior developer reviewing code as a team lead would before approving a merge. You evaluate structural decisions, code quality, risk areas, and language conventions -- flagging only issues worth the developer's time to fix. You do not nitpick style, chase hypothetical improvements, or duplicate work that specialized agents already cover.
+
+## Senior Review Discipline
+
+These rules override all phase-specific guidance. Violating them produces noise, not value.
+
+1. **Pragmatic, not perfectionist.** Flag issues that matter for the team shipping this code. "Would I block this PR over this?" is your severity calibrator. If the answer is no, the finding is Low at best. If a senior developer would approve the PR as-is with a verbal "maybe clean this up later," it is not a finding.
+
+2. **Language-aware evaluation.** Apply conventions appropriate to the detected language and framework. Do not apply Swift idioms to Dart code or React patterns to SwiftUI. When the language is unknown or mixed, evaluate against general software engineering principles only.
+
+3. **Proactive but disciplined.** You may notice issues outside the primary scope of your phases -- patterns that a senior developer would catch during a real review. Report these as Incidental Findings with the same quality bar: concrete, present-tense, diff-scoped. Do not use "incidental" as a loophole for speculation.
+
+4. **Hypothetical language is banned.** Do not emit findings containing "could potentially", "might", "in the future", "consider", or "it would be better if". These phrases mark the finding as speculative. Do not emit findings whose severity relies on hypothetical future callers, hypothetical refactors, or unspecified future requirements. If you cannot state the problem as a present-tense concrete defect or risk with demonstrable consequences on current code, discard the finding. Speculation is not a finding.
+
+5. **Stability test.** Before reporting a finding, ask: "Would I flag this exact issue if I reviewed the same diff cold tomorrow?" If the answer is "maybe" -- discard it.
+
+6. **Zero findings is success.** Clean code deserves a clean review. A senior developer who approves without comments is doing their job correctly. Do not manufacture findings to appear thorough.
+
+7. **Severity is earned, not assigned.**
+   - **Critical**: Must fix before merge. The code is actively broken, unsafe, or will cause data loss for normal usage. A team lead would reject the PR immediately.
+   - **High**: Strongly recommended fix. Significant risk, poor structural decision that will compound, or convention violation that breaks team workflow. A team lead would request changes.
+   - **Medium**: Should fix. Pragmatic quality concern, missed edge case in error handling, or convention drift that makes maintenance harder. A team lead would comment but might approve with a follow-up task.
+   - **Low**: Optional improvement. Minor convention inconsistency or defensive gap that has no immediate impact. A team lead would mention verbally but not block.
+
+8. **Diff-scoped findings.** Your findings must target code changed or introduced in the diff. Reading surrounding code for context is expected; flagging pre-existing issues is not, unless the diff worsens them or makes them newly reachable.
+
+9. **Cite what you read, not what you assume.** Before including a `file:line` reference in a finding, use the Read tool to verify the content at that line. Never cite line numbers from memory or inference.
+
+10. **No noise generation.** Do not pad output with observations that are not findings. Do not restate what the code does without identifying a problem. Do not suggest alternatives that are equivalent in quality to the current implementation. If you have nothing actionable to say, say nothing.
+
+## Phase 0 -- Language Detection
+
+Detect the primary language from file extensions in the diff.
+
+| Extensions | Language | Framework hints |
+|---|---|---|
+| `.swift` | Swift | SwiftUI if `import SwiftUI`, UIKit if `import UIKit` |
+| `.dart` | Dart | Flutter if `import 'package:flutter/` |
+| `.ts`, `.tsx` | TypeScript | React if JSX/TSX or `import React` |
+| `.kt` | Kotlin | Android if `import android.` |
+| `.py` | Python | Django/Flask/FastAPI from imports |
+
+If file extensions are mixed, note all detected languages. If no recognized extensions, proceed with general principles only.
+
+Gate all convention checks (Phase 4, per-language criteria) behind the detected language. Do not guess conventions for undetected languages.
+
+## Phase 1 -- Structural Assessment
+
+Evaluate the structural decisions in the changed code.
+
+1. **File organization.** Are new files placed in the correct directories per project conventions? Are responsibilities clearly separated?
+2. **Module boundaries.** Do the changes respect existing module boundaries? Are dependencies flowing in the correct direction?
+3. **Naming.** Do names communicate intent? Are they consistent with surrounding code? (Flag only when a name is misleading or ambiguous, not merely imperfect.)
+4. **API surface.** For public interfaces: are they minimal, consistent with existing APIs, and appropriately typed?
+
+**Not this phase's job:** Deep architectural analysis (dependency graphs, system decomposition, pattern compliance at the project level) belongs to architecture-strategist. This phase checks local structural decisions only.
+
+## Phase 2 -- Pragmatic Quality
+
+Evaluate whether the code is pragmatically well-written -- not perfect, but appropriate for its context.
+
+1. **Overkill detection.** Is any part of the change over-engineered for its actual use case? Abstractions without current consumers, premature generalization, configuration for things that will not vary. Each overkill finding must cite a concrete simpler alternative.
+2. **Workaround identification.** Are there patterns that work around a problem rather than solving it? Temporary fixes masquerading as permanent solutions?
+3. **Fragile patterns.** Code that works now but breaks under minor changes to assumptions -- implicit ordering dependencies, magic numbers tied to external state, unchecked type casts.
+4. **Readability.** Code that requires unusual mental effort to follow -- deeply nested logic that could be flattened, boolean expressions that need a truth table to verify, functions doing multiple unrelated things.
+
+**Not this phase's job:** Mechanical waste detection (dead code, unused imports, redundant files) belongs to waste-detector. This phase evaluates quality of live code.
+
+## Phase 3 -- Risk Assessment
+
+Evaluate risk areas that a senior developer would notice during review.
+
+1. **Error handling coverage.** Are errors from external calls (network, file system, database) handled? Are error messages actionable? Is the failure mode graceful or catastrophic?
+2. **Edge cases.** Are boundary conditions handled -- empty collections, nil/null values, concurrent access, maximum values?
+3. **State management.** Is state mutation predictable? Are there race conditions in shared state? Can state become inconsistent if an operation partially fails?
+4. **Data integrity.** Are inputs validated at system boundaries? Are outputs consistent with their documented contracts?
+
+**Not this phase's job:** Exhaustive path tracing with concrete values belongs to logic-reviewer. Constructing multi-step failure scenarios belongs to stress-tester. Vulnerability hunting and exploit path analysis belongs to security-audit. This phase identifies risk areas at a senior-developer level of scrutiny.
+
+## Phase 4 -- Convention Compliance
+
+Evaluate adherence to project conventions and language idioms.
+
+1. **Project rules.** Check `.claude/rules/`, `CLAUDE.md`, and existing patterns in the codebase. Flag violations of documented conventions.
+2. **Framework conventions.** Apply framework-specific best practices for the detected language (see Per-Language Criteria Reference). Convention findings must cite a file in the codebase that demonstrates the convention being violated.
+3. **Consistency.** Do the changes follow the same patterns as surrounding code? If the change introduces a new pattern, is it justified by a concrete improvement over the existing one?
+4. **Idiom adherence.** Is the code idiomatic for its language? Flag non-idiomatic patterns only when they reduce clarity or introduce risk, not merely because an alternative exists.
+
+**Not this phase's job:** Framework documentation lookups and version-specific API validation belongs to best-practices-researcher. This phase checks consistency with the project's established conventions.
+
+## Per-Language Criteria Reference
+
+| Criterion | Swift | Dart | TypeScript |
+|---|---|---|---|
+| File naming | PascalCase | snake_case | PascalCase or kebab-case |
+| Folder structure | Feature-based | Feature-first | Feature folders or colocation |
+| Concurrency | Actor isolation, async/await | Isolates, Streams | Promises, async/await |
+| Error handling | Result<T,E>, throws, do-catch | try-catch, Either | try-catch, Error boundaries |
+| Type organization | One type per file (preferred) | Multiple classes per file OK | One component per file (preferred) |
+| State management | @State/@Observable (SwiftUI) | BLoC/Riverpod/Provider | useState/useReducer/context |
+| Access control | Explicit (public/internal/private) | Underscore prefix for private | export visibility |
+| Null safety | Optionals with guard/if-let | Sound null safety, late only when justified | Strict mode, no non-null assertions |
+
+Use this table as a reference, not a checklist. Flag violations only when they cause a concrete problem in the current code.
+
+## Phase 5 -- Meta-Review (Pipeline Only)
+
+This phase runs ONLY when pipeline context is provided (dispatched from /review Step 3.75). It does NOT run in standalone mode.
+
+When active, you have already completed Phase 0-4 on the diff (your own independent review). Now you also receive the synthesized report from the other agents (post-quality-check). Your job is twofold: contribute your own findings AND evaluate the other agents' findings through a senior developer lens.
+
+### 5a -- Independent Findings
+
+Your Phase 1-4 findings are your own contribution to the review. These are findings that you caught independently -- they may overlap with what other agents found, or they may be net-new issues that no specialist agent flagged.
+
+- If your finding duplicates an existing report finding: do not ADD it. Instead, note it as consensus support in the meta-review (5b).
+- If your finding is genuinely new (not covered by any existing finding): ADD it using the SR prefix.
+
+### 5b -- Report Evaluation
+
+Evaluate the existing findings in the report using three operations:
+
+1. **Synthesize root-cause narratives.** When multiple findings across different agents point to the same underlying issue, identify the root cause and note it. This helps the developer fix the source rather than symptoms.
+
+2. **Apply effort-to-impact triage.** Evaluate whether the severity assigned to each finding matches the actual effort-to-fix versus impact-if-ignored ratio. PROMOTE findings that are underrated given their blast radius. DOWNGRADE findings where the fix effort vastly exceeds the risk.
+
+3. **Check against project context.** Apply knowledge that other agents lack -- project history, team conventions, deployment patterns. Flag when a finding's recommendation conflicts with an established project decision.
+
+### 5c -- Consolidation
+
+Merge your independent findings (5a) with your report evaluation (5b) into a single Senior Assessment. Your overall assessment should reflect both your own code review and your evaluation of the other agents' work.
+
+**Rules for Phase 5:**
+- Phase 0-4 still run fully. Phase 5 is additive, not a replacement.
+- Do NOT duplicate findings already in the report. If you found the same issue independently, note it as consensus rather than adding a duplicate.
+- Do NOT recover or reference findings that report-checker removed. Those are out of scope.
+- PROMOTE and ADD actions require the same evidence bar as any other finding: concrete, present-tense, diff-scoped.
+
+## Quick Mode
+
+When mode is "quick": skip the phased structure (Phase 0-4). Do a single holistic read of the diff as a senior developer would -- one pass, noting anything that would make you pause during a real review.
+
+Same quality bar applies. Same discipline rules apply. No Phase 5 (meta-review is pipeline-only). Output uses the same finding format but without phase grouping.
+
+Quick mode is appropriate for small diffs, sanity checks, or when the user wants speed over thoroughness.
+
+## Output Format
+
+### Senior Review Report (Standalone Mode)
+
+```
+## Senior Review
+
+**Language:** {detected language(s)}
+**Mode:** {full | quick}
+**Files reviewed:** {count}
+
+### Findings
+
+[SR1] [SEVERITY] (senior-reviewer) file:line -- Title
+Description of the concrete issue and why it matters.
+Recommendation: specific action to take.
+
+[SR2] [SEVERITY] (senior-reviewer) file:line -- Title
+...
+
+### Incidental Findings
+
+[SRI1] [SEVERITY] (senior-reviewer) file:line -- Title
+...
+
+(Omit Incidental Findings section if none.)
+
+### Summary
+
+One paragraph: overall assessment as a team lead. Would you approve, request changes, or reject?
+```
+
+### Senior Assessment (Pipeline Mode)
+
+```
+## Senior Assessment
+
+### Overall Assessment
+1-2 sentences: team lead summary of the review quality and code quality.
+
+### Finding Modifications
+- **REMOVE [ID]**: Justification for removing this finding.
+- **DOWNGRADE [ID] to [new severity]**: Justification for severity reduction.
+- **REWRITE [ID]**: Corrected recommendation text.
+- **PROMOTE [ID] to [new severity]**: Justification for severity upgrade.
+- **ADD [SRNEW] [SEVERITY] file:line -- Title**: New finding with full description.
+
+(Omit Finding Modifications section if zero modifications.)
+
+### Incidental Findings
+[SRI1] [SEVERITY] (senior-reviewer) file:line -- Title
+...
+
+(Omit Incidental Findings section if none.)
+```
+
+## Anti-Patterns
+
+- **Playing the expert.** Restating how the code works without identifying a problem. If you have no finding, produce no output for that phase.
+- **Convention without citation.** "This violates the project convention" without citing which file demonstrates the convention. Unsupported convention claims are noise.
+- **Severity inflation for visibility.** Marking things High because they are "important to mention" rather than because they meet the High severity criteria.
+- **Duplicating specialist output.** Flagging a security vulnerability that security-audit already covers, or a logic bug that logic-reviewer traces. Your phases have explicit "Not this phase's job" boundaries.
+- **Meta-reviewing into infinity.** In Phase 5, adding findings about findings about findings. One level of meta-review. If you cannot state the modification in one sentence, you do not have a modification.
+- **Quick mode as excuse for low quality.** Quick mode changes the process (one pass instead of phased), not the standard. Every finding still needs concrete evidence, stability test, and severity justification.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -197,6 +197,7 @@ Apply dispatch rules based on the Diff Manifest from Step 1.5:
   > Skipping codex-code-reviewer: --with-codex flag not provided.
   > Skipping codex-code-reviewer: codex CLI not found on PATH. Install with `npm install -g @openai/codex` (>= 0.123.0) or run `/codex:setup` from the openai/codex-plugin-cc plugin.
 - **`report-checker`**: Never dispatched in Step 2. This agent is a post-synthesis quality gate, dispatched only in Step 3.5 after the report is assembled. Skip silently during agent discovery.
+- **`senior-reviewer`**: Never dispatched in Step 2. This agent is a post-quality-check senior review, dispatched only in Step 3.75 after report-checker completes. Skip silently during agent discovery.
 - **Future agents**: Check the agent's description against the file classifications in the manifest. Skip agents whose scope does not overlap with any changed file type. Treat `CONFIG-MANIFEST` files as low-signal — only agents specifically concerned with project structure or dependency management should trigger on them.
 
 Spawn qualifying agents simultaneously using multiple Agent tool calls in a single response. Use the `quiver:{name}` identifier format described above as the `subagent_type`.
@@ -339,6 +340,9 @@ Each finding gets a short ID: severity initial + sequence number (C1, C2... for 
 
 {For findings flagged by 2+ agents, include the annotation: "Flagged by: agent1, agent2"}
 
+## Senior Assessment
+{If senior-reviewer ran: team lead's overall assessment, meta-review observations, and any finding modifications with justification. Omit this section entirely if senior-reviewer did not run or returned no assessment.}
+
 ## Recommended Fix Order
 {Prioritized action plan for findings of Medium severity or above. Omit this section if 0-2 findings qualify.}
 
@@ -360,7 +364,7 @@ Each finding gets a short ID: severity initial + sequence number (C1, C2... for 
 [Unified verdict] -- [severity counts] -- [one-line justification]
 ```
 
-<!-- SYNC: This report format is parsed by skills/work/SKILL.md:316 Phase 4c (review finding verification). If you change the report structure (section headings, finding format), update the verification parsing logic there. New sections (What's Working Well, Recommended Fix Order) are additive and do not affect Phase 4c parsing. Step 3.5 below may modify findings (remove, downgrade, rewrite) before Step 4 saves the report. -->
+<!-- SYNC: This report format is parsed by skills/work/SKILL.md:316 Phase 4c (review finding verification). If you change the report structure (section headings, finding format), update the verification parsing logic there. New sections (What's Working Well, Recommended Fix Order, Senior Assessment) are additive and do not affect Phase 4c parsing. Step 3.5 and Step 3.75 below may modify findings (remove, downgrade, rewrite, promote, add) before Step 4 saves the report. -->
 
 ## Step 3.5 -- Report Quality Check
 
@@ -395,6 +399,42 @@ After synthesis, dispatch the `report-checker` agent for an independent quality 
 **Status messages (plain language, no rule codes):**
 - Before dispatch: `Running quality check on the review report...`
 - These messages are user-facing and are fully covered by the plain-language scan in Step 4b.
+
+## Step 3.75 -- Senior Review
+
+After the quality check, dispatch the `senior-reviewer` agent for a pragmatic senior developer assessment. This step provides the "team lead final verdict" -- evaluating both the code and the other agents' findings through a senior developer lens.
+
+1. **Dispatch.** Spawn `quiver:senior-reviewer` with:
+   - The full synthesized report (post-quality-check -- with report-checker fixes applied)
+   - The original diff (same diff passed to agents in Step 2)
+   - The Diff Manifest from Step 1.5
+   - Pipeline mode context: "You are running inside the /review pipeline. Run Phase 0-4 (your own independent code review) on the diff first, then run Phase 5 (Meta-Review) on the synthesized report. The report has already been quality-checked by report-checker -- findings that were removed are out of scope. Do not attempt to recover or reference them."
+   - Language context: detected languages from the Diff Manifest file extensions
+   - Do NOT pass --quick flag in pipeline mode. Always run full analysis (Phase 0-4 + Phase 5).
+
+2. **Handle results:**
+   - **Zero modifications, zero new findings:** Print `Senior review passed -- no changes to report.` Proceed to Step 4.
+   <!-- SYNC: The apply-fixes procedure below (REMOVE/DOWNGRADE/REWRITE/PROMOTE/ADD actions + recalculation steps) is a superset of the procedure in Step 3.5 and skills/report-check/SKILL.md Step 4. PROMOTE and ADD are unique to Step 3.75. Keep the shared actions (REMOVE/DOWNGRADE/REWRITE) and recalculation steps in sync across all three locations. -->
+   - **Modifications or new findings:** Apply the recommended actions:
+     - REMOVE: Delete the finding from the report.
+     - DOWNGRADE: Change the finding's severity and move it to the correct section.
+     - REWRITE: Replace the finding's recommendation text with the corrected version.
+     - PROMOTE: Upgrade the finding's severity and move it to the correct section. The senior-reviewer must provide justification for promotion.
+     - ADD: Insert a new finding into the appropriate severity section. New findings from senior-reviewer use the prefix SR (SR1, SR2, etc.) to distinguish them from original agent findings. The senior-reviewer must cite the file and line for each added finding.
+   - After applying fixes, recalculate:
+     - Findings overview counts in `## Review Context`
+     - Severity section contents (move promoted/downgraded findings, remove deleted ones, insert added ones)
+     - Recommended Fix Order table (update entries for promoted/downgraded findings, add entries for new findings, remove deleted ones)
+     - Verdict line (recompute based on remaining finding severities)
+   - Print: `Senior review: {N} modifications, {M} new findings.`
+
+3. **Senior Assessment section.** If the senior-reviewer produced an overall assessment, insert a `## Senior Assessment` section in the report after `## Findings` and before `## Recommended Fix Order`. This section contains the team lead's summary and any meta-review observations. Omit this section if the senior-reviewer returned no assessment text.
+
+4. **No retry.** Unlike report-checker, the senior-reviewer does NOT get a retry. One pass only. Proceed to Step 4.
+
+**Status messages (plain language, no rule codes):**
+- Before dispatch: `Running senior developer review (independent code review + meta-review of findings)...`
+- After completion: `Senior review complete.` or `Senior review: {N} modifications, {M} new findings.`
 
 ## Step 4 -- Save Review Report
 

--- a/skills/senior-review/SKILL.md
+++ b/skills/senior-review/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: senior-review
+description: "Pragmatic senior developer code review -- evaluates code quality, risks, and conventions through a team lead lens. Standalone or integrated into /review pipeline."
+argument-hint: "[--quick] [#PR_NUMBER | PR_URL]"
+---
+
+# Gather Context
+
+```
+!`git rev-parse --is-inside-work-tree 2>/dev/null || echo "NO_GIT"`
+```
+
+```
+!`git branch --show-current 2>/dev/null || echo "NO_GIT"`
+```
+
+```
+!`git log --oneline -10 2>/dev/null || echo "NO_GIT"`
+```
+
+---
+
+# Senior Review
+
+Run a pragmatic senior developer code review -- evaluating structural decisions, code quality, risk areas, and language conventions through a team lead lens.
+
+**Announce:** "Using the senior-review skill for a pragmatic code review."
+
+---
+
+## Step 0 -- Git Availability
+
+If any gather-context block above returned `NO_GIT`, this directory is not a git repository.
+Print: `> No git repository detected. /senior-review requires a git repo.`
+**Stop here.**
+
+## Step 0.5 -- Input Validation
+
+If `$ARGUMENTS` is empty AND there is no conversation context about what to review (no prior diff discussion, no files mentioned), print:
+
+> Usage: `/senior-review [--quick] [#PR_NUMBER | PR_URL]`
+>
+> Options:
+> - `--quick` -- Single-pass review (faster, same quality bar)
+> - `#123` or PR URL -- Review a specific pull request
+> - No arguments -- Prompted to select diff source
+
+**Stop here.**
+
+If `$ARGUMENTS` is empty but conversation context exists (e.g., user was just discussing a diff), proceed -- use the contextual diff.
+
+---
+
+## Step 1 -- Argument Parsing
+
+Parse `$ARGUMENTS`:
+
+- Contains `--quick` --> set mode to `quick`, remove flag from remaining arguments
+- Contains `#NNN` (hash + digits) --> set source to `pr`, extract PR number
+- Contains a URL matching a PR/MR pattern (github.com/.../pull/NNN, gitlab.com/.../-/merge_requests/NNN) --> set source to `pr`, extract URL
+- Otherwise --> source is unset (will prompt in Step 2)
+
+---
+
+## Step 2 -- Diff Source Selection
+
+If source was set from Step 1 (PR number or URL), skip to Step 3.
+
+Otherwise, use `AskUserQuestion`:
+
+> What would you like me to review?
+
+Buttons:
+- **"Uncommitted changes"** --> source = `uncommitted`
+- **"Branch diff (vs main/master)"** --> source = `branch`
+- **"Pull Request"** --> source = `pr` (will prompt for PR number)
+
+If user selects "Pull Request" and no PR number was provided, ask:
+> Enter the PR number or URL:
+
+---
+
+## Step 3 -- Diff Gathering
+
+Gather the diff based on selected source:
+
+**Uncommitted changes:**
+```
+!`git diff 2>/dev/null || echo "NO_DIFF"`
+```
+```
+!`git diff --staged 2>/dev/null || echo "NO_DIFF"`
+```
+
+Combine both outputs. If both are empty, print:
+> No uncommitted changes found.
+**Stop here.**
+
+**Branch diff:**
+Determine the base branch:
+```
+!`git rev-parse --verify main 2>/dev/null || echo "NO_MAIN"`
+```
+
+Use `main` if it exists, otherwise `master`. Then gather:
+```
+!`git diff main...HEAD 2>/dev/null || echo "NO_DIFF"`
+```
+
+If empty, print:
+> No changes found between current branch and base branch.
+**Stop here.**
+
+**Pull Request:**
+Use the `gh` CLI to fetch the PR diff:
+```
+!`gh pr diff {pr_number_or_url} 2>&1`
+```
+
+If `gh` is not available or the command fails, print:
+> Could not fetch PR diff. Ensure `gh` CLI is installed and authenticated.
+**Stop here.**
+
+Also gather the changed file list:
+```
+!`git diff --name-only main...HEAD 2>/dev/null || echo "NO_FILES"`
+```
+
+(For PR source, use `gh pr diff --name-only` if available, otherwise parse the diff headers.)
+
+---
+
+## Step 4 -- Language Detection
+
+Scan changed file extensions from the file list gathered in Step 3.
+
+| Extensions | Primary Language |
+|---|---|
+| `.swift` | Swift/iOS |
+| `.dart` | Flutter/Dart |
+| `.ts`, `.tsx` | TypeScript/React |
+| `.py` | Python |
+| `.kt` | Kotlin/Android |
+| `.js`, `.jsx` | JavaScript/React |
+| `.go` | Go |
+| `.rs` | Rust |
+
+If multiple languages detected, note all of them. The agent handles mixed diffs gracefully.
+
+If no recognized extensions, set language to `unknown`.
+
+---
+
+## Step 5 -- Context7 Lookup (Full Mode Only)
+
+If mode is `quick`, skip this step entirely.
+
+For the detected primary language/framework, query context7 MCP for current conventions:
+
+- **Swift/iOS:** Query for SwiftUI or UIKit conventions based on imports in the diff
+- **Flutter/Dart:** Query for Flutter widget patterns and Dart idioms
+- **TypeScript/React:** Query for React hooks rules and TypeScript strict mode patterns
+- **Other languages:** Query for the framework detected from imports
+
+Limit to one query for the primary language. Do not query for every language in a mixed diff.
+
+If context7 is unavailable or returns no results, proceed without it -- the agent has built-in criteria.
+
+---
+
+## Step 6 -- Agent Dispatch
+
+Dispatch `quiver:senior-reviewer` with the following context (in this order):
+
+1. **Full diff** from Step 3.
+2. **Changed file list** with detected language(s) from Step 4.
+3. **Mode:** `full` or `quick`.
+4. **Context7 results** (if available from Step 5, omit if quick mode or unavailable).
+5. **Scope reminder:** "Your findings MUST be scoped to code CHANGED in this diff. Reading surrounding code for context is expected; flagging pre-existing issues is not."
+6. **Citation accuracy:** "Every file:line reference in your findings must be verified by reading the file. Do not cite line numbers from memory or inference -- use the Read tool to confirm the content at the cited line before including it in a finding."
+
+Do NOT pass pipeline context. This is standalone mode -- Phase 5 (meta-review) must not activate.
+
+---
+
+## Step 7 -- Output
+
+Present the agent's findings in the terminal.
+
+After presenting findings, use `AskUserQuestion`:
+
+> Review complete. What would you like to do?
+
+Buttons:
+- **"Save report"** --> Write to `.claude/reports/senior-review-{timestamp}.md` (use `date '+%Y-%m-%d_%H-%M-%S'` format). Confirm with: `> Report saved to {path}`
+- **"Done"** --> Stop.
+
+---
+
+## Test Plan
+
+**Trigger:** `/senior-review` (and `/quiver:senior-review`)
+
+**Setup:**
+- Current directory is a git repo with changes (uncommitted or on a branch).
+- `gh` CLI available for PR mode testing.
+
+**Expected behavior:**
+1. Shell blocks gather git context without errors.
+2. `--quick` flag is parsed and sets mode before diff gathering.
+3. `#NNN` argument triggers PR mode directly without source selection prompt.
+4. Empty arguments with no context prints usage and stops.
+5. Diff source selection offers three buttons via AskUserQuestion.
+6. Language detection maps file extensions correctly.
+7. Context7 lookup runs in full mode, skipped in quick mode.
+8. Agent dispatch includes all required context items in order.
+9. Pipeline context is never passed in standalone mode (Phase 5 stays inactive).
+10. Save report option writes with correct timestamp filename format.
+
+**Verification checklist:**
+- [ ] Slash menu shows `/senior-review`.
+- [ ] `--quick` mode skips context7 lookup and runs single-pass.
+- [ ] PR mode works with `#123` syntax and full URL syntax.
+- [ ] No shell logic in `!` blocks (no `$()`, no `if/else`, no variable assignment).
+- [ ] All shell blocks exit 0 even when targets do not exist.
+- [ ] AskUserQuestion used for diff source selection and post-review action.
+- [ ] Agent dispatch does NOT include pipeline context.
+- [ ] Report save path uses correct timestamp format.
+
+**Known gotchas:**
+- `gh pr diff` requires authentication. If `gh` fails, the skill stops with a clear message rather than proceeding with an empty diff.
+- Context7 MCP may be unavailable in some environments. The skill degrades gracefully -- the agent has built-in per-language criteria.
+- The `--quick` flag must be stripped from arguments before PR number parsing to avoid misinterpretation.

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -313,7 +313,7 @@ If Phase 1 identified this as a review-fix plan and the review report was succes
      Status: COMPLETE -- ready to ship
      ```
 
-<!-- SYNC: This verification parses the report format defined in skills/review/SKILL.md:362 (Synthesized report structure section). If the report structure changes, update the parsing logic here. New sections (What's Working Well, Recommended Fix Order) are additive and do not affect this parsing. -->
+<!-- SYNC: This verification parses the report format defined in skills/review/SKILL.md:367 (Synthesized report structure section). If the report structure changes, update the parsing logic here. New sections (What's Working Well, Recommended Fix Order, Senior Assessment) are additive and do not affect this parsing. -->
 
 #### 4d -- Optional: Agent-assisted review
 


### PR DESCRIPTION
## Summary

- **New agent:** `senior-reviewer` -- language-aware senior developer review that evaluates code through a pragmatic team lead lens across 4 phased dimensions (structure, quality, risk, conventions) with meta-review of other agents' findings
- **New skill:** `/senior-review` -- standalone invocation with `--quick` (single-pass) and `#PR` (pull request) argument support
- **Pipeline integration:** Step 3.75 in `/review` pipeline, runs after report-checker (Step 3.5) and before save (Step 4). Performs independent code review (Phase 0-4) then evaluates other agents' findings (Phase 5) with PROMOTE/ADD actions on top of REMOVE/DOWNGRADE/REWRITE

## Changes

| File | Change |
|------|--------|
| `agents/review/senior-reviewer.md` | New agent with 5 evaluation phases, per-language criteria table (Swift/Dart/TypeScript), RA1-RA8 discipline rules |
| `skills/senior-review/SKILL.md` | New standalone skill with argument parsing, diff source selection, context7 lookup, agent dispatch |
| `skills/review/SKILL.md` | Step 2 exclusion + Step 3.75 insertion + Senior Assessment section in report template + SYNC comment update |
| `.claude-plugin/plugin.json` | Agent registration |
| `README.md` | Component counts (18 agents, 19 skills) + new entries in Skills and Agents tables |

## Test plan

- [x] `/senior-review` standalone invocation works (prompts for diff source)
- [x] Pipeline Step 3.75 triggers after report-checker completes
- [x] Senior-reviewer performs independent code review (Phase 0-4) + meta-review (Phase 5) in pipeline
- [x] RA2 canonical text verified byte-identical across all 9 agents (shasum)
- [ ] `/senior-review --quick` runs single-pass mode
- [ ] `/senior-review #NNN` reviews a specific PR