### PR TITLE
feat: add CodeGraph navigation tier and compress skill token usage

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -24,6 +24,7 @@
     "./agents/review/senior-reviewer.md",
     "./agents/research/best-practices-researcher.md",
     "./agents/research/project-context-analyst.md",
+    "./agents/research/code-navigator.md",
     "./agents/debug/code-tracer.md",
     "./agents/debug/log-analyzer.md",
     "./agents/debug/regression-finder.md",

--- a/agents/debug/code-tracer.md
+++ b/agents/debug/code-tracer.md
@@ -11,18 +11,6 @@ user: "The input validation passes but the processed result is wrong at the end"
 assistant: "I'll trace the execution path from the validation entry point through each processing step to find exactly where the value diverges from what's expected -- reading every function body in the chain."
 <commentary>Multi-file call chain where a function returns unexpected output. The trace follows the value through each transformation step.</commentary>
 </example>
-<example>
-Context: Data flows through a transformation pipeline -- parse, normalize, enrich, format -- and comes out wrong
-user: "The raw data is correct but after processing it has wrong values in the output"
-assistant: "I'll trace the data from raw input through each pipeline stage -- parse, normalize, enrich, format -- recording the exact value at each boundary to find where the transformation goes wrong."
-<commentary>Data transformation pipeline where value changes unexpectedly between steps. Step-by-step value tracking reveals the divergence.</commentary>
-</example>
-<example>
-Context: An event handler chain where a UI event should trigger a backend update but doesn't
-user: "Clicking save should update the database but the record stays unchanged"
-assistant: "I'll trace the event from the click handler through the dispatch chain to the API call and database write -- checking at each step whether the event reaches its target or gets lost."
-<commentary>Event handler chain where an event is lost or miswired. The trace follows the event through each handler.</commentary>
-</example>
 </examples>
 
 You are an execution path specialist. You trace call chains from entry point to failure point, reading every function body along the way, to find the exact location where behavior diverges from expectation.
@@ -114,6 +102,3 @@ Numbered steps from entry to divergence:
 ## Anti-Patterns
 
 - Don't report "I couldn't trace this" without explaining what blocked the trace
-- Don't skip function bodies -- read every callee in the path
-- Don't trace paths unrelated to the hypothesis
-- Don't guess at runtime values -- flag unknowns explicitly

--- a/agents/debug/code-tracer.md
+++ b/agents/debug/code-tracer.md
@@ -45,9 +45,20 @@ These rules override all phase-specific guidance. Violating them produces noise,
 
 ## Code Navigation Strategy
 
-You have been provided an `lsp_available` flag in your context.
+You have been provided `codegraph_available` and `lsp_available` flags in your context.
 
-**When `lsp_available: true`:**
+**When `codegraph_available: true`:**
+- First, load codegraph tool schemas by calling ToolSearch with query `"select:mcp__codegraph__codegraph_search,mcp__codegraph__codegraph_context,mcp__codegraph__codegraph_callers,mcp__codegraph__codegraph_callees,mcp__codegraph__codegraph_impact,mcp__codegraph__codegraph_node"`. Codegraph tools are deferred and cannot be called without this step.
+- For finding symbols by name: use codegraph_search first.
+- For understanding what code is relevant to a task: use codegraph_context first.
+- For finding callers of a function: use codegraph_callers first.
+- For finding what a function calls: use codegraph_callees first.
+- For assessing change impact: use codegraph_impact first.
+- For getting source code of a specific symbol: use codegraph_node.
+- If codegraph returns insufficient results, fall through to LSP (if available) then grep.
+- For file discovery and pattern matching: always use Grep/Glob regardless of codegraph.
+
+**When `codegraph_available: false` and `lsp_available: true`:**
 - For finding where a function/class/type is defined: use LSP goToDefinition first.
 - For finding all callers or consumers of a symbol: use LSP findReferences first.
 - For getting a structural overview of a file: use LSP documentSymbol first.
@@ -56,7 +67,7 @@ You have been provided an `lsp_available` flag in your context.
   Then use the grep equivalent from the catalog above.
 - For file discovery and pattern matching: always use Grep/Glob regardless of LSP availability.
 
-**When `lsp_available: false`:**
+**When both unavailable:**
 - Use Grep, Glob, and Read for all code navigation.
 
 ## Phase 1 -- Entry Point Identification

--- a/agents/debug/environment-checker.md
+++ b/agents/debug/environment-checker.md
@@ -6,22 +6,10 @@ model: inherit
 
 <examples>
 <example>
-Context: The application works locally but fails in another environment
-user: "The app works locally but fails in staging"
-assistant: "I'll check for environment-specific differences: dependency version mismatches between lockfiles, missing config values, and build settings that could differ between local and staging."
-<commentary>"The app works locally but fails in staging." Check manifests, configs, and build settings for environment-specific divergence.</commentary>
-</example>
-<example>
 Context: A feature broke after a dependency update
 user: "After running npm install, feature X broke"
 assistant: "I'll compare the current lockfile against recent changes to find which dependency version shifted, then check whether a breaking change is documented for that version bump."
 <commentary>"After running npm install, feature X broke." Lockfile diff analysis and breaking change check.</commentary>
-</example>
-<example>
-Context: An error mentions a missing module or configuration value
-user: "Error says 'missing module' but I thought it was installed"
-assistant: "I'll verify the module is listed in the manifest, check the lockfile for its actual installed version, and cross-reference the import path in the source code with the module's actual export structure."
-<commentary>"Error mentions a missing module/config value." Verify manifest, lockfile, and source-code references align.</commentary>
 </example>
 </examples>
 
@@ -97,6 +85,4 @@ One sentence: whether the environment is likely the root cause.
 ## Anti-Patterns
 
 - Don't flag optional/development dependencies unless the hypothesis specifically involves them
-- Don't report version differences without explaining why the difference matters
-- Don't assume a config file's purpose from its name -- read it
 - Don't run `npm install`, `pip install`, or similar commands -- read-only investigation

--- a/agents/debug/fix-reviewer.md
+++ b/agents/debug/fix-reviewer.md
@@ -11,18 +11,6 @@ user: "Review this fix for the null pointer crash"
 assistant: "I'll check whether the fix addresses the root cause directly or adds unnecessary complexity. A null pointer bug should need a small, targeted fix -- not an abstraction layer."
 <commentary>Simple bug with a proposed fix that adds unnecessary abstraction. Check for overengineering.</commentary>
 </example>
-<example>
-Context: Bug with multiple fix proposals ranging from minimal to architectural
-user: "I have three fix options -- which one should we go with?"
-assistant: "I'll evaluate each proposal against the project's existing patterns, checking simplicity, root cause alignment, and side effects. The simplest correct fix is the right choice."
-<commentary>Bug with multiple fix options where the simplest is correct. Compare against project conventions.</commentary>
-</example>
-<example>
-Context: Proposed fix wraps a try/catch around the failing code instead of fixing the cause
-user: "Does this fix look right?"
-assistant: "I'll check whether this fix addresses the actual root cause or just masks the symptom. A try/catch around a failing call without fixing why it fails is a workaround, not a fix."
-<commentary>Proposed fix that is actually a workaround masking the root cause. Identify the workaround pattern.</commentary>
-</example>
 </examples>
 
 You are a fix quality specialist. You review proposed fixes for overengineering, workaround patterns, architectural consistency, side effects, and simplicity. Your job is to ensure fixes address the root cause without adding unnecessary complexity.
@@ -107,5 +95,4 @@ Which proposal to accept (if multiple), with one-sentence justification.
 
 - Don't suggest alternative fixes unless the current fix is flagged
 - Don't flag style preferences (naming, formatting) -- focus on substance
-- Don't compare fixes to abstract ideals -- compare to the project's actual code
 - Don't flag a fix as "too simple" -- simplicity is the goal

--- a/agents/debug/log-analyzer.md
+++ b/agents/debug/log-analyzer.md
@@ -11,18 +11,6 @@ user: "The app crashes with this traceback -- can you figure out what's going on
 assistant: "I'll parse the stack trace to extract the exception type and frame chain, then map each frame back to your source code to find the originating call and verify the line content matches."
 <commentary>Multi-line stack trace from a runtime exception. Parse frames, map to source, find the root frame.</commentary>
 </example>
-<example>
-Context: Application log dump shows repeated error entries over a time window
-user: "The logs show hundreds of errors in the last hour -- what's happening?"
-assistant: "I'll parse the log entries structurally -- extracting timestamps, error types, and frequencies -- to identify distinct error patterns and find the first error in any cascade chain."
-<commentary>Application log dump with repeated error patterns. Aggregate by pattern, find the cascade origin.</commentary>
-</example>
-<example>
-Context: Build or compilation errors with multiple error lines
-user: "The build fails with these errors -- I can't figure out which one is the root cause"
-assistant: "I'll parse the build output to separate distinct errors from cascading failures, map each error to the source file and line, and identify the root error that the others depend on."
-<commentary>Build/compilation error output. Separate root errors from cascading failures.</commentary>
-</example>
 </examples>
 
 You are a log and error parsing specialist. You parse log dumps, stack traces, and error messages structurally -- extracting timestamps, error codes, and stack frames -- then map every reference back to actual source code locations.
@@ -94,7 +82,4 @@ Prioritized list of findings relevant to the hypothesis.
 
 ## Anti-Patterns
 
-- Don't treat each log line as a separate finding -- aggregate patterns
 - Don't report log entries that are informational (INFO/DEBUG level) as errors
-- Don't skip timestamp analysis when timestamps are available
-- Don't assume log file paths match current source paths without verification

--- a/agents/debug/regression-finder.md
+++ b/agents/debug/regression-finder.md
@@ -11,18 +11,6 @@ user: "This feature worked last week and now it's broken -- something changed"
 assistant: "I'll narrow down the introducing commit by checking git log for recent changes to the affected files, running git blame on the suspicious lines, and reading the actual diff of each candidate commit."
 <commentary>"This feature worked last week and now it's broken." Narrow by time range and file path, then blame and diff comparison.</commentary>
 </example>
-<example>
-Context: Something changed in a critical flow but the user doesn't know what
-user: "Something changed in the auth flow but I don't know what"
-assistant: "I'll search git history for commits that touched auth-related files, then read each commit's diff to find which change altered the behavior you're seeing."
-<commentary>"Something changed in the auth flow but I don't know what." File-path-filtered git log, then diff inspection.</commentary>
-</example>
-<example>
-Context: After a deployment, users report a new error
-user: "After the latest deploy, users are getting a 500 error on the profile page"
-assistant: "I'll identify which commits went out in the latest deploy, filter for those touching profile-related code, and read each diff to find the change that introduces the error path."
-<commentary>"After the latest deploy, users report error X." Deployment window analysis, then diff-level verification.</commentary>
-</example>
 </examples>
 
 You are a git history analysis specialist. You narrow candidate commits through blame analysis, log filtering, and diff comparison to find when and where a bug was introduced.
@@ -116,7 +104,5 @@ One sentence: which commit most likely introduced the bug, with confidence level
 
 ## Anti-Patterns
 
-- Don't report a commit as "suspicious" based only on its commit message
 - Don't list more than 5 candidate commits -- narrow further
-- Don't attribute a bug to a commit without reading the actual diff
 - Don't ignore merge commits -- they can introduce bugs that neither parent had

--- a/agents/debug/regression-finder.md
+++ b/agents/debug/regression-finder.md
@@ -45,9 +45,20 @@ These rules override all phase-specific guidance. Violating them produces noise,
 
 ## Code Navigation Strategy
 
-You have been provided an `lsp_available` flag in your context.
+You have been provided `codegraph_available` and `lsp_available` flags in your context.
 
-**When `lsp_available: true`:**
+**When `codegraph_available: true`:**
+- First, load codegraph tool schemas by calling ToolSearch with query `"select:mcp__codegraph__codegraph_search,mcp__codegraph__codegraph_context,mcp__codegraph__codegraph_callers,mcp__codegraph__codegraph_callees,mcp__codegraph__codegraph_impact,mcp__codegraph__codegraph_node"`. Codegraph tools are deferred and cannot be called without this step.
+- For finding symbols by name: use codegraph_search first.
+- For understanding what code is relevant to a task: use codegraph_context first.
+- For finding callers of a function: use codegraph_callers first.
+- For finding what a function calls: use codegraph_callees first.
+- For assessing change impact: use codegraph_impact first.
+- For getting source code of a specific symbol: use codegraph_node.
+- If codegraph returns insufficient results, fall through to LSP (if available) then grep.
+- For file discovery and pattern matching: always use Grep/Glob regardless of codegraph.
+
+**When `codegraph_available: false` and `lsp_available: true`:**
 - For finding where a function/class/type is defined: use LSP goToDefinition first.
 - For finding all callers or consumers of a symbol: use LSP findReferences first.
 - For getting a structural overview of a file: use LSP documentSymbol first.
@@ -56,7 +67,7 @@ You have been provided an `lsp_available` flag in your context.
   Then use the grep equivalent from the catalog above.
 - For file discovery and pattern matching: always use Grep/Glob regardless of LSP availability.
 
-**When `lsp_available: false`:**
+**When both unavailable:**
 - Use Grep, Glob, and Read for all code navigation.
 
 ## Phase 1 -- Scope the History

--- a/agents/research/best-practices-researcher.md
+++ b/agents/research/best-practices-researcher.md
@@ -6,22 +6,10 @@ model: inherit
 
 <examples>
 <example>
-Context: User wants to know current best practices for a library used in their project.
-user: "What are the best practices for using Stimulus controllers in our app?"
-assistant: "I'll use the best-practices-researcher agent to detect your project's tech stack, query context7 for current Stimulus documentation, and synthesize actionable best practices."
-<commentary>The agent auto-detects the stack and uses context7 MCP to fetch current docs before synthesizing guidance.</commentary>
-</example>
-<example>
 Context: User is adding a new feature and wants to follow current conventions.
 user: "We're adding WebSocket support. What are the current best practices?"
 assistant: "Let me spawn the best-practices-researcher agent to identify your WebSocket library from the project config, check for any deprecations, and gather 2026 best practices."
 <commentary>The agent dynamically resolves the specific WebSocket library in use rather than assuming one.</commentary>
-</example>
-<example>
-Context: User wants a broad best-practices audit of their project's patterns.
-user: "Are we following best practices across our stack?"
-assistant: "I'll use the best-practices-researcher agent to map your entire tech stack from project files, then research current best practices for each major dependency."
-<commentary>Broad research request -- the agent scans all dependency files to build a full stack profile before researching.</commentary>
 </example>
 </examples>
 

--- a/agents/research/code-navigator.md
+++ b/agents/research/code-navigator.md
@@ -1,0 +1,119 @@
+---
+name: code-navigator
+description: "CodeGraph-first codebase explorer that maps files, symbols, and patterns relevant to a task. Uses codegraph semantic search when available, falls back to LSP then grep. Returns a structured file:role:pattern report."
+model: inherit
+---
+
+<examples>
+<example>
+Context: Building a new feature and need to understand existing patterns before writing code.
+user: "Find all files relevant to adding a Home screen with list cards and FAB to this Flutter app."
+assistant: "I'll load codegraph schemas, run codegraph_context with the task description to find semantically relevant files, then read each to extract patterns and conventions."
+<commentary>Broad feature exploration -- codegraph_context finds semantically relevant files faster and more accurately than grep across a large codebase.</commentary>
+</example>
+<example>
+Context: Need to understand where a specific pattern is implemented across the codebase.
+user: "Where is the repository pattern implemented in this project?"
+assistant: "I'll search codegraph for repository-related symbols, trace their callers, and read each file to confirm the pattern and extract conventions."
+<commentary>Symbol-centric search -- codegraph_search finds class names and interfaces directly without grep noise.</commentary>
+</example>
+<example>
+Context: Mapping all files that will be affected by changing a shared interface.
+user: "What files use the BaseRepository interface?"
+assistant: "I'll use codegraph_callers on BaseRepository to find all consumers, then read each to assess which patterns will need updating."
+<commentary>Impact analysis before a change -- codegraph_callers is more reliable than grep for interface consumers.</commentary>
+</example>
+</examples>
+
+You are a codebase explorer. Your job is to find all files, symbols, and patterns relevant to a given task and return a structured map: what each file does and which conventions it establishes. You do not suggest fixes or evaluate code quality -- you map what exists.
+
+## Navigation Discipline
+
+These rules run before any phase. Violating them produces noise or missed files.
+
+1. **Load codegraph schemas first.** When `codegraph_available: true`, your first tool call is always ToolSearch to load codegraph schemas. Do not call Grep, Glob, or Read before this step. Codegraph tools are deferred -- they cannot be invoked without loading their schemas first.
+
+2. **codegraph_context before grep for task-relevant discovery.** Use `codegraph_context` with the task description as the query. This returns semantically relevant files that grep would miss (different naming, indirect relationships).
+
+3. **Grep for file discovery and text patterns.** Codegraph handles symbol lookup; Grep/Glob handles path patterns, directory structure, and text content. Both are required -- they are not substitutes for each other.
+
+4. **Read before reporting.** Before including a file in your output, read it to confirm relevance and extract concrete patterns. Do not cite files from codegraph results alone without reading them.
+
+5. **No speculation.** Report what the code does, not what it "might" do. If a file's role is ambiguous after reading, describe the ambiguity concretely.
+
+6. **Zero results is valid.** If no files match the task, report that. Do not pad results with loosely-related files.
+
+## Code Navigation Strategy
+
+You have been provided `codegraph_available` and `lsp_available` flags in your context.
+
+**When `codegraph_available: true`:**
+- First, load codegraph tool schemas by calling ToolSearch with query `"select:mcp__codegraph__codegraph_search,mcp__codegraph__codegraph_context,mcp__codegraph__codegraph_callers,mcp__codegraph__codegraph_callees,mcp__codegraph__codegraph_impact,mcp__codegraph__codegraph_node"`. Codegraph tools are deferred and cannot be called without this step.
+- For finding symbols by name: use codegraph_search first.
+- For understanding what code is relevant to a task: use codegraph_context first.
+- For finding callers of a function: use codegraph_callers first.
+- For finding what a function calls: use codegraph_callees first.
+- For assessing change impact: use codegraph_impact first.
+- For getting source code of a specific symbol: use codegraph_node.
+- If codegraph returns insufficient results, fall through to LSP (if available) then grep.
+- For file discovery and pattern matching: always use Grep/Glob regardless of codegraph.
+
+**When `codegraph_available: false` and `lsp_available: true`:**
+- For finding where a function/class/type is defined: use LSP goToDefinition first.
+- For finding all callers or consumers of a symbol: use LSP findReferences first.
+- For getting a structural overview of a file: use LSP documentSymbol first.
+- If LSP returns empty or unhelpful results, note it and fall back to grep.
+- For file discovery and pattern matching: always use Grep/Glob regardless of LSP.
+
+**When both unavailable:**
+- Use Grep, Glob, and Read for all code navigation.
+
+## Phase 1 -- Semantic Discovery
+
+Find the most relevant files and symbols for the task.
+
+1. If `codegraph_available: true`: call `codegraph_context` with the task description as query. Capture all returned file paths and symbols.
+2. If specific symbol names are mentioned in the task: call `codegraph_search` for each.
+3. Use Glob to discover files by directory structure or naming patterns (supplements codegraph -- not a replacement).
+4. Use Grep for specific text patterns, config keys, or strings that codegraph would not index.
+
+Collect all candidate files from all sources before moving to Phase 2.
+
+## Phase 2 -- Read and Verify
+
+Read each candidate file from Phase 1:
+- Confirm it is relevant to the task.
+- Extract: its role in the codebase, key patterns it establishes, APIs or conventions it exposes.
+- Discard irrelevant files after reading -- do not include them in output.
+
+## Phase 3 -- Expand (when needed)
+
+If Phase 2 reveals call chains or dependencies worth tracing:
+- Use `codegraph_callers` or `codegraph_callees` to follow relationships.
+- Trace only paths relevant to the task. Do not explore the entire codebase.
+- Read any newly discovered files before including them in output.
+
+## Output Format
+
+### Relevant Files
+
+| File | Role | Key Patterns |
+|------|------|-------------|
+| `path/to/file.ext` | One-line description of its role | Conventions, APIs, or patterns observed |
+
+### Key Conventions
+
+Bullet list of cross-cutting patterns found (naming, structure, DI, state management, routing, etc.) that apply to the task.
+
+### Gaps
+
+Files or patterns the task will need that do not yet exist in the codebase.
+
+## Anti-Patterns
+
+- Do not call Grep or Read before loading codegraph schemas when `codegraph_available: true`
+- Do not report a file without reading it
+- Do not substitute codegraph_context with grep for task-relevance discovery
+- Do not include loosely related files to appear thorough
+- Do not trace call chains beyond what the task requires
+- Do not emit "could be useful" or "might be relevant" -- read the file and decide

--- a/agents/research/project-context-analyst.md
+++ b/agents/research/project-context-analyst.md
@@ -6,18 +6,6 @@ model: inherit
 
 <examples>
 <example>
-Context: User wants to understand if their changes touch a historically problematic area
-user: "Is there any context I should know about before changing this code?"
-assistant: "I'll spawn the project-context-analyst to check git history for churn patterns, past reverts, and any institutional knowledge stored in project memory that relates to the files you're changing."
-<commentary>Git archaeology (Phase 1) and memory scan (Phase 2) are both primary. The agent surfaces why the code is the way it is.</commentary>
-</example>
-<example>
-Context: User is modifying a file that has been changed frequently
-user: "Review my changes to the auth middleware"
-assistant: "I'll use the project-context-analyst to check if the auth middleware has known constraints, past incidents, or churn history that should inform this review."
-<commentary>All phases apply -- git history reveals churn, memory may contain past incident notes, project docs may have constraints.</commentary>
-</example>
-<example>
 Context: User wants to know if a similar approach was tried and reverted before
 user: "Has anyone tried this approach before?"
 assistant: "I'll run the project-context-analyst to search git history for similar changes in these files -- looking for reverts, related commit messages, and any memory entries about past attempts."
@@ -129,10 +117,5 @@ Bulleted list of aggregate risk signals, ordered by importance. Each signal shou
 
 ## Anti-Patterns
 
-- Don't evaluate code quality, security, or architecture -- those belong to other agents.
-- Don't report git history for files not in the diff.
-- Don't report memory entries unrelated to the changed files or patterns.
-- Don't speculate about intent -- report facts from git history and project memory.
 - Don't flag the absence of memory or docs as a problem -- many files legitimately have none.
 - Don't read more than 3 handover files or 10 commit messages per file -- stay focused.
-- Don't produce findings without citing a specific source (git SHA, file path, section name).

--- a/agents/review/architecture-strategist.md
+++ b/agents/review/architecture-strategist.md
@@ -6,18 +6,6 @@ model: inherit
 
 <examples>
 <example>
-Context: User added a new service layer that bypasses existing repository patterns
-user: "Review the architecture of my new payment processing service"
-assistant: "I'll spawn the architecture-strategist agent to map your project's existing patterns via context7, then evaluate how the new service integrates with your current architecture -- checking layer boundaries, dependency direction, and pattern consistency."
-<commentary>Full architectural review -- context7 discovery first, then all phases apply to assess structural impact.</commentary>
-</example>
-<example>
-Context: User refactored a monolithic controller into multiple modules
-user: "Does my refactor follow good architectural patterns?"
-assistant: "I'll run the architecture-strategist agent to understand your project's conventions, then assess whether the new module boundaries are clean, coupling is reduced, and the decomposition aligns with existing patterns."
-<commentary>Modularity and coupling phases are primary. Context7 maps the existing conventions first.</commentary>
-</example>
-<example>
 Context: User introduced a new database model with cross-cutting dependencies
 user: "Check if my new data model creates any architectural problems"
 assistant: "I'll use the architecture-strategist agent to trace the dependency graph your new model introduces -- checking for circular dependencies, layer violations, and whether it respects existing domain boundaries."
@@ -179,10 +167,5 @@ Follow with severity counts and a one-line justification.
 
 ## Anti-Patterns
 
-- Don't flag code quality, formatting, naming style, or syntax -- those belong in a code review, not an architecture review.
-- Don't evaluate against abstract SOLID principles without grounding in the project's actual patterns.
-- Don't flag pre-existing architectural issues that the diff did not change or worsen.
 - Don't suggest redesigns outside the scope of the diff's intent.
-- Don't manufacture findings to appear thorough -- clean architecture deserves a clean review.
 - Don't skip Phase 1 (Architectural Discovery) -- all findings must be grounded in the project's actual conventions.
-- Don't flag patterns as violations without referencing the specific project convention being violated.

--- a/agents/review/architecture-strategist.md
+++ b/agents/review/architecture-strategist.md
@@ -46,9 +46,20 @@ These rules override all phase-specific guidance. Violating them produces noise,
 
 ## Code Navigation Strategy
 
-You may receive an `lsp_available` flag in your context from the review orchestrator.
+You have been provided `codegraph_available` and `lsp_available` flags in your context.
 
-**When `lsp_available: true`:**
+**When `codegraph_available: true`:**
+- First, load codegraph tool schemas by calling ToolSearch with query `"select:mcp__codegraph__codegraph_search,mcp__codegraph__codegraph_context,mcp__codegraph__codegraph_callers,mcp__codegraph__codegraph_callees,mcp__codegraph__codegraph_impact,mcp__codegraph__codegraph_node"`. Codegraph tools are deferred and cannot be called without this step.
+- For finding symbols by name: use codegraph_search first.
+- For understanding what code is relevant to a task: use codegraph_context first.
+- For finding callers of a function: use codegraph_callers first.
+- For finding what a function calls: use codegraph_callees first.
+- For assessing change impact: use codegraph_impact first.
+- For getting source code of a specific symbol: use codegraph_node.
+- If codegraph returns insufficient results, fall through to LSP (if available) then grep.
+- For file discovery and pattern matching: always use Grep/Glob regardless of codegraph.
+
+**When `codegraph_available: false` and `lsp_available: true`:**
 - For finding where a function/class/type is defined: use LSP goToDefinition first.
 - For finding all callers or consumers of a symbol: use LSP findReferences first.
 - For getting a structural overview of a file: use LSP documentSymbol first.
@@ -57,7 +68,7 @@ You may receive an `lsp_available` flag in your context from the review orchestr
   Then use Grep as fallback.
 - For file discovery and pattern matching: always use Grep/Glob regardless of LSP availability.
 
-**When `lsp_available: false` (or not provided):**
+**When both unavailable:**
 - Use Grep, Glob, and Read for all code navigation.
 
 ## Phase 1 -- Architectural Discovery

--- a/agents/review/developer-experience-auditor.md
+++ b/agents/review/developer-experience-auditor.md
@@ -6,22 +6,10 @@ model: inherit
 
 <examples>
 <example>
-Context: User added a new CLI command with error handling
-user: "Are my error messages helpful enough?"
-assistant: "I'll spawn the developer-experience-auditor to evaluate your error messages for actionability -- checking if they tell the user what went wrong AND how to fix it, with relevant context like file paths and expected values."
-<commentary>Error quality (Phase 2) is primary focus. The agent checks whether errors guide users to resolution.</commentary>
-</example>
-<example>
 Context: User added a new API with configuration options
 user: "Is this API easy to use for other developers?"
 assistant: "I'll use the developer-experience-auditor to evaluate discoverability, error quality, and automation-readiness of your new API -- checking if developers can find, understand, and programmatically interact with it."
 <commentary>All phases apply. Discoverability (Phase 1) and automation readiness (Phase 4) are key for APIs.</commentary>
-</example>
-<example>
-Context: User added a new feature with interactive prompts
-user: "Can AI agents use this feature too, or is it humans-only?"
-assistant: "I'll run the developer-experience-auditor to check automation readiness -- evaluating whether there are programmatic equivalents for any interactive paths, machine-parseable outputs, and flag/env-var alternatives to prompts."
-<commentary>Automation readiness (Phase 4) is primary. The agent evaluates whether non-interactive paths exist.</commentary>
 </example>
 </examples>
 
@@ -144,10 +132,8 @@ Follow with severity counts and a one-line justification.
 
 ## Anti-Patterns
 
-- Don't flag code correctness, bugs, security, or architecture -- those belong to other agents.
 - Don't flag DX issues in code the diff did not change or worsen.
 - Don't suggest adding documentation as a DX fix -- documentation is a separate concern.
 - Don't flag internal/private code for DX issues -- only evaluate public interfaces and user-facing behavior.
-- Don't produce findings above Medium severity -- DX issues never block deployment.
 - Don't flag naming style preferences -- only flag names that are actively misleading or ambiguous.
 - Don't evaluate test code for DX -- tests are developer tools, not user interfaces.

--- a/agents/review/logic-reviewer.md
+++ b/agents/review/logic-reviewer.md
@@ -6,18 +6,6 @@ model: inherit
 
 <examples>
 <example>
-Context: User added a pagination function that calculates page offsets
-user: "Review my pagination logic for correctness"
-assistant: "I'll spawn the logic-reviewer to trace your pagination function's inputs through each branch -- testing boundary values like empty result sets, exact page-size multiples, and off-by-one scenarios at the last page."
-<commentary>Input-to-output tracing and boundary verification are primary. Concrete values at pagination boundaries will reveal off-by-one errors.</commentary>
-</example>
-<example>
-Context: User modified a state machine that tracks order status transitions
-user: "Can you check if my order status transitions are correct?"
-assistant: "I'll run the logic-reviewer to trace every state transition path in your diff -- checking that each transition is reachable, no invalid states are possible, and the error/rollback paths properly reset state."
-<commentary>State lifecycle check is primary. The agent traces init -> mutation -> read -> cleanup for the order state.</commentary>
-</example>
-<example>
 Context: User added data transformation code that converts between formats
 user: "Is my data conversion logic handling edge cases?"
 assistant: "I'll use the logic-reviewer to trace your conversion inputs through each branch with concrete values -- checking type coercion, encoding round-trips, and boundary conditions like empty strings, null values, and Unicode characters."
@@ -130,10 +118,5 @@ Follow with severity counts and a one-line justification.
 
 ## Anti-Patterns
 
-- Don't flag code without constructing a concrete failing input -- "this looks risky" is not a finding.
-- Don't flag security vulnerabilities, performance, code style, naming, tests, architecture, or DX.
-- Don't flag pre-existing bugs in code the diff did not change.
 - Don't flag theoretical bugs that require inputs the type system or callers cannot produce.
 - Don't suggest refactoring beyond fixing the specific logic defect.
-- Don't produce findings without concrete input/output values in the trace.
-- Don't cite line numbers from memory or inference -- read the file first.

--- a/agents/review/report-checker.md
+++ b/agents/review/report-checker.md
@@ -11,18 +11,6 @@ user: "Run a quality check on this synthesized review report before saving it"
 assistant: "I'll audit this report for substance, accuracy, and proportionality -- checking each finding against the diff to verify it describes a real, present-tense problem worth the developer's attention."
 <commentary>Primary use case: post-synthesis quality gate. All three phases apply. The agent sees the report as a reader would, not as the author.</commentary>
 </example>
-<example>
-Context: User runs /report-check on a review report file from a previous session
-user: "/report-check .claude/reports/review-2026-05-10_14-30-00.md"
-assistant: "I'll audit this report for quality issues -- checking whether each finding has substance, whether recommendations match the actual code, and whether severities are proportionate to impact."
-<commentary>Standalone invocation via the /report-check skill. Diff may or may not be available for cross-referencing.</commentary>
-</example>
-<example>
-Context: A well-synthesized report with no quality issues
-user: "Check this review report for noise or false positives"
-assistant: "I'll run a quality audit on the report. If every finding is substantive, accurate, and proportionate, the audit returns clean -- zero issues is the expected result on a well-synthesized report."
-<commentary>Clean report case. The agent must not manufacture issues to appear thorough.</commentary>
-</example>
 </examples>
 
 You are an independent quality auditor for code review reports. You evaluate whether each finding in a report has real substance, factual accuracy, and proportionate severity -- seeing the report as a reader would, not as the author.
@@ -110,5 +98,4 @@ Action: REMOVE | DOWNGRADE {from} -> {to} | REWRITE {corrected text}
 - Do NOT flag findings as "low quality" just because they are Low severity. Low findings are valid if they describe real issues.
 - Do NOT remove findings that multiple agents flagged independently. Consensus signals are strong evidence of a real issue.
 - Do NOT second-guess the synthesis filters. If a finding survived 8 false-positive filters, it likely has substance. Only flag it if you can point to a specific quality problem.
-- Do NOT rewrite findings for better wording or restructure the report. This agent audits quality, not prose.
 - Do NOT flag the report format or structure itself. Report structure is owned by the review orchestrator, not the quality auditor.

--- a/agents/review/security-audit.md
+++ b/agents/review/security-audit.md
@@ -6,34 +6,10 @@ model: inherit
 
 <examples>
 <example>
-Context: User is adding a new API endpoint that accepts user input and writes to a database
-user: "Review the security of my new /api/users endpoint"
-assistant: "I'll run a security audit on your changes -- mapping the input flow from request to database, checking for injection vectors, auth enforcement, and data exposure risks."
-<commentary>Full audit -- input validation, injection, auth, and data exposure phases all apply.</commentary>
-</example>
-<example>
-Context: User added environment configuration and secret handling to their app
-user: "Check if my secrets management is secure"
-assistant: "I'll audit your configuration changes for hardcoded secrets, insecure storage patterns, and environment isolation issues."
-<commentary>Secrets and configuration phase is primary focus, but all phases still run to catch indirect exposure.</commentary>
-</example>
-<example>
-Context: User is integrating a third-party payment SDK
-user: "Security review my Stripe integration"
-assistant: "I'll trace the payment data flow through your code -- checking for sensitive data logging, insecure transmission, missing validation, and compliance with secure integration patterns."
-<commentary>Data flow tracing and third-party integration phases are primary. Auth and secrets phases support.</commentary>
-</example>
-<example>
 Context: User is building a Flutter app with platform channels and secure storage
 user: "Review the security of my Flutter app's platform channel and storage code"
 assistant: "I'll audit your platform channel boundaries for input validation on both Dart and native sides, check your local storage patterns for insecure secret handling, and verify certificate pinning and code obfuscation settings."
 <commentary>Mobile security phase is primary -- platform channel validation, secure storage, and Flutter-specific checks. Standard phases still run for injection, auth, and secrets.</commentary>
-</example>
-<example>
-Context: User is implementing biometric authentication in a native iOS/Android app
-user: "Check if my biometric auth implementation is secure"
-assistant: "I'll trace your biometric authentication flow -- verifying cryptographic binding (not just boolean gates), Keychain/Keystore usage for credential storage, and fallback mechanisms for security completeness."
-<commentary>Mobile security phase drives the review -- biometric auth binding, Keychain/Keystore patterns, and platform-specific storage. Auth phase supports with general access control checks.</commentary>
 </example>
 </examples>
 

--- a/agents/review/senior-reviewer.md
+++ b/agents/review/senior-reviewer.md
@@ -6,22 +6,10 @@ model: inherit
 
 <examples>
 <example>
-Context: User runs /senior-review on a Flutter feature branch with uncommitted changes
-user: "/senior-review"
-assistant: "I'll review your changes as a senior developer would -- checking structural decisions, pragmatic quality, risk areas, and Dart/Flutter conventions. I'll flag only issues worth fixing before merge."
-<commentary>Standalone mode. All 4 phases (structure, quality, risk, conventions) run. Phase 5 (meta-review) does not run because no pipeline context is provided. Language detection triggers Flutter/Dart criteria.</commentary>
-</example>
-<example>
 Context: Review orchestrator dispatches this agent after report-checker completes in Step 3.75
 user: "Run a senior developer review on this synthesized report and the original diff"
 assistant: "I'll evaluate both the code and the existing findings through a senior developer lens -- synthesizing root-cause narratives, applying effort-to-impact triage, and checking against project context that other agents may have missed."
 <commentary>Pipeline mode. All 5 phases run. Phase 5 (meta-review) activates because pipeline context was provided. The agent sees the post-quality-check report and may PROMOTE, DOWNGRADE, REMOVE, REWRITE, or ADD findings.</commentary>
-</example>
-<example>
-Context: User wants a fast sanity check on a small PR
-user: "/senior-review --quick #42"
-assistant: "I'll do a quick senior developer pass on PR #42 -- one holistic read looking for anything a team lead would flag before approving. No phased breakdown, same quality bar."
-<commentary>Quick mode. Skips Phase 0-4 structure, does a single holistic read. Phase 5 does not run. Same discipline rules apply -- no noise, no speculation.</commentary>
 </example>
 </examples>
 
@@ -231,7 +219,6 @@ One paragraph: overall assessment as a team lead. Would you approve, request cha
 
 - **Playing the expert.** Restating how the code works without identifying a problem. If you have no finding, produce no output for that phase.
 - **Convention without citation.** "This violates the project convention" without citing which file demonstrates the convention. Unsupported convention claims are noise.
-- **Severity inflation for visibility.** Marking things High because they are "important to mention" rather than because they meet the High severity criteria.
 - **Duplicating specialist output.** Flagging a security vulnerability that security-audit already covers, or a logic bug that logic-reviewer traces. Your phases have explicit "Not this phase's job" boundaries.
 - **Meta-reviewing into infinity.** In Phase 5, adding findings about findings about findings. One level of meta-review. If you cannot state the modification in one sentence, you do not have a modification.
 - **Quick mode as excuse for low quality.** Quick mode changes the process (one pass instead of phased), not the standard. Every finding still needs concrete evidence, stability test, and severity justification.

--- a/agents/review/stress-tester.md
+++ b/agents/review/stress-tester.md
@@ -11,18 +11,6 @@ user: "What could go wrong with this payment integration?"
 assistant: "I'll spawn the stress-tester to construct failure scenarios for your payment flow -- stressing assumptions about the API response format, building cascade chains around timeout/retry behavior, and testing what happens during concurrent payment attempts."
 <commentary>Assumption stress and cascade chain techniques are primary. Dependency evolution checks the payment API contract stability.</commentary>
 </example>
-<example>
-Context: User modified a caching layer that multiple services read from
-user: "Could my cache changes cause issues across services?"
-assistant: "I'll run the stress-tester to fracture the composition between your cache and its consumers -- constructing scenarios where cache invalidation timing, stale reads during deployment, and concurrent writes produce incorrect behavior."
-<commentary>Composition fracture is primary. Deployment boundary checks the old-cache-format vs new-code scenario.</commentary>
-</example>
-<example>
-Context: User added a job queue processor with retry logic
-user: "Is my retry logic safe under load?"
-assistant: "I'll use the stress-tester to build cascade chains around your retry behavior -- what happens when retries create more load, when partial processing leaves orphaned state, and when the recovery path itself fails."
-<commentary>Cascade chain is primary -- retry storms and recovery-induced failures. Abuse scenario tests rapid job submission.</commentary>
-</example>
 </examples>
 
 You are a failure scenario architect. Where other reviewers check whether code meets quality criteria, you construct specific sequences of events that make it break. You think in chains: "if this happens, then that happens, which causes this to fail, leaving the system in this state." You do not evaluate -- you attack.
@@ -223,6 +211,3 @@ Follow with severity counts, depth used (standard/deep), and a one-line justific
 - Don't flag DX issues -- developer-experience-auditor owns those.
 - Don't flag architectural concerns -- architecture-strategist owns those.
 - Don't construct scenarios that require multiple independent unlikely events to coincide.
-- Don't produce vague risk warnings without a constructible scenario.
-- Don't cite line numbers from memory or inference -- read the file first.
-- Don't flag pre-existing failure modes the diff did not introduce or worsen.

--- a/agents/review/stress-tester.md
+++ b/agents/review/stress-tester.md
@@ -74,9 +74,20 @@ Calibrate your depth based on the Diff Manifest and content analysis -- not raw 
 
 ## Code Navigation Strategy
 
-You may receive an `lsp_available` flag in your context from the review orchestrator.
+You have been provided `codegraph_available` and `lsp_available` flags in your context.
 
-**When `lsp_available: true`:**
+**When `codegraph_available: true`:**
+- First, load codegraph tool schemas by calling ToolSearch with query `"select:mcp__codegraph__codegraph_search,mcp__codegraph__codegraph_context,mcp__codegraph__codegraph_callers,mcp__codegraph__codegraph_callees,mcp__codegraph__codegraph_impact,mcp__codegraph__codegraph_node"`. Codegraph tools are deferred and cannot be called without this step.
+- For finding symbols by name: use codegraph_search first.
+- For understanding what code is relevant to a task: use codegraph_context first.
+- For finding callers of a function: use codegraph_callers first.
+- For finding what a function calls: use codegraph_callees first.
+- For assessing change impact: use codegraph_impact first.
+- For getting source code of a specific symbol: use codegraph_node.
+- If codegraph returns insufficient results, fall through to LSP (if available) then grep.
+- For file discovery and pattern matching: always use Grep/Glob regardless of codegraph.
+
+**When `codegraph_available: false` and `lsp_available: true`:**
 - For finding where a function/class/type is defined: use LSP goToDefinition first.
 - For finding all callers or consumers of a symbol: use LSP findReferences first.
 - For getting a structural overview of a file: use LSP documentSymbol first.
@@ -85,7 +96,7 @@ You may receive an `lsp_available` flag in your context from the review orchestr
   Then use Grep as fallback.
 - For file discovery and pattern matching: always use Grep/Glob regardless of LSP availability.
 
-**When `lsp_available: false` (or not provided):**
+**When both unavailable:**
 - Use Grep, Glob, and Read for all code navigation.
 
 ## Technique 1 -- Assumption Stress

--- a/agents/review/test-reviewer.md
+++ b/agents/review/test-reviewer.md
@@ -11,18 +11,6 @@ user: "Are my tests good enough?"
 assistant: "I'll spawn the test-reviewer to evaluate your test assertions -- checking if they verify specific behavior or just confirm the mocks were called, and whether the tests would catch a real regression if the implementation changed."
 <commentary>Assertion strength analysis is primary. Heavy mocking is a signal for false confidence tests.</commentary>
 </example>
-<example>
-Context: User modified business logic but only added happy-path tests
-user: "Do I have enough test coverage for this change?"
-assistant: "I'll run the test-reviewer to analyze your coverage against the new branches in your diff -- prioritizing error paths and failure handling over happy-path variants, since those are the most commonly missed and highest-impact gaps."
-<commentary>Risk-based gap analysis is primary. The agent prioritizes P0 (error paths) over P1-P3.</commentary>
-</example>
-<example>
-Context: User added tests that use setTimeout and Date.now for timing assertions
-user: "My tests pass locally but fail intermittently in CI"
-assistant: "I'll use the test-reviewer to scan for flaky test patterns -- time-dependent assertions, shared mutable state between tests, and execution-order dependencies that cause intermittent CI failures."
-<commentary>Flaky test patterns and test isolation are primary. These are the extra coverage areas beyond standard coverage analysis.</commentary>
-</example>
 </examples>
 
 You are a test effectiveness analyst. You do not check whether tests exist -- you check whether tests prove anything. Your core question for every test is: "If a real bug were introduced in the code this test covers, would this test catch it?" You evaluate the gap between test confidence and test value.
@@ -150,10 +138,6 @@ Follow with severity counts and a one-line justification.
 
 ## Anti-Patterns
 
-- Don't flag missing tests for code the diff did not change -- pre-existing test debt is out of scope.
 - Don't flag test style preferences (describe/it vs test, file naming, AAA format) -- team conventions vary.
 - Don't flag coverage percentages -- flag specific untested code paths that matter.
 - Don't flag missing tests for trivial getters/setters without conditional logic.
-- Don't flag code correctness, security, architecture, waste, or DX -- those belong to other agents.
-- Don't claim a branch is untested without searching for tests that exercise it first.
-- Don't cite line numbers from memory or inference -- read the file first.

--- a/agents/review/waste-detector.md
+++ b/agents/review/waste-detector.md
@@ -6,18 +6,6 @@ model: inherit
 
 <examples>
 <example>
-Context: User added a new utility file that duplicates existing functionality
-user: "Review my PR for any unnecessary code"
-assistant: "I'll spawn the waste-detector agent to check if any new code duplicates existing utilities, introduces dead paths, or adds unnecessary ceremony."
-<commentary>Full waste audit -- all phases apply. Redundancy scan (Phase 2) is particularly relevant.</commentary>
-</example>
-<example>
-Context: User added configuration files and wrapper scripts to a project
-user: "Is all this config necessary or am I over-engineering?"
-assistant: "I'll use the waste-detector agent to evaluate whether each new file earns its place -- checking for YAGNI violations, framework-provided alternatives, and premature abstraction."
-<commentary>Existence audit (Phase 1) and ceremony check (Phase 4) are primary. The agent asks "does this need to exist?" before anything else.</commentary>
-</example>
-<example>
 Context: User refactored code and added several new abstractions
 user: "Did I over-abstract this? Is there dead code?"
 assistant: "I'll run the waste-detector to trace whether each new abstraction has callers, whether the framework already provides equivalent functionality, and whether simpler approaches exist."
@@ -172,11 +160,6 @@ Follow with severity counts and a one-line justification.
 
 ## Anti-Patterns
 
-- Don't flag code quality, bugs, security, or architecture -- those belong to other agents.
-- Don't flag working code as waste because you would have written it differently.
-- Don't claim redundancy without citing the specific existing code that duplicates the new code.
 - Don't flag dead code in the existing codebase that the diff did not introduce.
 - Don't suggest refactoring beyond the scope of waste removal.
 - Don't flag documentation, comments, or test files as waste.
-- Don't produce Critical findings -- waste is never deployment-blocking.
-- Don't cite line numbers from memory or inference -- read the file first to confirm what is actually there.

--- a/agents/review/waste-detector.md
+++ b/agents/review/waste-detector.md
@@ -69,9 +69,20 @@ For each file added or significantly modified in the diff, evaluate whether it e
 
 ## Code Navigation Strategy
 
-You may receive an `lsp_available` flag in your context from the review orchestrator.
+You have been provided `codegraph_available` and `lsp_available` flags in your context.
 
-**When `lsp_available: true`:**
+**When `codegraph_available: true`:**
+- First, load codegraph tool schemas by calling ToolSearch with query `"select:mcp__codegraph__codegraph_search,mcp__codegraph__codegraph_context,mcp__codegraph__codegraph_callers,mcp__codegraph__codegraph_callees,mcp__codegraph__codegraph_impact,mcp__codegraph__codegraph_node"`. Codegraph tools are deferred and cannot be called without this step.
+- For finding symbols by name: use codegraph_search first.
+- For understanding what code is relevant to a task: use codegraph_context first.
+- For finding callers of a function: use codegraph_callers first.
+- For finding what a function calls: use codegraph_callees first.
+- For assessing change impact: use codegraph_impact first.
+- For getting source code of a specific symbol: use codegraph_node.
+- If codegraph returns insufficient results, fall through to LSP (if available) then grep.
+- For file discovery and pattern matching: always use Grep/Glob regardless of codegraph.
+
+**When `codegraph_available: false` and `lsp_available: true`:**
 - For finding where a function/class/type is defined: use LSP goToDefinition first.
 - For finding all callers or consumers of a symbol: use LSP findReferences first.
 - For getting a structural overview of a file: use LSP documentSymbol first.
@@ -80,7 +91,7 @@ You may receive an `lsp_available` flag in your context from the review orchestr
   Then use Grep as fallback.
 - For file discovery and pattern matching: always use Grep/Glob regardless of LSP availability.
 
-**When `lsp_available: false` (or not provided):**
+**When both unavailable:**
 - Use Grep, Glob, and Read for all code navigation.
 
 ## Phase 2 -- Redundancy Scan

--- a/agents/workflow/plan-reviewer.md
+++ b/agents/workflow/plan-reviewer.md
@@ -11,12 +11,6 @@ user: "Review this implementation plan for issues"
 assistant: "I'll review the plan for dependency and ordering issues. Task 3 reads `config/auth.yml` but Task 5 is the one that creates it -- Task 3 must move after Task 5 or the implementer will hit a missing-file error."
 <commentary>REORDER finding with concrete task numbers and the specific file that creates the dependency. The agent traces task inputs/outputs to find the ordering bug.</commentary>
 </example>
-<example>
-Context: A clean, well-structured plan with correct ordering and full spec coverage
-user: "Check this plan before I start building"
-assistant: "Plan reviewed: 8 tasks, all dependencies resolve correctly, every spec requirement maps to at least one task, no placeholders found. Zero findings -- ready to execute."
-<commentary>Zero findings is a valid outcome. The agent does not manufacture issues to appear thorough.</commentary>
-</example>
 </examples>
 
 You are a plan quality reviewer. You review implementation plans as a reader who will execute them -- checking whether the tasks are ordered correctly, whether dependencies resolve, whether the spec is fully covered, and whether the plan contains enough detail to build from. You did not write this plan. You evaluate it.

--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -60,14 +60,7 @@ If user picks "Skip brainstorm", **stop here** and suggest running `/plan <task>
 
 ### Decomposition Check
 
-After assessing complexity, evaluate whether the idea is too large for a single spec:
-
-**Trigger signals:**
-- The description contains 3+ independent subsystems (e.g., "chat, file management, billing")
-- Components span different technology layers (backend + frontend + mobile + infra)
-- Estimated affected file count exceeds 20+
-
-If any trigger fires, use `AskUserQuestion`:
+If the description contains 3+ independent subsystems, spans multiple technology layers (backend + frontend + mobile + infra), or estimates 20+ affected files, use `AskUserQuestion`:
 > This idea contains multiple independent subsystems. Splitting into sub-projects produces better specs than cramming everything into one.
 Buttons: `["Split into sub-projects", "Continue as single spec"]`
 
@@ -77,17 +70,11 @@ Buttons: `["Split into sub-projects", "Continue as single spec"]`
 
 ## Step 1.5 -- Visual Companion Offer
 
-If the idea involves UI/UX, layout, design, architecture diagrams, or other visual content:
-
-Use `AskUserQuestion`:
+If the idea involves UI/UX, layout, design, or architecture diagrams, use `AskUserQuestion`:
 > This topic is well-suited for visual content. I can open a browser-based companion to show mockups and diagrams as we go. Want to try it?
 Buttons: `["Yes, open visual companion", "No, continue with text"]`
 
-**If "Yes":** Read the `visual-companion` skill for setup instructions. Start the companion server and keep it running throughout the brainstorm session. For each step that involves a visual question, write HTML content and direct the user to their browser. For text-only questions, continue in the terminal.
-
-**If "No":** Continue with normal text-only flow.
-
-**If the topic is NOT visual** (pure backend, data model, API design, etc.): Skip this step entirely. Do not offer the companion.
+**If "Yes":** Read the `visual-companion` skill for setup instructions. Start the companion server and keep it running throughout the session; write HTML content for visual questions and continue in the terminal for text-only ones. **If "No":** Continue with normal text-only flow. Skip this step entirely for pure backend, data model, or API-design topics.
 
 ## Step 2 -- Clarifying Questions
 
@@ -99,12 +86,7 @@ Ask questions to fill gaps in your understanding. Focus on: purpose, constraints
 - Always include an "Other" free-text option as the last button (AskUserQuestion adds this automatically).
 - **Question count follows depth:** Quick = 0-1, Standard = 2-3, Deep = 3-4.
 - **Group independent questions.** If two questions have no dependency on each other, ask them in the same `AskUserQuestion` call using the multi-question format (up to 4 questions per call). Only separate questions when the answer to one determines what you ask next.
-- After each answer, decide: enough context to proceed, or one more question needed? Do not ask questions for the sake of filling a quota.
-
-**When to skip questions entirely:**
-- The user provided a detailed description with clear scope, constraints, and success criteria
-- The idea is a well-known pattern (CRUD, auth, API endpoint) with obvious implementation paths
-- The user explicitly said "just brainstorm approaches" without wanting scope refinement
+- After each answer, decide: enough context to proceed, or one more question needed? Do not ask questions for the sake of filling a quota. Skip entirely if the user provided clear scope/constraints/success criteria, the idea is a well-known pattern (CRUD, auth, endpoint), or the user explicitly said "just brainstorm approaches".
 
 ## Step 3 -- Generate Approaches
 
@@ -118,9 +100,7 @@ Present 2-3 distinct approaches. Each approach must include:
 **Lead with your recommendation.** Mark it clearly and explain why in 1-2 sentences. Do not be neutral -- take a position.
 
 **Rules:**
-- Approaches must reference actual project structure observed in gather-context. Do not propose patterns that conflict with the project's existing conventions. When evaluating approaches, penalize complexity that does not directly serve the stated requirements.
-- Approaches must be genuinely different strategies, not cosmetic variations of the same idea.
-- Ground approaches in the actual codebase context (existing patterns, frameworks, conventions observed from gather-context).
+- Approaches must be genuinely different strategies grounded in actual project structure and conventions from gather-context. Penalize complexity that does not serve stated requirements.
 - If the idea has a "standard way" in the project's stack, include it as one approach even if you recommend something different.
 - For Quick depth: 2 approaches, concise (3-4 lines each). For Deep: 3 approaches, detailed (8-12 lines each).
 
@@ -160,86 +140,38 @@ Handle each response:
 
 Write the validated design as a spec document. Scale section depth to complexity -- a Quick spec can be 50 lines, a Deep spec can be 200+. Not every section is required for every depth.
 
-**Document structure:**
+**Required sections by depth:**
+- **Quick:** Executive Summary, Design (Chosen Approach + Key Decisions + Affected Areas), Success Criteria. Omit Context, Alternatives, Open Questions unless they add clear value.
+- **Standard:** All sections above plus Context and Open Questions. Skip Alternatives Considered.
+- **Deep:** All sections including Alternatives Considered and Design Principles Applied.
 
-```markdown
-# [Feature/Idea Name] -- Brainstorm Spec
-
-**Date:** YYYY-MM-DD
-**Status:** Draft
-**Depth:** Quick | Standard | Deep
-
-## Executive Summary
-[Copy from Step 4 -- this is the approved summary]
-
-## Context
-[Why this idea exists. What problem it solves. Any prior art or existing patterns.]
-
-## Design
-
-### Chosen Approach: [Name]
-[Detailed description of the selected approach]
-
-### Key Decisions
-[Numbered list of design decisions with brief rationale for each]
-
-### Affected Areas
-[File paths, modules, or system boundaries that will be touched]
-
-## Alternatives Considered  <!-- Deep only -->
-[Other approaches from Step 3, with why they were not chosen]
-
-## Open Questions  <!-- if any remain -->
-[Questions that surfaced during brainstorming but were deferred to planning phase]
-
-## Success Criteria
-[How we know this is done and working correctly]
-
-## Design Principles Applied  <!-- Standard and Deep only -->
-- **YAGNI:** [Features explicitly removed or deferred from this spec, with reasons]
-- **Single Responsibility:** [Each unit's sole responsibility]
-- **Interface Clarity:** [Communication interfaces between units]
-```
-
-**Rules:**
-- Quick depth: Executive Summary + Design + Success Criteria. Skip Context, Alternatives, Open Questions unless they add value.
-- Standard depth: All sections except Alternatives Considered.
-- Deep depth: All sections.
-- No placeholders -- every section must have real content. If you cannot fill a section, remove it.
-- Standard and Deep depth: "Design Principles Applied" section is required. Quick depth: optional.
-- Always write spec documents in English, regardless of the conversation language. Only write in another language if the user explicitly requests it.
+**Section content rules:**
+- Header block: `# [Feature/Idea Name] -- Brainstorm Spec` with `Date`, `Status: Draft`, `Depth` fields.
+- Executive Summary: copy the approved summary from Step 4.
+- Design > Chosen Approach: detailed description of the selected approach.
+- Design > Key Decisions: numbered list with brief rationale per decision.
+- Design > Affected Areas: file paths, modules, or system boundaries.
+- Alternatives Considered (Deep only): other approaches from Step 3 with rejection reasons.
+- Open Questions: items deferred to planning phase.
+- Success Criteria: how we know it is done and working.
+- Design Principles Applied (Standard + Deep): YAGNI (features deferred and why), Single Responsibility (each unit's role), Interface Clarity (communication interfaces).
+- No placeholders -- every included section must have real content. Remove sections you cannot fill.
+- Always write in English unless the user explicitly requests another language.
 
 ### Save the spec:
 
 1. Create `docs/brainstorms/` if it does not exist.
 2. Write the spec as `docs/brainstorms/YYYY-MM-DD-<descriptive-name>.md` (use `date '+%Y-%m-%d'` for the date prefix).
-3. **Verify:** Read the file back and confirm it was written correctly. Confirm no raw `{...}` placeholder text remains.
-
-## Step 6 -- Spec Self-Review
-
-After writing, review with fresh eyes:
-
-1. **Placeholder scan:** Any "TBD", "TODO", unfilled sections, or vague requirements like "add appropriate handling"? Fix them inline.
-2. **Internal consistency:** Do sections contradict each other? Does the design match the executive summary?
-3. **Scope check:** Is this focused enough for a single `/plan` session, or should it be decomposed into sub-specs?
-4. **Ambiguity check:** Could any requirement be interpreted two different ways? Pick one interpretation and make it explicit.
-
-Fix any issues by editing the saved file. No need to re-review after fixes.
+3. **Verify:** Read the file back and confirm it was written correctly. Then self-review with fresh eyes: (1) placeholder scan -- any "TBD", "TODO", or vague requirements? Fix inline; (2) internal consistency -- do sections contradict each other or diverge from the executive summary? Fix inline; (3) scope check -- is this focused enough for a single `/plan` session, or should it be decomposed into sub-specs? (4) ambiguity check -- can any requirement be read two ways? Pick one interpretation and make it explicit. Fix any issues by editing the saved file.
 
 ## Step 7 -- User Review Gate
 
-After self-review passes, present the user with the opportunity to review:
-
 Use `AskUserQuestion`:
-- **question:** "Spec saved to `docs/brainstorms/{filename}`. You can review it now or move forward. What would you like to do?"
-- Buttons:
-  1. `"Looks good -- move to planning"` / "Invoke /plan with this spec as input"
-  2. `"Let me review first"` / "I want to read the spec and may request changes"
-  3. `"Save and stop"` / "Keep the spec, I will plan later"
+> Spec saved. You can review it now or move forward. What would you like to do?
+Buttons: `["Looks good -- move to planning", "Let me review first", "Save and stop"]`
 
-Handle each response:
-- **Looks good -- move to planning** -- invoke the `plan` skill with the spec path as context: "Plan the implementation based on the brainstorm spec at `docs/brainstorms/{filename}`"
-- **Let me review first** -- say: "Take your time. When you are ready, let me know if you want changes or if we should move to `/plan`." **Stop here** and wait.
+- **Looks good -- move to planning** -- invoke the `plan` skill with the spec path as context.
+- **Let me review first** -- say: "Take your time. Let me know if you want changes or if we should move to `/plan`." **Stop here** and wait.
 - **Save and stop** -- stop here.
 
 ---
@@ -254,8 +186,7 @@ Handle each response:
 - **Don't** force questions when the user gave a clear, detailed description -- assess and skip if appropriate.
 - **Don't** show depth labels ("This is Standard depth") to the user -- depth is internal routing logic.
 - **Don't** leave placeholder sections in the spec ("TBD", "TODO") -- either fill them or remove them.
-- **Don't** add features the user didn't ask for -- if it's not in the requirements, it's not in the spec. Ask the user before adding "nice to have" features.
-- **Don't** design for hypothetical future requirements -- solve the problem at hand. If the user says "we might need X later", note it in Open Questions, don't architect for it now.
+- **Don't** add features the user didn't ask for and don't architect for hypothetical future requirements -- solve the problem at hand. If "we might need X later" comes up, note it in Open Questions only.
 
 ---
 
@@ -263,25 +194,21 @@ Handle each response:
 
 **Trigger:** `/brainstorm <idea>` (and `/quiver:brainstorm` should also work)
 
-**Setup:**
-- Project root with optional `docs/brainstorms/` directory.
+**Setup:** Project root with optional `docs/brainstorms/` directory.
 
 **Expected behavior:**
-1. Skill silently gathers project context (Glob over brainstorms/plans/source dirs) and runs the three git shell blocks.
-2. Skill restates the idea, picks a depth (Quick / Standard / Deep) silently, and asks 0-4 clarifying questions via `AskUserQuestion`.
-3. Skill presents 2-3 distinct approaches grounded in the codebase, leads with a recommendation, and asks the user to choose via `AskUserQuestion`.
-4. After approach selection, skill prints the Executive Summary and asks `Approve / Adjust / Restart` via `AskUserQuestion`.
-5. On approval, skill writes the spec to `docs/brainstorms/YYYY-MM-DD-<name>.md` (in English regardless of conversation language) and reads it back to verify.
-6. Skill ends with `AskUserQuestion` offering `Looks good / Let me review first / Save and stop`; on the first option it invokes the `plan` skill with the spec path.
+1. Silently gathers project context and runs three git shell blocks.
+2. Restates the idea, picks depth silently, asks 0-4 clarifying questions via `AskUserQuestion`.
+3. Presents 2-3 approaches with a recommendation; user selects via `AskUserQuestion`.
+4. Prints Executive Summary; user approves/adjusts/restarts via `AskUserQuestion`.
+5. Writes spec to `docs/brainstorms/YYYY-MM-DD-<name>.md` (English), reads it back, self-reviews.
+6. Final `AskUserQuestion` offering `Looks good / Let me review first / Save and stop`; first option invokes `plan` with the spec path.
 
 **Verification checklist:**
-- [ ] Slash menu shows `/brainstorm`.
-- [ ] Spec file is written under `docs/brainstorms/` with the date-prefixed filename.
-- [ ] All clarifying / approach / approval / next-step prompts use `AskUserQuestion`, not plain text.
-- [ ] Spec body has no raw `{placeholder}` text.
-- [ ] Visual companion offer appears only when the topic is visual (UI/UX/architecture diagrams).
-- [ ] Spec language is English unless the user explicitly asked for another language.
+- [ ] Slash menu shows `/brainstorm`; spec file written under `docs/brainstorms/` with date-prefixed filename.
+- [ ] All clarifying / approach / approval / next-step prompts use `AskUserQuestion`, not plain text; spec has no raw `{placeholder}` text.
+- [ ] Visual companion offer appears only for visual topics; spec language is English unless user explicitly requested otherwise.
 
 **Known gotchas:**
-- Visual companion requires the `visual-companion` skill's runtime; if its server cannot start, the brainstorm should fall back to text without aborting.
-- The decomposition check fires on 3+ subsystems or 20+ estimated files; tuning these heuristics affects when the split prompt is offered.
+- Visual companion falls back to text-only if its server cannot start -- the brainstorm must not abort.
+- Decomposition check fires at 3+ subsystems or 20+ estimated files; these thresholds control when the split prompt appears.

--- a/skills/code-navigation/SKILL.md
+++ b/skills/code-navigation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-navigation
-description: "LSP-first code navigation with grep fallback. Provides agents with a reusable strategy for semantic code exploration -- goToDefinition, findReferences, documentSymbol -- with automatic fallback to grep when LSP is unavailable or returns empty results."
+description: "CodeGraph-first code navigation with LSP and grep fallback. Provides agents with a reusable strategy for semantic code exploration -- codegraph tools when available, LSP goToDefinition/findReferences/documentSymbol otherwise, grep as last resort."
 ---
 
 # Code Navigation
@@ -55,6 +55,7 @@ Agents that search the broader codebase should include this block in their promp
 You have been provided `codegraph_available` and `lsp_available` flags in your context.
 
 **When `codegraph_available: true`:**
+- First, load codegraph tool schemas by calling ToolSearch with query `"select:mcp__codegraph__codegraph_search,mcp__codegraph__codegraph_context,mcp__codegraph__codegraph_callers,mcp__codegraph__codegraph_callees,mcp__codegraph__codegraph_impact,mcp__codegraph__codegraph_node"`. Codegraph tools are deferred and cannot be called without this step.
 - For finding symbols by name: use codegraph_search first.
 - For understanding what code is relevant to a task: use codegraph_context first.
 - For finding callers of a function: use codegraph_callers first.
@@ -79,7 +80,7 @@ You have been provided `codegraph_available` and `lsp_available` flags in your c
 
 ## Skill-Level Navigation Detection
 
-Skills that dispatch code-exploration agents (`/plan`, `/review`) run this detection once before agent dispatch. Results are passed to all agents as context.
+Skills that dispatch code-exploration agents (`/plan`, `/review`) run this detection once before agent dispatch. Results are passed as `codegraph_available` and `lsp_available` flags to `quiver:code-navigator` and other agents that search the codebase.
 
 ### CodeGraph Detection Flow
 

--- a/skills/code-navigation/SKILL.md
+++ b/skills/code-navigation/SKILL.md
@@ -7,6 +7,29 @@ description: "LSP-first code navigation with grep fallback. Provides agents with
 
 Reference skill for agents that search the broader codebase. Defines when to use LSP vs Grep/Glob and how to handle fallback.
 
+## Navigation Hierarchy
+
+Three tiers, highest precision first. Use the highest available tier for each operation.
+
+| Tier | Tools | Available When | Best For |
+|------|-------|---------------|----------|
+| CodeGraph | `codegraph_search`, `codegraph_context`, `codegraph_callers`, `codegraph_callees`, `codegraph_impact`, `codegraph_node` | `.codegraph/` exists in project root | Symbol lookup, task-relevant files, call chains, change impact |
+| LSP | `goToDefinition`, `findReferences`, `documentSymbol` | Language server installed | Definition jump, reference finding, file structure |
+| Grep/Glob/Read | Pattern matching + file reads | Always | File discovery, text patterns, config files, non-code content |
+
+## CodeGraph Operation Catalog
+
+Six semantic operations. For file discovery and text patterns, use Grep/Glob regardless of CodeGraph.
+
+| Operation | Use When |
+|-----------|----------|
+| `codegraph_search` | Find symbols by name (functions, classes, types) |
+| `codegraph_context` | Get relevant code context for a task description |
+| `codegraph_callers` | Find what calls a function |
+| `codegraph_callees` | Find what a function calls |
+| `codegraph_impact` | Assess what is affected by changing a symbol |
+| `codegraph_node` | Get details and source code for a specific symbol |
+
 ## LSP Operation Catalog
 
 Three semantic operations where LSP outperforms grep. For everything else, use Grep/Glob/Read directly.
@@ -24,14 +47,24 @@ Three semantic operations where LSP outperforms grep. For everything else, use G
 
 ## Agent Instructions Block
 
-Agents that search the broader codebase should include this block in their prompt. The dispatching skill passes `lsp_available: true|false` as part of the agent's context.
+Agents that search the broader codebase should include this block in their prompt. The dispatching skill passes `codegraph_available: true|false` and `lsp_available: true|false` as part of the agent's context.
 
 ```
 ## Code Navigation Strategy
 
-You have been provided an `lsp_available` flag in your context.
+You have been provided `codegraph_available` and `lsp_available` flags in your context.
 
-**When `lsp_available: true`:**
+**When `codegraph_available: true`:**
+- For finding symbols by name: use codegraph_search first.
+- For understanding what code is relevant to a task: use codegraph_context first.
+- For finding callers of a function: use codegraph_callers first.
+- For finding what a function calls: use codegraph_callees first.
+- For assessing change impact: use codegraph_impact first.
+- For getting source code of a specific symbol: use codegraph_node.
+- If codegraph returns insufficient results, fall through to LSP (if available) then grep.
+- For file discovery and pattern matching: always use Grep/Glob regardless of codegraph.
+
+**When `codegraph_available: false` and `lsp_available: true`:**
 - For finding where a function/class/type is defined: use LSP goToDefinition first.
 - For finding all callers or consumers of a symbol: use LSP findReferences first.
 - For getting a structural overview of a file: use LSP documentSymbol first.
@@ -40,15 +73,22 @@ You have been provided an `lsp_available` flag in your context.
   Then use the grep equivalent from the catalog above.
 - For file discovery and pattern matching: always use Grep/Glob regardless of LSP availability.
 
-**When `lsp_available: false`:**
+**When both unavailable:**
 - Use Grep, Glob, and Read for all code navigation.
 ```
 
-## Skill-Level LSP Detection
+## Skill-Level Navigation Detection
 
-Skills that dispatch code-exploration agents (`/plan`, `/review`) run this detection once before agent dispatch. The result is passed to all agents as context.
+Skills that dispatch code-exploration agents (`/plan`, `/review`) run this detection once before agent dispatch. Results are passed to all agents as context.
 
-### Detection Flow
+### CodeGraph Detection Flow
+
+1. Check if `.codegraph/` directory exists at project root.
+2. If exists: set `codegraph_available=true`.
+3. If not: set `codegraph_available=false`. No user prompt -- CodeGraph is a passive enhancement.
+4. Pass `codegraph_available` alongside `lsp_available` to all dispatched agents.
+
+### LSP Detection Flow
 
 1. **Check project memory** for cached LSP preference.
    - If `lsp_declined` found: set `lsp_available=false`, skip to step 4.
@@ -97,7 +137,7 @@ LSP preference is stored in project memory:
 If your agent searches the broader codebase (beyond files it already knows about), reference this skill:
 
 1. Add the **Code Navigation Strategy** block from above to your agent's prompt.
-2. Ensure the dispatching skill passes `lsp_available` context to your agent.
+2. Ensure the dispatching skill passes `codegraph_available` and `lsp_available` context to your agent.
 3. Your agent does NOT need to handle LSP detection -- that is the skill's responsibility.
 
 ---
@@ -111,16 +151,18 @@ If your agent searches the broader codebase (beyond files it already knows about
 - An LSP server is optionally installed for the project's primary language.
 
 **Expected behavior:**
-1. Consumer skills run a single LSP detection per session and pass the resulting `lsp_available` flag to every agent prompt that searches the codebase.
+1. Consumer skills run a single navigation detection per session (CodeGraph + LSP) and pass both `codegraph_available` and `lsp_available` flags to every agent prompt that searches the codebase.
 2. Agents that include the Code Navigation Strategy block use LSP `goToDefinition` / `findReferences` / `documentSymbol` first when `lsp_available: true`, falling back to grep on empty results.
 3. With `lsp_available: false`, agents use Grep / Glob / Read for all navigation.
 4. LSP preference (`lsp_confirmed` or `lsp_declined`) is cached in project memory at `lsp_preference.md` and reused across sessions.
 
 **Verification checklist:**
-- [ ] `/plan` and `/review` both run LSP detection exactly once before agent dispatch (not per agent).
+- [ ] `/plan` and `/review` both run navigation detection (CodeGraph + LSP) exactly once before agent dispatch (not per agent).
 - [ ] At least one dispatched agent prompt contains the literal phrase `lsp_available:` in the agent context.
 - [ ] When LSP returns empty results, the agent prints a fallback notice before running grep.
 - [ ] Project memory ends up with `lsp_preference.md` after the first detection run.
+- [ ] `codegraph_available` flag detected and passed to agents when `.codegraph/` exists.
+- [ ] When `.codegraph/` does not exist, `codegraph_available` is false and behavior is unchanged.
 
 **Known gotchas:**
 - LSP availability is cached per project; clearing or installing a new language server requires `forget LSP preference` or manual `lsp_preference.md` removal.

--- a/skills/create-agent/SKILL.md
+++ b/skills/create-agent/SKILL.md
@@ -95,11 +95,11 @@ Using the resolved fields and the [Agent Authoring Reference](#agent-authoring-r
 - Methodology sections should contain actionable, domain-specific checks ordered by impact.
 - Output format should match the agent's purpose (e.g., severity-based for reviewers, structured findings for auditors).
 - Run [Quality Gates](#quality-gates) before proceeding to save.
-- **Code navigation hint:** If the agent's purpose involves searching or exploring the broader codebase (not just reading files it already knows about), include the Code Navigation Strategy block from `skills/code-navigation/SKILL.md`. Add a comment near the top of the generated agent file:
+- **Code navigation hint:** If the agent's purpose involves searching or exploring the broader codebase (not just reading files it already knows about), copy the Code Navigation Strategy block verbatim from `skills/code-navigation/SKILL.md` (the section starting with `## Code Navigation Strategy`) into the generated agent file. Add a comment above it:
   ```
   <!-- This agent searches the codebase. The Code Navigation Strategy block
        (from skills/code-navigation/SKILL.md) is included below. The dispatching
-       skill must pass lsp_available context. -->
+       skill must pass codegraph_available and lsp_available context. -->
   ```
 
 ---

--- a/skills/hypothesis-debugging/SKILL.md
+++ b/skills/hypothesis-debugging/SKILL.md
@@ -113,7 +113,10 @@ Dispatch qualifying agents in parallel (multiple Agent tool calls in a single re
 - Symptom summary from Step 1.4 (the curated synthesis of codebase findings -- not the raw bug description)
 - Recent changes context from Step 1.3 (recently changed files and their overlap with the bug area) -- include only if git is available
 - Raw error/log output extracted in Step 1.1 (verbatim stack traces, error messages, log snippets) -- include only if present
+- `codegraph_available` flag: check once if `.codegraph/` exists at project root; set `true` or `false`. No user prompt.
 - `lsp_available` flag (detect once using the Code Navigation Strategy detection flow from `skills/code-navigation/SKILL.md`; cache for the session)
+
+Pass both flags to each dispatched agent. Agents that search the codebase (code-tracer, regression-finder, environment-checker) carry the Code Navigation Strategy block and will call ToolSearch to load codegraph tools when `codegraph_available: true`.
 
 For simple single-file checks: handle directly without agent dispatch. Read the file, inspect the relevant code, and evaluate the hypothesis.
 

--- a/skills/orchestrate-agents/SKILL.md
+++ b/skills/orchestrate-agents/SKILL.md
@@ -160,8 +160,10 @@ Agent(
 ```
 
 - **Tools:** Read-only (Glob, Grep, Read, LSP -- no Edit, Write, Agent)
-- **Best for:** Codebase search, file discovery, code understanding, dependency mapping
-- **When to use:** Any subtask that only needs to READ and REPORT. Never for tasks that modify files.
+- **Best for:** Non-codebase read tasks: checking if a specific config file exists, reading raw log output, grep-only operations with no benefit from codegraph
+- **When to use:** Only when the task is pure file I/O with no need for semantic code understanding. For any task that involves finding, mapping, or understanding source code, use `quiver:code-navigator` instead (see rule below).
+
+> **Hard rule -- codebase exploration:** Always use `quiver:code-navigator` instead of `Explore` for any task that involves finding, understanding, or mapping source code. `Explore` ignores codegraph semantic tools even when codegraph is available and falls back to grep for everything. `quiver:code-navigator` loads codegraph schemas first, uses semantic search, and falls back to grep only when needed -- fewer tokens, higher precision.
 
 ### Plan
 
@@ -195,8 +197,8 @@ Agent(
 
 | Need | Agent Type | Recommended Frontmatter Model |
 |------|-----------|-------------------------------|
-| Find files matching a pattern | `Explore` | `haiku` |
-| Understand how a module works | `Explore` | `haiku` or `sonnet` |
+| Find files matching a pattern in source code | `quiver:code-navigator` | `inherit` |
+| Understand how a module works | `quiver:code-navigator` | `inherit` |
 | Run shell commands or git operations | `general-purpose` | inherit |
 | Design before implementing | `Plan` | inherit or `opus` |
 | Write or modify code | `general-purpose` | inherit |
@@ -263,7 +265,8 @@ flowchart TD
     D -->|Yes| C
     D -->|No| E
 
-    E -->|Read/search only| F[Explore]
+    E -->|Codebase exploration| F[quiver:code-navigator]
+    E -->|Non-codebase read only| G[Explore]
     E -->|Planning/design| H[Plan]
     E -->|Write/modify code or shell commands| I[general-purpose]
 ```
@@ -304,7 +307,7 @@ When creating custom agents (via frontmatter `model` field), choose the right mo
 ```
 Plan:
   Step 1: quiver:waste-detector -- Audit current branch diff (parallel: yes)
-  Step 2: Explore -- Find untested code paths (parallel: yes)
+  Step 2: quiver:code-navigator -- Find untested code paths (parallel: yes)
   Step 3: general-purpose -- Implement fixes from review findings (depends on: step 1, 2)
   Step 4: general-purpose -- Run test suite to verify fixes (depends on: step 3)
 ```
@@ -338,14 +341,14 @@ Agent(
 )
 
 Agent(
-  subagent_type="Explore",
+  subagent_type="quiver:code-navigator",
   description="Find untested code",
   prompt="Find all source files in src/ that do NOT have a corresponding test file in tests/ or __tests__/. List each untested file with its line count. Ignore index files and type definitions.",
   run_in_background=true
 )
 
 Agent(
-  subagent_type="Explore",
+  subagent_type="quiver:code-navigator",
   description="Check for TODOs",
   prompt="Find all TODO, FIXME, HACK, and XXX comments in the codebase. For each, report: file path, line number, the comment text, and how old it is (git blame the line). Sort by age, oldest first.",
   run_in_background=true
@@ -366,7 +369,7 @@ flowchart LR
 ```
 # Step 1: Research (synchronous -- blocks until done)
 Agent(
-  subagent_type="Explore",
+  subagent_type="quiver:code-navigator",
   description="Analyze current auth implementation",
   prompt="Analyze the authentication system in this codebase. Find: 1) All auth-related files (models, middleware, controllers), 2) Which auth library/strategy is used, 3) How sessions are managed, 4) Any existing tests for auth. Report file paths and a summary of each component's role."
 )
@@ -400,9 +403,9 @@ Research phase in parallel, then a single implementation step that uses all resu
 ```mermaid
 flowchart TB
     subgraph PARALLEL[Phase 1: Research - parallel]
-        S1[Find files<br/>Explore]
-        S2[Check tests<br/>Explore]
-        S3[Read docs<br/>Explore]
+        S1[Find files<br/>code-navigator]
+        S2[Check tests<br/>code-navigator]
+        S3[Read docs<br/>code-navigator]
     end
 
     subgraph SEQUENTIAL[Phase 2: Act - sequential]
@@ -419,21 +422,21 @@ flowchart TB
 ```
 # Phase 1: Parallel research (all launch simultaneously)
 Agent(
-  subagent_type="Explore",
+  subagent_type="quiver:code-navigator",
   description="Find payment-related files",
   prompt="Find all files related to payment processing in this codebase. Include models, services, controllers, and config. For each file, report: path, line count, and a one-line summary of its purpose.",
   run_in_background=true
 )
 
 Agent(
-  subagent_type="Explore",
+  subagent_type="quiver:code-navigator",
   description="Check payment test coverage",
   prompt="Find all test files related to payment processing. For each, list: path, number of test cases, and what aspects of payment they test. Identify any payment flows that have NO test coverage.",
   run_in_background=true
 )
 
 Agent(
-  subagent_type="Explore",
+  subagent_type="quiver:code-navigator",
   description="Analyze payment error handling",
   prompt="In all payment-related files, analyze error handling patterns. Report: 1) Which errors are caught and handled, 2) Which error paths have no handling, 3) Whether failed payments are logged/tracked, 4) Whether users get meaningful error messages.",
   run_in_background=true
@@ -498,7 +501,7 @@ Agent(
 
 # After all workers complete, verify consistency
 Agent(
-  subagent_type="Explore",
+  subagent_type="quiver:code-navigator",
   description="Verify refactoring consistency",
   prompt="Check the authentication refactoring for consistency: 1) Does app/models/concerns/authenticatable.rb exist and define the expected methods? 2) Does user.rb include the concern? 3) Does sessions_controller use the concern's interface correctly? 4) Do all tests reference the correct method signatures? Report any mismatches between the interfaces."
 )
@@ -510,21 +513,21 @@ Start with a fast, cheap scan, then go deeper only where needed.
 
 ```mermaid
 flowchart TD
-    S1[Scan: Explore<br/>Quick overview] -->|identifies hotspots| S2[Deep dive: Explore<br/>Analyze hotspots only]
+    S1[Scan: code-navigator<br/>Quick overview] -->|identifies hotspots| S2[Deep dive: code-navigator<br/>Analyze hotspots only]
     S2 -->|finds issues| S3[Fix: general-purpose<br/>Targeted fixes]
 ```
 
 ```
 # Step 1: Fast broad scan
 Agent(
-  subagent_type="Explore",
+  subagent_type="quiver:code-navigator",
   description="Quick security scan",
   prompt="Do a quick scan of the entire codebase for obvious security issues. Check for: hardcoded secrets, SQL string concatenation, unescaped user input in HTML, eval() calls, and exposed debug endpoints. Report ONLY file paths and line numbers -- no detailed analysis yet."
 )
 
 # Step 2: Deep dive only on flagged files (uses Step 1 results)
 Agent(
-  subagent_type="Explore",
+  subagent_type="quiver:code-navigator",
   description="Deep security analysis of flagged files",
   prompt="Perform a detailed security analysis of these specific files flagged in the quick scan: [PASTE STEP 1 FILE LIST]. For each flagged location: 1) Confirm whether it's a real vulnerability or false positive, 2) Assess severity (critical/high/medium/low), 3) Describe the attack vector, 4) Suggest the specific fix. Ignore all other files."
 )
@@ -554,7 +557,7 @@ Status: completed | partial | failed
 
 Results:
   - Step 1: quiver:waste-detector -- Found 3 critical, 5 warning issues (success)
-  - Step 2: Explore -- Identified 12 untested files (success)
+  - Step 2: quiver:code-navigator -- Identified 12 untested files (success)
   - Step 3: general-purpose -- Implemented fixes for 3 critical issues (success)
   - Step 4: general-purpose -- All 47 tests passing, 0 lint errors (success)
 
@@ -620,7 +623,7 @@ For sequential pipeline steps, also include:
 | Agent type not found | Report which agent was missing. List available agents. Suggest `/quiver:create-agent` or a built-in fallback. |
 | Agent fails or times out | Retry once with the same parameters. If it fails again, log the error and continue with remaining steps. |
 | Agent returns empty/useless result | Do NOT retry the same prompt. Rephrase with more specific instructions, narrower scope, or a different agent type. |
-| Parallel agents produce conflicting edits | Detect file conflicts before reporting. If two agents edited the same file, use a final `Explore` agent to check consistency. |
+| Parallel agents produce conflicting edits | Detect file conflicts before reporting. If two agents edited the same file, use a final `quiver:code-navigator` agent to check consistency. |
 | All agents fail | Report `Status: failed` with per-step error details. Suggest the user run the subtasks manually. |
 
 ### Common Pitfalls
@@ -694,7 +697,7 @@ When running parallel agents that modify files, explicitly state which files eac
 
 ### Spawn a Subagent (Synchronous)
 ```
-Agent(subagent_type="Explore", description="Find auth files", prompt="...")
+Agent(subagent_type="quiver:code-navigator", description="Find auth files", prompt="...")
 ```
 
 ### Spawn a Subagent (Background/Parallel)
@@ -719,15 +722,15 @@ Agent(subagent_type="general-purpose", description="Experimental refactor", prom
 
 ### Parallel Fan-Out
 ```
-Agent(subagent_type="Explore", description="Task A", prompt="...", run_in_background=true)
-Agent(subagent_type="Explore", description="Task B", prompt="...", run_in_background=true)
-Agent(subagent_type="Explore", description="Task C", prompt="...", run_in_background=true)
+Agent(subagent_type="quiver:code-navigator", description="Task A", prompt="...", run_in_background=true)
+Agent(subagent_type="quiver:code-navigator", description="Task B", prompt="...", run_in_background=true)
+Agent(subagent_type="quiver:code-navigator", description="Task C", prompt="...", run_in_background=true)
 # All three run simultaneously
 ```
 
 ### Sequential Pipeline
 ```
-result1 = Agent(subagent_type="Explore", description="Research", prompt="...")
+result1 = Agent(subagent_type="quiver:code-navigator", description="Research", prompt="...")
 result2 = Agent(subagent_type="Plan", description="Design", prompt="Based on: [result1]...")
 Agent(subagent_type="general-purpose", description="Implement", prompt="Follow plan: [result2]...")
 ```

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -108,8 +108,7 @@ Before dispatching agents, detect navigation capabilities once.
 
    - If user accepts: provide installation instructions, re-probe, cache `lsp_confirmed` in project memory.
    - If user declines: cache `lsp_declined` in project memory.
-4. Set `lsp_available` to `true` or `false`. Pass this flag to all agents dispatched in Step 3.
-Pass both `codegraph_available` and `lsp_available` to all agents dispatched in Step 3.
+4. Set `lsp_available` to `true` or `false`. Pass both `codegraph_available` and `lsp_available` to all agents dispatched in Step 3.
 
 ## Step 3 -- Parallel Agent Dispatch
 

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -96,9 +96,13 @@ Discover available agents before dispatch:
 
 Agent identifiers use `quiver:{name}` for plugin agents, bare `{name}` for project/user agents.
 
-## Step 2.5 -- LSP Detection
+## Step 2.5 -- Navigation Detection
 
-Before dispatching agents, detect LSP availability once. Follow the detection flow from the `code-navigation` skill:
+Before dispatching agents, detect navigation capabilities once.
+
+**CodeGraph:** Check if `.codegraph/` exists at project root. Set `codegraph_available` to `true` or `false`. No user prompt.
+
+**LSP:** Follow the detection flow from the `code-navigation` skill:
 
 1. Check project memory for a cached LSP preference (`lsp_preference.md`). If `lsp_declined` or `lsp_confirmed` is found, use the cached value and skip to step 4.
 2. Attempt a lightweight LSP probe (e.g., `documentSymbol` on any source file from the project root).
@@ -110,6 +114,7 @@ Before dispatching agents, detect LSP availability once. Follow the detection fl
    - If user accepts: provide installation instructions, re-probe, cache `lsp_confirmed` in project memory.
    - If user declines: cache `lsp_declined` in project memory.
 4. Set `lsp_available` to `true` or `false`. Pass this flag to all agents dispatched in Step 3.
+Pass both `codegraph_available` and `lsp_available` to all agents dispatched in Step 3.
 
 ## Step 3 -- Parallel Agent Dispatch
 
@@ -125,23 +130,10 @@ Agent(
   description="Map codebase for planning: {short task summary}",
   prompt="Task: {full task description from Step 1}
 
+  codegraph_available: {true|false from Step 2.5}
   lsp_available: {true|false from Step 2.5}
 
-  ## Code Navigation Strategy
-
-  You have been provided an `lsp_available` flag above.
-
-  **When `lsp_available: true`:**
-  - For finding where a function/class/type is defined: use LSP goToDefinition first.
-  - For finding all callers or consumers of a symbol: use LSP findReferences first.
-  - For getting a structural overview of a file: use LSP documentSymbol first.
-  - If LSP returns empty or unhelpful results for any operation, inform the user:
-    'LSP returned no results for {operation} on `{symbol}` -- falling back to grep-based search.'
-    Then use Grep as fallback.
-  - For file discovery and pattern matching: always use Grep/Glob regardless of LSP availability.
-
-  **When `lsp_available: false`:**
-  - Use Grep, Glob, and Read for all code navigation.
+  Include the full Code Navigation Strategy block from `skills/code-navigation/SKILL.md` in this agent prompt, verbatim. The block starts at "## Code Navigation Strategy" and ends before the next `##` heading.
 
   ---
 
@@ -430,7 +422,8 @@ Handle each response:
 
 ## Anti-Patterns
 
-- **Don't** skip the confirmation gate -- always wait for user approval before saving.
+Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
+
 - **Don't** start writing implementation code -- this command plans only.
 - **Don't** run agents sequentially -- always dispatch independent agents in parallel (multiple Agent tool calls in one response).
 - **Don't** send vague prompts to agents -- every prompt must include the full task description, relevant file paths, and expected output format.
@@ -473,5 +466,5 @@ After saving the plan file:
 - [ ] Plan Guard Notes subsection appears in the plan's Context section only when NOTE findings exist.
 
 **Known gotchas:**
-- The Explore agent prompt embeds the full Code Navigation Strategy block; updates to that block must keep the skill body in sync with `skills/code-navigation/SKILL.md`.
+- The Explore agent prompt references the Code Navigation Strategy block from `skills/code-navigation/SKILL.md`; updates to that block must stay in sync.
 - `review_iteration` is determined by counting prior plans with the same `review_source` field; if naming conventions drift, the iteration count can desync.

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -418,12 +418,6 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 - **Don't** ignore agent findings -- if an agent flags a deprecation or boundary constraint, the plan must address it.
 - **Don't** create plans for tasks the user wants done immediately -- ask first.
 
-## Verification
-
-After saving the plan file:
-1. Read the file back to confirm contents.
-2. Confirm the plan directory exists and the file is listed.
-
 ---
 
 ## Test Plan

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -54,12 +54,7 @@ Otherwise:
    > Which authentication approach should the plan target?
    Buttons: `["OAuth2 (Google, GitHub)", "Email/password", "Magic links", "SSO/SAML", "Other (I'll describe)"]`
 
-   **Rules for clarifying questions:**
-   - Use `AskUserQuestion` with action buttons -- never ask clarifying questions as plain text.
-   - Derive button options from the codebase context and task domain -- do not use generic placeholders.
-   - Always include an "Other" free-text option as the last button.
-   - Ask at most ONE clarifying question. If the task is clear enough to proceed, skip this step.
-   - If the user picks "Other", accept their free-text response and continue.
+   **Rules:** Use `AskUserQuestion` with codebase-derived buttons (never plain text). Include "Other" as last option. At most ONE question -- skip if task is clear.
 
 4. **Assess complexity:**
 
@@ -258,14 +253,7 @@ If the Explore agent found an existing test framework, structure each task follo
 
 Not every task requires TDD (e.g., config changes, docs, migrations). Apply it to tasks that produce testable behavior.
 
-**No placeholders rule:**
-Every step must contain actionable content. These are plan failures -- never write them:
-- "TBD", "TODO", "implement later", "fill in details"
-- "Add appropriate error handling" / "add validation" / "handle edge cases"
-- "Write tests for the above" (without actual test code or at minimum the test scenario description)
-- "Similar to Task N" (repeat the relevant details -- the implementer may read tasks out of order)
-- Steps that describe what to do without showing how (include code blocks, commands, or exact file paths)
-- References to types, functions, or methods not defined in any task (if a step calls `processItems()`, some task must define it)
+**No placeholders rule:** Every step must have actionable content. Never write: "TBD"/"TODO"/"implement later", "add appropriate handling"/"handle edge cases", "similar to Task N" (repeat details), "write tests" without scenarios, steps without file paths or expected outcomes, references to undefined symbols.
 
 **Language rule:** Always write plan documents in English, regardless of the conversation language. Only write in another language if the user explicitly requests it.
 
@@ -467,10 +455,10 @@ After saving the plan file:
 - [ ] Review-fix detection produces frontmatter with `review_source` and `review_iteration`.
 - [ ] No raw `{placeholder}` strings remain in the saved plan.
 - [ ] The Step 7 and Step 8 user gates appear as `AskUserQuestion` calls, not plain-text prompts.
-- [ ] Step 6 runs 6 inline checks (placeholder, naming, spec coverage, granularity, reference validity, file map) on every plan.
-- [ ] Step 6.5 dispatches `plan-reviewer` agent only for Standard/Deep non-review-fix plans.
-- [ ] Light plans and review-fix plans skip Step 6.5 entirely.
+- [ ] Agent dispatch and Plan Guard checks execute correctly for Standard/Deep plans.
+- [ ] Step 6.5 agent dispatch follows skip conditions (Light and review-fix plans skip).
 - [ ] Plan Guard Notes subsection appears in the plan's Context section only when NOTE findings exist.
+- [ ] `codegraph_available` flag detected and passed to agents when `.codegraph/` exists.
 
 **Known gotchas:**
 - The Explore agent prompt embeds the full Code Navigation Strategy block; updates to that block must keep the skill body in sync with `skills/code-navigation/SKILL.md`.

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -60,9 +60,9 @@ Otherwise:
 
 | Complexity | Signals | Agents to Dispatch |
 |------------|---------|-------------------|
-| **Light** | 1-3 files, single layer, well-understood | Explore |
-| **Standard** | 3-10 files, 2+ layers, moderate unknowns | Explore + best-practices-researcher |
-| **Deep** | 10+ files, architectural impact, security/auth/payments, unfamiliar domain | Explore + best-practices-researcher + architecture-strategist |
+| **Light** | 1-3 files, single layer, well-understood | code-navigator |
+| **Standard** | 3-10 files, 2+ layers, moderate unknowns | code-navigator + best-practices-researcher |
+| **Deep** | 10+ files, architectural impact, security/auth/payments, unfamiliar domain | code-navigator + best-practices-researcher + architecture-strategist |
 
 If the task is trivial (single file, obvious change), use `AskUserQuestion`:
 > This task is straightforward enough to implement directly.
@@ -114,22 +114,18 @@ Before dispatching agents, detect navigation capabilities once.
 
 Spawn all qualifying agents simultaneously using multiple Agent tool calls in a single response. Every agent prompt must be **self-contained** -- agents have zero memory of this conversation.
 
-**Review-fix plans: reduced dispatch.** If Step 1 detected review-fix context, the review report already identified the problems and affected files. Skip best-practices-researcher and architecture-strategist -- they add no value when the scope is "fix these specific findings." Dispatch only the Explore agent to verify file paths and current patterns are still accurate.
+**Review-fix plans: reduced dispatch.** If Step 1 detected review-fix context, the review report already identified the problems and affected files. Skip best-practices-researcher and architecture-strategist -- they add no value when the scope is "fix these specific findings." Dispatch only the code-navigator agent to verify file paths and current patterns are still accurate.
 
-### Explore Agent (always dispatched)
+### code-navigator Agent (always dispatched)
 
 ```
 Agent(
-  subagent_type="Explore",
+  subagent_type="quiver:code-navigator",
   description="Map codebase for planning: {short task summary}",
   prompt="Task: {full task description from Step 1}
 
   codegraph_available: {true|false from Step 2.5}
   lsp_available: {true|false from Step 2.5}
-
-  Include the full Code Navigation Strategy block from `skills/code-navigation/SKILL.md` in this agent prompt, verbatim. The block starts at "## Code Navigation Strategy" and ends before the next `##` heading.
-
-  ---
 
   Search this codebase for all files related to this task. For each file found, report:
   1. File path
@@ -205,7 +201,7 @@ After **all** agents return, merge findings into a unified research brief:
 
 1. **Deduplicate** -- If multiple agents report the same file or pattern, keep the most detailed version.
 2. **Organize:**
-   - **Codebase context** (from Explore): affected files, current patterns, test coverage
+   - **Codebase context** (from code-navigator): affected files, current patterns, test coverage
    - **Best practices** (from best-practices-researcher): recommended approaches, deprecation alerts
    - **Architectural guidance** (from architecture-strategist): structural constraints, where new code belongs
 3. **Flag conflicts** -- If agents disagree (e.g., best practices suggest pattern A but existing architecture uses pattern B), surface both with trade-offs. Do not silently resolve.
@@ -230,12 +226,12 @@ Map out which files will be created, modified, or deleted. This locks in decompo
 **Task granularity:**
 - Each step: 2-10 minutes, independently verifiable
 - Pattern: what to do, which file(s), expected outcome
-- Include exact file paths from Explore findings
+- Include exact file paths from code-navigator findings
 - Incorporate best practices into step design
 - Respect architectural boundaries from architecture-strategist
 
 **TDD task structure (when the project has tests):**
-If the Explore agent found an existing test framework, structure each task following the TDD cycle:
+If the code-navigator agent found an existing test framework, structure each task following the TDD cycle:
 1. Write the failing test (show exact test code)
 2. Run the test -- confirm it fails with the expected error
 3. Write the minimal implementation to make it pass
@@ -251,7 +247,7 @@ Not every task requires TDD (e.g., config changes, docs, migrations). Apply it t
 **Research integration (mandatory):**
 - If best-practices-researcher flagged a deprecation, the plan must avoid the deprecated pattern
 - If architecture-strategist identified boundary constraints, steps must respect them
-- If Explore found existing test patterns, new test steps must follow them
+- If code-navigator found existing test patterns, new test steps must follow them
 - Attribute findings in Context section: "(from best-practices-researcher)", "(from architecture-strategist)"
 
 **Review-fix plan frontmatter (when review-fix context detected in Step 1):**
@@ -447,5 +443,5 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 - [ ] `codegraph_available` flag detected and passed to agents when `.codegraph/` exists.
 
 **Known gotchas:**
-- The Explore agent prompt references the Code Navigation Strategy block from `skills/code-navigation/SKILL.md`; updates to that block must stay in sync.
+- The code-navigator agent (`agents/research/code-navigator.md`) owns the Code Navigation Strategy. When updating the strategy in `skills/code-navigation/SKILL.md`, update the agent file too.
 - `review_iteration` is determined by counting prior plans with the same `review_source` field; if naming conventions drift, the iteration count can desync.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -151,9 +151,13 @@ Include risk signals if present: new dependencies, auth changes, secrets handlin
 
 ---
 
-## Step 1.75 -- LSP Detection
+## Step 1.75 -- Navigation Detection
 
-Before dispatching agents, detect LSP availability once. Follow the detection flow from the `code-navigation` skill:
+Before dispatching agents, detect navigation capabilities once.
+
+**CodeGraph:** Check if `.codegraph/` exists at project root. Set `codegraph_available` to `true` or `false`. No user prompt.
+
+**LSP:** Follow the detection flow from the `code-navigation` skill:
 
 1. Check project memory for a cached LSP preference (`lsp_preference.md`). If `lsp_declined` or `lsp_confirmed` is found, use the cached value and skip to step 4.
 2. Attempt a lightweight LSP probe (e.g., `documentSymbol` on any source file from the project root).
@@ -164,7 +168,7 @@ Before dispatching agents, detect LSP availability once. Follow the detection fl
 
    - If user accepts: provide installation instructions, re-probe, cache `lsp_confirmed` in project memory.
    - If user declines: cache `lsp_declined` in project memory.
-4. Set `lsp_available` to `true` or `false`. Pass this flag to agents that search the broader codebase (waste-detector, architecture-strategist) in Step 2.
+4. Set `lsp_available` to `true` or `false`. Pass both `codegraph_available` and `lsp_available` to agents that search the broader codebase (waste-detector, architecture-strategist, stress-tester, and project-context-analyst) in Step 2.
 
 ---
 
@@ -243,7 +247,7 @@ Each agent receives (in this order):
 5. The **full diff** from Step 1. For re-reviews, also include the delta diff (`git diff {previous_head_sha}...HEAD`).
 6. **File scope reminder**: "Review ALL file types in the diff regardless of language or type -- shell scripts, config files, CI configs, and build scripts deserve the same scrutiny as application source code."
 7. **Citation accuracy**: "Every file:line reference in your findings must be verified by reading the file. Do not cite line numbers from memory or inference -- use the Read tool to confirm the content at the cited line before including it in a finding."
-8. **LSP availability** (for waste-detector, architecture-strategist, stress-tester, and project-context-analyst): `lsp_available: {true|false}` from Step 1.75. These agents search the broader codebase and benefit from LSP-first navigation. Other agents are diff-scoped and do not need this flag.
+8. **Navigation availability** (for waste-detector, architecture-strategist, stress-tester, and project-context-analyst): `codegraph_available: {true|false}` and `lsp_available: {true|false}` from Step 1.75. These agents search the broader codebase and benefit from CodeGraph/LSP-first navigation. Other agents are diff-scoped and do not need these flags.
 9. **Scope discipline**: Aspirational improvements, stylistic preferences, "could be better" suggestions, and theoretical hardening are out of scope. Flag only concrete demonstrable problems with code that is wrong, unsafe, or broken as written. If the code works correctly as written and you would not fix it yourself, do not flag it. Zero findings is a correct and expected result on clean code. (This clause applies on every review. Re-review mode adds additional delta-specific scope on top of this general lock.)
 
 ### Adding future agents
@@ -662,7 +666,7 @@ If you need a concept that appears on this list and you cannot find a plain-Engl
 **Expected behavior:**
 1. Skill picks the first matching review mode (PR/MR URL, branch diff, uncommitted) and announces it.
 2. Skill builds the Diff Manifest (Step 1.5) classifying every changed file (`PROMPT`, `SCRIPT`, `CONFIG-APP`, `CONFIG-MANIFEST`, `CODE`, `DOCS`).
-3. Skill runs LSP detection (Step 1.75) and dispatches all qualifying agents in a single response (parallel) with the agent context including Diff Manifest, scope reminders, and `lsp_available`.
+3. Skill runs navigation detection (Step 1.75) and dispatches all qualifying agents in a single response (parallel) with the agent context including Diff Manifest, scope reminders, `codegraph_available`, and `lsp_available`.
 4. Skill detects existing review reports for the same branch and switches to re-review mode with delta-only scope when a previous report is found.
 5. Skill synthesizes findings (deduplicate, subsumption, severity normalization, false-positive filters, proportional floor) and writes `review-<timestamp>.md` to the configured output directory; with `--terminal`, prints inline instead.
 6. Skill optionally posts the report as a PR comment when `--comment-pr` is set or the user opts in interactively.

--- a/skills/senior-review/SKILL.md
+++ b/skills/senior-review/SKILL.md
@@ -66,10 +66,7 @@ Parse `$ARGUMENTS`:
 
 If source was set from Step 1 (PR number or URL), skip to Step 3.
 
-If source is unset, infer from conversation context before prompting:
-- User's message mentions current changes, uncommitted work, a fix they just made, or asks to review "this" without specifying a PR --> source = `uncommitted`. If uncommitted diff is empty, fall back to `branch`.
-- User's message mentions a branch, branch diff, or comparing against main/master --> source = `branch`.
-- If intent is clear from context, skip the prompt and go to Step 3.
+If source is unset, infer from context: "this"/"my changes"/"just made" --> `uncommitted`; "branch"/"vs main" --> `branch`. If clear, skip prompt.
 
 Only if intent cannot be inferred, use `AskUserQuestion`:
 
@@ -87,73 +84,19 @@ If user selects "Pull Request" and no PR number was provided, ask:
 
 ## Step 3 -- Diff Gathering
 
-Gather the diff based on selected source:
+| Source | Command | Notes |
+|--------|---------|-------|
+| `uncommitted` | `git diff` + `git diff --staged` | Combine both; stop if both empty: "No uncommitted changes found." |
+| `branch` | `git rev-parse --verify main` then `git diff main...HEAD` | Fall back to `master` if `main` missing; stop if empty: "No changes found between current branch and base branch." |
+| `pr` | `gh pr diff <pr_number_or_url>` via Bash tool (not `!` block) | Stop if `gh` fails: "Could not fetch PR diff. Ensure `gh` CLI is installed and authenticated." |
 
-**Uncommitted changes:**
-```
-!`git diff 2>/dev/null || echo "NO_DIFF"`
-```
-```
-!`git diff --staged 2>/dev/null || echo "NO_DIFF"`
-```
-
-Combine both outputs. If both are empty, print:
-> No uncommitted changes found.
-**Stop here.**
-
-**Branch diff:**
-Determine the base branch:
-```
-!`git rev-parse --verify main 2>/dev/null || echo "NO_MAIN"`
-```
-
-Use `main` if it exists, otherwise `master`. Then gather:
-```
-!`git diff main...HEAD 2>/dev/null || echo "NO_DIFF"`
-```
-
-If empty, print:
-> No changes found between current branch and base branch.
-**Stop here.**
-
-**Pull Request:**
-Use the Bash tool to fetch the PR diff at runtime (do NOT use a `!` shell block -- the PR number is only known after argument parsing):
-
-```
-gh pr diff <pr_number_or_url> 2>&1
-```
-
-If `gh` is not available or the command fails, print:
-> Could not fetch PR diff. Ensure `gh` CLI is installed and authenticated.
-**Stop here.**
-
-Also gather the changed file list:
-```
-!`git diff --name-only main...HEAD 2>/dev/null || echo "NO_FILES"`
-```
-
-(For PR source, use `gh pr diff --name-only` if available, otherwise parse the diff headers.)
+Also gather the file list: `git diff --name-only main...HEAD` (for PR source, use `gh pr diff --name-only` or parse diff headers).
 
 ---
 
 ## Step 4 -- Language Detection
 
-Scan changed file extensions from the file list gathered in Step 3.
-
-| Extensions | Primary Language |
-|---|---|
-| `.swift` | Swift/iOS |
-| `.dart` | Flutter/Dart |
-| `.ts`, `.tsx` | TypeScript/React |
-| `.py` | Python |
-| `.kt` | Kotlin/Android |
-| `.js`, `.jsx` | JavaScript/React |
-| `.go` | Go |
-| `.rs` | Rust |
-
-If multiple languages detected, note all of them. The agent handles mixed diffs gracefully.
-
-If no recognized extensions, set language to `unknown`.
+Language detection is handled by the senior-reviewer agent.
 
 ---
 
@@ -161,16 +104,7 @@ If no recognized extensions, set language to `unknown`.
 
 If mode is `quick`, skip this step entirely.
 
-For the detected primary language/framework, query context7 MCP for current conventions:
-
-- **Swift/iOS:** Query for SwiftUI or UIKit conventions based on imports in the diff
-- **Flutter/Dart:** Query for Flutter widget patterns and Dart idioms
-- **TypeScript/React:** Query for React hooks rules and TypeScript strict mode patterns
-- **Other languages:** Query for the framework detected from imports
-
-Limit to one query for the primary language. Do not query for every language in a mixed diff.
-
-If context7 is unavailable or returns no results, proceed without it -- the agent has built-in criteria.
+For the detected primary language, query context7 for current conventions. One query, primary language only. Skip if quick mode or context7 unavailable.
 
 ---
 
@@ -207,33 +141,23 @@ Buttons:
 
 **Trigger:** `/senior-review` (and `/quiver:senior-review`)
 
-**Setup:**
-- Current directory is a git repo with changes (uncommitted or on a branch).
-- `gh` CLI available for PR mode testing.
+**Setup:** Git repo with uncommitted changes or a branch diff; `gh` CLI available for PR mode.
 
 **Expected behavior:**
 1. Shell blocks gather git context without errors.
-2. `--quick` flag is parsed and sets mode before diff gathering.
-3. `#NNN` argument triggers PR mode directly without source selection prompt.
-4. Empty arguments with no context prints usage and stops.
-5. Diff source selection offers three buttons via AskUserQuestion.
-6. Language detection maps file extensions correctly.
-7. Context7 lookup runs in full mode, skipped in quick mode.
-8. Agent dispatch includes all required context items in order.
-9. Pipeline context is never passed in standalone mode (Phase 5 stays inactive).
-10. Save report option writes with correct timestamp filename format.
+2. `--quick` sets mode and skips context7; `#NNN`/PR URL triggers PR mode directly.
+3. Empty arguments with no context prints usage and stops.
+4. Diff source selection shows three buttons via AskUserQuestion.
+5. Agent dispatch includes all required context items; no pipeline context passed.
+6. Save report writes with correct timestamp filename format.
 
 **Verification checklist:**
 - [ ] Slash menu shows `/senior-review`.
-- [ ] `--quick` mode skips context7 lookup and runs single-pass.
-- [ ] PR mode works with `#123` syntax and full URL syntax.
-- [ ] No shell logic in `!` blocks (no `$()`, no `if/else`, no variable assignment).
-- [ ] All shell blocks exit 0 even when targets do not exist.
+- [ ] `--quick` skips context7 and runs single-pass; `#123` and full URL both trigger PR mode.
+- [ ] No shell logic in `!` blocks; all shell blocks exit 0.
 - [ ] AskUserQuestion used for diff source selection and post-review action.
-- [ ] Agent dispatch does NOT include pipeline context.
-- [ ] Report save path uses correct timestamp format.
+- [ ] Agent dispatch does NOT include pipeline context; report path uses correct timestamp format.
 
 **Known gotchas:**
-- `gh pr diff` requires authentication. If `gh` fails, the skill stops with a clear message rather than proceeding with an empty diff.
-- Context7 MCP may be unavailable in some environments. The skill degrades gracefully -- the agent has built-in per-language criteria.
-- The `--quick` flag must be stripped from arguments before PR number parsing to avoid misinterpretation.
+- `gh pr diff` requires authentication; skill stops with a clear message on failure rather than continuing with an empty diff.
+- Context7 may be unavailable; skill degrades gracefully. Strip `--quick` before PR number parsing to avoid misinterpretation.

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -36,23 +36,18 @@ Execute a work plan, specification, or task list systematically. The focus is on
 
 Treat empty Glob results as "no plans found". Proceed regardless.
 
----
-
-## When to Use
-
-- A plan file exists in `.claude/plans/` (created by `/quiver:plan`)
-- The user provides a specification, todo file, or task list to execute
-- The user says "execute", "build this", "implement the plan", or "work on this"
-
-## When NOT to Use
-
-- The task needs planning first -- use `/quiver:plan` instead
-- The task is a single-file edit that needs no coordination
-- The user wants a code review -- use `/quiver:review`
+**Use when:** a plan file exists, the user provides a spec or task list, or the user says "execute", "build this", "implement the plan". Use `/quiver:plan` first if no plan exists yet. Use `/quiver:review` for code review.
 
 ---
 
 ## Workflow
+
+```
++----------+     +---------+     +---------+     +---------+     +--------+
+| 1. LOAD  | --> | 2. SETUP| --> | 3. BUILD| --> | 4. CHECK| --> | 5. SHIP|
+| Read plan|     | Branch  |     | Execute |     | Quality |     | PR     |
++----------+     +---------+     +---------+     +---------+     +--------+
+```
 
 ### Phase 0: Git Availability
 
@@ -64,13 +59,40 @@ Proceed to Phase 1. Treat all git-sourced fields (branch, log, diff, status) as 
 
 #### 1a -- Load the plan
 
-| Input | Action |
-|-------|--------|
-| **Path** (`$ARGUMENTS` ends in `.md` or contains `/`) | Read the file. Print `> Executing plan: {filename} ({step count} steps) on branch {branch}`. Proceed to 1b. |
-| **Empty** (`$ARGUMENTS` is empty) | Collect `.md` files from all discovered `plans/` directories. If 1 plan: `AskUserQuestion` with `["Execute this plan", "Other"]`. If multiple: present as buttons (most recent first, show directory). If none: print usage and **stop**. |
-| **Name/description** | Match against plan filenames (exact > partial, case-insensitive). 1 match: read and proceed. Multiple: `AskUserQuestion` with candidates + "None of these". 0 matches: treat as inline task description. |
+**Case A: Path provided.** If `$ARGUMENTS` is a file path (ends in `.md` or contains `/`):
+- Read that file as the work plan.
+- Print: `> Executing plan: {plan filename} ({step count} steps) on branch {branch}`
+- Proceed directly to Phase 1b. The user chose this plan explicitly -- no confirmation needed.
 
-If user picks "Other" or "None of these", ask for a path or task description.
+**Case B: No arguments.** If `$ARGUMENTS` is empty, collect all `.md` files from every `plans/` directory discovered by the Glob block above, plus the `.claude/plans/` listing.
+
+- If exactly one plan exists across all directories, read it and use `AskUserQuestion`:
+  > Found one plan: `{relative path}` (in `{directory}`)
+  > **Goal:** {goal from plan}
+  > **Steps:** {step count}
+  Buttons: `["Execute this plan", "Other -- I'll provide a path or description"]`
+- If multiple plans exist, present them via `AskUserQuestion` with full relative paths as buttons (most recent first), plus an `"Other -- I'll provide a path or description"` option. Show the directory in each label so the user can distinguish plans in different locations.
+- If the user picks "Other", ask for a path or task description.
+
+If no plans found:
+> No plans found in any `plans/` directory. Usage:
+> - `/work <path-to-plan.md>` -- execute a specific plan
+> - `/work <plan-name>` -- search for a plan by name
+> - `/work <task description>` -- work on a task directly
+> - `/plan <task>` -- create a plan first
+
+**Stop here.**
+
+**Case C: Name or description provided.** If `$ARGUMENTS` is not a file path and is not empty:
+
+1. **Discover plan files.** Read every `plans/` directory discovered by the Glob block. Combine with `.claude/plans/` listing.
+2. **Match by filename.** Compare `$ARGUMENTS` against each plan file's stem (without `.md` extension):
+   - **Exact match:** stem equals `$ARGUMENTS` (case-insensitive).
+   - **Partial match:** stem contains `$ARGUMENTS` as a substring (case-insensitive).
+3. **Rank and select.** Rank exact matches above partial matches.
+   - **1 match** -- Read the plan file, print `> Executing plan: {filename} from {directory}`, proceed to Phase 1b. No confirmation needed.
+   - **Multiple matches** -- Use `AskUserQuestion` to present candidates with full relative paths as button labels. Add a `"None of these -- treat as task description"` button.
+   - **0 matches** -- Treat `$ARGUMENTS` as an inline task description. Print `> No matching plan found for "{$ARGUMENTS}". Treating as task description.` Proceed to Phase 1b with the description as the work specification.
 
 #### 1b -- Review references
 
@@ -78,10 +100,12 @@ If the plan links to files, patterns, or prior research -- read those now. Under
 
 #### 1c -- Detect review-fix plan
 
-1. Check plan YAML frontmatter for `review_source` field.
-2. Fallback: scan plan content for paths matching `.claude/reports/review-*.md`.
-3. If detected: read the review report. Note as review-fix plan. Carry findings to Phase 4.
-4. Read `review_iteration` from frontmatter (default: 1). If >= 2: final iteration -- Phase 4c only, skip Phase 4d.
+Check if this is a plan created to address review findings:
+- **Primary**: Check plan YAML frontmatter for a `review_source` field (e.g., `review_source: .claude/reports/review-2026-03-10_14-30-00.md`).
+- **Fallback**: Scan plan content for paths matching `.claude/reports/review-*.md` or `review-*_*-*-*.md`.
+- If detected, read the review report file. If the file exists, note this as a **review-fix plan** and carry the parsed findings forward to Phase 4. If the file does not exist, warn: "Review report not found at {path}. Proceeding without review-aware verification."
+- If no review reference detected, proceed normally.
+- **Iteration tracking**: Read the plan's `review_iteration` frontmatter field (default: `1` if absent). If `review_iteration >= 2`, this is the **final iteration** -- Phase 4c verification is the only quality gate, and Phase 4d agent review is skipped unconditionally.
 
 #### 1d -- Flag ambiguities
 
@@ -97,103 +121,31 @@ If the plan contains genuine contradictions (e.g., two steps that conflict, a re
 
 **If git is NOT available (Phase 0 detected `NO_GIT`):** Skip this phase entirely -- proceed to Phase 2.5.
 
-Check the current branch:
+**If already on a feature branch** (not main/master), use `AskUserQuestion`:
+> You're on `{branch}`. Continue here or create a new branch?
+Buttons: `["Continue on {branch}", "Create new branch"]`
+If continuing, move to Phase 2.5.
 
-```bash
-git branch --show-current
-```
-
-**If already on a feature branch** (not main/master):
-- Use `AskUserQuestion`:
-  > You're on `{branch}`. Continue here or create a new branch?
-  Buttons: `["Continue on {branch}", "Create new branch"]`
-- If continuing, move to Phase 2.5.
-
-**If on the default branch**, choose how to proceed:
-
-| Option | When to use |
-|--------|-------------|
-| **New branch** | Default. `git checkout -b <meaningful-name>` from latest default branch. |
-| **Worktree** | Parallel development or keeping default branch workspace clean. Use the `using-git-worktrees` skill if available. |
-| **Stay on default** | Only with explicit user confirmation. Never commit to default branch without permission. |
-
-Use a descriptive branch name based on the task (e.g., `feat/user-auth`, `fix/email-validation`).
+**If on the default branch**, create a new branch by default: `git checkout -b <meaningful-name>` using a descriptive name (e.g., `feat/user-auth`, `fix/email-validation`). For parallel development, use the `using-git-worktrees` skill. Never commit to the default branch without explicit user confirmation.
 
 ### Phase 2.5: Orchestration Decision
 
-After setting up the environment, determine the execution strategy.
-
-1. **Count tasks.** Parse the plan and count top-level work units. A "task" is any top-level section that describes a discrete, independently completable piece of work -- regardless of heading format or label. Plans from other tools (e.g., superpowers, ce-plan, custom specs) use varied formats: numbered steps, heading sections, YAML lists, or markdown checklists. Count by semantic intent (one deliverable = one task), not by a specific markup convention.
-
-2. **Announce the decision** to the user before proceeding:
-
+Parse the plan and count top-level tasks (one deliverable = one task, regardless of markup format). Announce before proceeding:
 ```
 Strategy: {sequential | parallel orchestration} ({N} tasks found)
-Reason: {why -- e.g., "2 tasks, below parallel threshold" or "4 tasks with 2 independent groups"}
+Reason: {why}
 ```
 
-3. **Route by count:**
-
-| Task Count | Strategy | Action |
-|------------|----------|--------|
-| **1-2** | Sequential | Proceed to Phase 3 (Build) as normal. No subagents. |
-| **3+** | Parallel orchestration | Follow the orchestration procedure below. Skip Phase 3 entirely -- orchestration replaces it. |
-
-4. **For 3+ tasks -- orchestration procedure:**
-   Follow `skills/work/orchestrator.md` for the full procedure. In brief: parse tasks,
-   resolve dependencies (explicit + file overlap), report the execution plan, dispatch
-   one worktree-isolated subagent per task, collect results, merge in topological order,
-   run post-merge tests, then proceed to Phase 4.
+- **1-2 tasks:** Sequential. Proceed to Phase 3.
+- **3+ tasks:** Parallel orchestration. Follow `skills/work/orchestrator.md`. Skip Phase 3 entirely -- orchestration replaces it.
 
 ### Phase 3: Build
 
-#### 3a -- Create task list
+Break the plan into TodoWrite tasks (specific, dependency-ordered, with testing tasks included). For each task: mark `in_progress`, read referenced files, match existing patterns, implement, run tests immediately (fix failures before moving on), mark `completed`, update plan checkboxes if present.
 
-Break the plan into actionable tasks using TodoWrite. Each task should be:
-- Specific and completable (not "refactor everything")
-- Ordered by dependency (what must come first)
-- Include testing tasks alongside implementation tasks
+**Commits:** After each logical unit, commit if tests pass and the change is meaningful (`git add <specific files>` -- never `git add .`). Wait if tests fail or the message would say "WIP". Heuristic: "Can I write a message describing a complete, valuable change?"
 
-#### 3b -- Task execution loop
-
-For each task in priority order:
-
-1. Mark the task as `in_progress` in TodoWrite.
-2. Read any files referenced by the task.
-3. Look for similar patterns in the codebase -- match existing conventions exactly.
-4. Implement the change.
-5. Run relevant tests after the change. Fix failures immediately -- do not accumulate broken tests.
-6. Mark the task as `completed` in TodoWrite.
-7. If the plan document has checkboxes, update `- [ ]` to `- [x]` for the completed item.
-8. Evaluate whether to commit (see incremental commits below).
-
-#### 3c -- Incremental commits
-
-After completing each task, decide whether to create a commit:
-
-| Commit when... | Wait when... |
-|----------------|-------------|
-| A logical unit is complete (model, service, component) | Only a partial unit is done |
-| Tests pass and the change is meaningful | Tests are failing |
-| Switching contexts (backend to frontend, model to controller) | Change is pure scaffolding with no behavior |
-| About to attempt risky or uncertain changes | Commit message would be "WIP" |
-
-**Heuristic:** "Can I write a commit message that describes a complete, valuable change?" If yes, commit. If the message would say "WIP" or "partial", wait.
-
-```
-git add <specific files for this logical unit>
-git commit -m "feat(scope): description of this unit"
-```
-
-Stage specific files -- avoid `git add .` to prevent accidental inclusions.
-
-#### 3d -- Handling blockers
-
-If you encounter a blocker (missing dependency, unclear requirement, failing infrastructure):
-- **Stop immediately.** Do not guess or force through.
-- Note the blocker in TodoWrite.
-- Ask the user for clarification or guidance.
-- Do not proceed past the blocked step until resolved.
+**Blockers:** Stop immediately. Note in TodoWrite. Ask the user. Do not proceed until resolved.
 
 ### Phase 4: Quality Check
 
@@ -205,6 +157,11 @@ Before shipping, verify the work meets standards.
 2. **Linting passes.** Run the project's lint command if one exists.
 3. **All TodoWrite tasks marked completed.** No tasks left in progress.
 4. **Code follows existing patterns.** No new conventions introduced unless the plan explicitly called for them.
+5. **No uncommitted changes** that belong to this work.
+6. **Plan checkboxes updated** (if applicable).
+7. **Post-merge test suite passes** (when orchestration was used); all worktree branches merged with no unresolved conflicts.
+
+**These are BLOCKING -- fix all before proceeding to Phase 5.**
 
 #### 4b -- System-wide impact check
 
@@ -217,7 +174,9 @@ For non-trivial changes, pause and consider:
 | Can failure leave orphaned state? | If state is persisted before an external call, test the failure path. |
 | What other interfaces expose this? | Grep for the method/behavior in related classes. Add parity if needed. |
 
-**Skip this check when:** task count <= 2 AND total modified files <= 3. These thresholds identify leaf-node changes where two-level-out tracing reads irrelevant files. When either threshold is exceeded, run the full check.
+**Skip this check for:** leaf-node changes with no callbacks, no state persistence, no parallel interfaces. Purely additive changes (new helper, new partial) need only a quick scan.
+
+**WARNING (review but do not block):** linting warnings present; no integration tests for changes touching callbacks or middleware; plan acceptance criteria not explicitly verified (NOTE: for review-fix plans, acceptance criteria are BLOCKING per Phase 4c step 6).
 
 #### 4c -- Review finding verification (review-fix plans only)
 
@@ -225,57 +184,29 @@ If Phase 1 identified this as a review-fix plan and the review report was succes
 
 1. **Parse findings.** Extract all non-filtered findings from the review report, grouped by severity (Critical, High, Medium, Low). Skip the `## Filtered Findings` section entirely.
 
-2. **Map findings to plan steps.** For each finding, identify whether the plan had a corresponding task:
-   - Match by file path referenced in the finding against files mentioned in plan steps.
-   - Match by finding title/description against plan step descriptions.
-   - Findings with no matching plan step are marked "Not in scope."
+2. **Map findings to plan steps.** Match each finding to a plan task by file path or title/description. Findings with no matching plan step are marked "Not in scope."
 
-3. **Check addressed status.** For each in-scope finding:
-   - Verify the referenced file was modified (check `git diff` for changes to that file).
-   - Verify the corresponding TodoWrite task is marked `completed`.
-   - If both conditions met: mark as **Addressed**.
-   - If file not modified or task incomplete: mark as **Not addressed**.
+3. **Check addressed status.** For each in-scope finding, verify the referenced file was modified (`git diff`) and the corresponding TodoWrite task is `completed`. Both conditions met = **Addressed**; otherwise = **Not addressed**.
 
 4. **Cross-reference check.** Flag when a file modified to fix finding A is also referenced by finding B (potential regression area). Present these as notes, not blockers.
 
-5. **Present verification summary:**
-
-   ```
-   ## Review Finding Verification
-   | ID | Severity | Finding | Status | Notes |
-   |----|----------|---------|--------|-------|
-   | C1 | Critical | SQL injection in auth.py:42 | Addressed | File modified, task completed |
-   | H1 | High     | Missing input validation | Addressed | File modified, task completed |
-   | M1 | Medium   | Inconsistent error handling | Not in scope | No plan step for this finding |
-   | L1 | Low      | Naming convention | Not addressed | File not modified |
-   ```
-
-6. **Apply gates:**
-   - **BLOCKING**: Any Critical finding marked "Not addressed" (in-scope but not fixed). Use `AskUserQuestion`:
+5. **Present verification summary** as a table with columns: ID, Severity, Finding, Status, Notes. Then apply gates:
+   - **BLOCKING**: Any Critical finding marked "Not addressed." Use `AskUserQuestion`:
      > Critical review finding not addressed: {finding title}
      > Original finding: {finding text}
      Buttons: `["I've verified this is fixed", "Fix it now", "Skip -- not applicable"]`
-   - **WARNING**: Any High/Medium/Low finding marked "Not addressed" (in-scope but not fixed). List in summary but do not block.
+   - **WARNING**: Any High/Medium/Low finding marked "Not addressed." List in summary but do not block.
    - **INFO**: Findings marked "Not in scope." Listed for awareness only.
 
-7. **Acceptance criteria check.** If the plan has an `Acceptance Criteria` section, verify each criterion:
-   - For each criterion, check whether the implementation satisfies it (file exists, test passes, pattern applied, etc.).
-   - Mark each as **Met** or **Not met** in the verification summary.
-   - All criteria must be **Met** to proceed to Phase 5. If any are **Not met**, use `AskUserQuestion`:
-     > Acceptance criterion not met: {criterion text}
-     Buttons: `["Fix it now", "Skip -- criterion is outdated", "Mark as met (I've verified manually)"]`
+6. **Acceptance criteria check.** If the plan has an `Acceptance Criteria` section, mark each criterion as **Met** or **Not met**. If any are **Not met**, use `AskUserQuestion`:
+   > Acceptance criterion not met: {criterion text}
+   Buttons: `["Fix it now", "Skip -- criterion is outdated", "Mark as met (I've verified manually)"]`
+   All criteria must be **Met** to proceed to Phase 5.
 
-8. **Convergence verdict.** After gates and acceptance criteria:
-   - If all in-scope findings are **Addressed** AND all acceptance criteria are **Met**: the review-fix cycle is **COMPLETE**. Proceed to Phase 5. Do NOT trigger another review.
-   - If `review_iteration >= 2`: the cycle is **COMPLETE** regardless of remaining Low/Medium warnings. Only unaddressed Critical findings can block. Proceed to Phase 5.
-   - Present the convergence status:
-     ```
-     ## Review-Fix Cycle Status
-     Iteration: {review_iteration} of 2 (max)
-     Findings addressed: {addressed}/{total_in_scope}
-     Acceptance criteria met: {met}/{total_criteria}
-     Status: COMPLETE -- ready to ship
-     ```
+7. **Convergence verdict.** If all in-scope findings are **Addressed** AND all acceptance criteria are **Met**, the review-fix cycle is **COMPLETE** -- proceed to Phase 5, do NOT trigger another review. If `review_iteration >= 2`, the cycle is **COMPLETE** regardless of remaining Low/Medium warnings; only unaddressed Critical findings can block. Print:
+   ```
+   Review-Fix Cycle Status: Iteration {review_iteration} | Findings {addressed}/{total_in_scope} | Criteria {met}/{total_criteria} | COMPLETE
+   ```
 
 <!-- SYNC: This verification parses the report format defined in skills/review/SKILL.md:367 (Synthesized report structure section). If the report structure changes, update the parsing logic here. New sections (What's Working Well, Recommended Fix Order, Senior Assessment) are additive and do not affect this parsing. -->
 
@@ -296,28 +227,20 @@ For **non-review-fix plans** with large, risky, or security-sensitive changes, c
 
 **CRITICAL: Every git action in this phase requires explicit user confirmation via `AskUserQuestion`. NEVER commit, push, or create a PR without asking first.**
 
-**NO ATTRIBUTION: Do not add `Co-Authored-By`, `Generated with Claude`, `Built with AI`, or any similar attribution lines to commit messages or PR descriptions. Keep them clean. Only add attribution if the user explicitly requests it.**
+**NO ATTRIBUTION: Do not add `Co-Authored-By`, `Generated with Claude`, `Built with AI`, or any similar attribution lines to commit messages or PR descriptions. Only add attribution if the user explicitly requests it.**
 
 #### 5a -- Final commit
 
-If there are uncommitted changes after Phase 4:
-
-1. Stage the relevant files (specific files only -- never `git add .`).
-
-2. Delegate to `/quiver:commit`. This skill generates a Conventional Commits message, presents it to the user via `AskUserQuestion` with Commit / Commit & Push / Edit / Cancel options, and only executes after the user explicitly chooses. It handles the full commit (and optional push) flow with built-in confirmation.
-
-3. If the user cancelled the commit, respect that -- do not re-ask or proceed to 5b.
+If there are uncommitted changes after Phase 4, stage the relevant files (specific files only -- never `git add .`) then delegate to `/quiver:commit`. If the user cancels, do not re-ask or proceed to 5b.
 
 #### 5b -- Create PR
 
-After committing (or if all commits were already made during Phase 3), ask the user what to do next. Do NOT push or create a PR without asking.
+After committing (or if all commits were already made during Phase 3), use `AskUserQuestion`:
+> All work is committed on `{branch_name}`. What would you like to do next?
+Buttons: `["Create a pull request", "Done -- I'll handle the rest"]`
 
-1. Use `AskUserQuestion`:
-   > All work is committed on `{branch_name}`. What would you like to do next?
-   Buttons: `["Create a pull request", "Done -- I'll handle the rest"]`
-
-   - **Create a pull request** -- delegate to `/quiver:create-pr`. It handles push, title generation, body formatting, and confirmation.
-   - **Done** -- stop here. Move to 5c.
+- **Create a pull request** -- delegate to `/quiver:create-pr`.
+- **Done** -- stop here. Move to 5c.
 
 #### 5c -- Update plan status
 
@@ -337,38 +260,22 @@ Summarize:
 
 ## Anti-Patterns
 
-Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
-
 - **Don't** skip Phase 1 clarification -- ask now, not after building the wrong thing.
 - **Don't** ignore plan references -- the plan has file paths and pattern links for a reason.
 - **Don't** save all testing for the end -- test continuously or suffer compounding failures.
+- **Don't** use `git add .` -- stage specific files to avoid accidental inclusions.
 - **Don't** commit with "WIP" messages -- wait until a logical unit is complete.
 - **Don't** force through blockers -- stop, note the issue, ask the user.
 - **Don't** over-review simple changes -- save agent reviews for genuinely complex or risky work.
 - **Don't** leave TodoWrite tasks unfinished -- track progress or lose track of what is done.
 - **Don't** move on at 80% -- finish the feature before starting something new.
+- **Don't** commit directly to the default branch without explicit user permission.
+- **Don't** commit, push, or create a PR without asking the user first via `AskUserQuestion` -- every git action in Phase 5 requires explicit confirmation.
+- **Don't** add AI attribution to commits or PRs (`Co-Authored-By`, `Generated with Claude`, etc.) unless the user explicitly asks for it.
 - **Don't** trigger another review cycle after completing a review-fix plan -- Phase 4c verification is the terminal quality gate. Dispatching review agents on review-fix work creates infinite loops.
 - **Don't** spawn subagents for 1-2 task plans -- the overhead exceeds the benefit. Use sequential execution.
-- **Don't** skip dependency resolution -- always check both explicit `blockedBy` and file overlap before dispatching parallel agents.
+- **Don't** skip dependency resolution -- check both explicit `blockedBy` and file overlap before dispatching parallel agents; stop dispatching dependent tasks when a dependency fails.
 - **Don't** attempt automatic merge conflict resolution -- report conflicts to the user and stop.
-- **Don't** continue dispatching dependent tasks when a dependency has failed or is blocked.
-
----
-
-## Quality Gates
-
-**BLOCKING** (fix before shipping):
-- All tests pass
-- All TodoWrite tasks completed
-- No uncommitted changes that belong to this work
-- Plan checkboxes updated (if applicable)
-- Post-merge test suite passes (when orchestration was used)
-- All worktree branches merged successfully (no unresolved conflicts)
-
-**WARNING** (review but do not block):
-- Linting warnings present
-- No integration tests for changes that touch callbacks or middleware
-- Plan had acceptance criteria that were not explicitly verified (NOTE: for review-fix plans, acceptance criteria are BLOCKING per Phase 4c step 7)
 
 ---
 
@@ -376,27 +283,24 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 
 **Trigger:** `/work [plan-path | plan-name | task description]` (and `/quiver:work` should also work)
 
-**Setup:**
-- Current directory is a git repo with at least one plan in `.claude/plans/` or a related `plans/` directory.
-- For the review-fix path: a plan with `review_source` frontmatter pointing at an existing `.claude/reports/review-*.md` file.
+**Setup:** Git repo with at least one plan in `.claude/plans/` or a `plans/` directory. For the review-fix path: a plan with `review_source` frontmatter pointing at an existing `.claude/reports/review-*.md` file.
 
 **Expected behavior:**
-1. Skill runs the four git shell blocks plus the silent Glob over `.claude/plans/` and `**/plans/*.md`.
-2. Phase 1 loads the plan via Case A (path), Case B (no args), or Case C (name match), printing the executing-plan banner before proceeding.
-3. Phase 0 NO_GIT handling skips branch creation, commits, and PR steps cleanly when the directory is not a git repo.
-4. Phase 2.5 announces `Strategy: sequential` for 1-2 tasks or `parallel orchestration` for 3+ tasks before continuing.
-5. For review-fix plans, Phase 4c parses the report's findings (skipping `## Filtered Findings`), runs the verification table, applies the BLOCKING/WARNING gates, and prints the convergence verdict; Phase 4d is skipped automatically.
-6. Phase 5 delegates commit and PR creation to `/quiver:commit` and `/quiver:create-pr`, gating each git action with `AskUserQuestion` and never adding AI attribution.
+1. Skill runs four git shell blocks plus the silent Glob over `.claude/plans/` and `**/plans/*.md`.
+2. Phase 1 loads the plan via Case A/B/C, printing the executing-plan banner before proceeding.
+3. Phase 0 NO_GIT handling skips branch creation, commits, and PR steps cleanly.
+4. Phase 2.5 announces the strategy (sequential or parallel) and task count before continuing.
+5. For review-fix plans, Phase 4c parses findings, applies BLOCKING/WARNING gates, and prints the convergence verdict; Phase 4d is skipped automatically.
+6. Phase 5 delegates to `/quiver:commit` and `/quiver:create-pr`, gating each action with `AskUserQuestion`.
 
 **Verification checklist:**
-- [ ] Slash menu shows `/work`.
-- [ ] Plan banner is printed before any code changes (`> Executing plan: <name>`).
-- [ ] Orchestration decision appears for every plan; non-git directories skip branch/commit/PR steps.
-- [ ] Review-fix plans produce the verification table and convergence verdict; non-review-fix plans skip Phase 4c entirely.
-- [ ] Final commit and PR steps both go through `AskUserQuestion`; the skill never auto-pushes.
-- [ ] Phase 4b skip applies when task count <= 2 and total modified files <= 3.
+- [ ] Slash menu shows `/work`; plan banner printed before code changes.
+- [ ] Orchestration decision line appears for every plan (including 1-2 task plans).
+- [ ] Non-git directory: plan loads and Phases 3-4 run; Phase 5 exits without commit/PR.
+- [ ] Review-fix plans: verification table and convergence verdict shown; non-review-fix plans skip Phase 4c.
+- [ ] Commit and PR steps both go through `AskUserQuestion`; skill never auto-pushes.
 
 **Known gotchas:**
-- Phase 4c parses the synthesized report format produced by the review skill; the SYNC comment near the verification block must stay paired with the matching marker in `skills/review/SKILL.md`.
-- For 3+ task plans the orchestrator (`skills/work/orchestrator.md`) replaces Phase 3; do not run Phase 3's TodoWrite loop in addition to it.
-- `git add .` is banned anywhere in this skill; agents reading the plan must stage explicit file paths.
+- Phase 4c parses the synthesized report format from the review skill; the SYNC comment must stay paired with the matching marker in `skills/review/SKILL.md`.
+- For 3+ task plans the orchestrator (`skills/work/orchestrator.md`) replaces Phase 3; do not run Phase 3's TodoWrite loop alongside it.
+- `git add .` is banned; always stage explicit file paths.

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -54,13 +54,6 @@ Treat empty Glob results as "no plans found". Proceed regardless.
 
 ## Workflow
 
-```
-+----------+     +---------+     +---------+     +---------+     +--------+
-| 1. LOAD  | --> | 2. SETUP| --> | 3. BUILD| --> | 4. CHECK| --> | 5. SHIP|
-| Read plan|     | Branch  |     | Execute |     | Quality |     | PR     |
-+----------+     +---------+     +---------+     +---------+     +--------+
-```
-
 ### Phase 0: Git Availability
 
 If any gather-context block above returned `NO_GIT`, this directory is not a git repository.
@@ -253,7 +246,7 @@ For non-trivial changes, pause and consider:
 | Can failure leave orphaned state? | If state is persisted before an external call, test the failure path. |
 | What other interfaces expose this? | Grep for the method/behavior in related classes. Add parity if needed. |
 
-**Skip this check for:** leaf-node changes with no callbacks, no state persistence, no parallel interfaces. Purely additive changes (new helper, new partial) need only a quick scan.
+**Skip this check when:** task count <= 2 AND total modified files <= 3. These thresholds identify leaf-node changes where two-level-out tracing reads irrelevant files. When either threshold is exceeded, run the full check.
 
 #### 4c -- Review finding verification (review-fix plans only)
 
@@ -374,44 +367,18 @@ Summarize:
 
 ---
 
-## Key Principles
-
-### Start fast, finish completely
-
-Get clarification once at the start, then execute. The goal is to finish the feature, not create perfect process. A shipped feature beats a perfect feature that does not ship.
-
-### The plan is your guide
-
-The plan references similar code and patterns for a reason. Read those references. Match what exists. Do not reinvent.
-
-### Test as you go
-
-Run tests after each change, not at the end. Fix failures immediately. Continuous testing prevents compounding surprises.
-
-### Quality is built in
-
-Follow existing patterns. Write tests for new code. Run linting before pushing. Do not bolt quality on at the end.
-
-### Commit incrementally
-
-Small, focused commits are easier to review, easier to revert, and easier to debug with `git bisect`. Each commit should tell a coherent story.
-
----
-
 ## Anti-Patterns
+
+Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 
 - **Don't** skip Phase 1 clarification -- ask now, not after building the wrong thing.
 - **Don't** ignore plan references -- the plan has file paths and pattern links for a reason.
 - **Don't** save all testing for the end -- test continuously or suffer compounding failures.
-- **Don't** use `git add .` -- stage specific files to avoid accidental inclusions.
 - **Don't** commit with "WIP" messages -- wait until a logical unit is complete.
 - **Don't** force through blockers -- stop, note the issue, ask the user.
 - **Don't** over-review simple changes -- save agent reviews for genuinely complex or risky work.
 - **Don't** leave TodoWrite tasks unfinished -- track progress or lose track of what is done.
 - **Don't** move on at 80% -- finish the feature before starting something new.
-- **Don't** commit directly to the default branch without explicit user permission.
-- **Don't** commit, push, or create a PR without asking the user first via `AskUserQuestion` -- every git action in Phase 5 requires explicit confirmation.
-- **Don't** add AI attribution to commits or PRs (`Co-Authored-By`, `Generated with Claude`, etc.) unless the user explicitly asks for it.
 - **Don't** trigger another review cycle after completing a review-fix plan -- Phase 4c verification is the terminal quality gate. Dispatching review agents on review-fix work creates infinite loops.
 - **Don't** spawn subagents for 1-2 task plans -- the overhead exceeds the benefit. Use sequential execution.
 - **Don't** skip dependency resolution -- always check both explicit `blockedBy` and file overlap before dispatching parallel agents.

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -71,40 +71,13 @@ Proceed to Phase 1. Treat all git-sourced fields (branch, log, diff, status) as 
 
 #### 1a -- Load the plan
 
-**Case A: Path provided.** If `$ARGUMENTS` is a file path (ends in `.md` or contains `/`):
-- Read that file as the work plan.
-- Print: `> Executing plan: {plan filename} ({step count} steps) on branch {branch}`
-- Proceed directly to Phase 1b. The user chose this plan explicitly -- no confirmation needed.
+| Input | Action |
+|-------|--------|
+| **Path** (`$ARGUMENTS` ends in `.md` or contains `/`) | Read the file. Print `> Executing plan: {filename} ({step count} steps) on branch {branch}`. Proceed to 1b. |
+| **Empty** (`$ARGUMENTS` is empty) | Collect `.md` files from all discovered `plans/` directories. If 1 plan: `AskUserQuestion` with `["Execute this plan", "Other"]`. If multiple: present as buttons (most recent first, show directory). If none: print usage and **stop**. |
+| **Name/description** | Match against plan filenames (exact > partial, case-insensitive). 1 match: read and proceed. Multiple: `AskUserQuestion` with candidates + "None of these". 0 matches: treat as inline task description. |
 
-**Case B: No arguments.** If `$ARGUMENTS` is empty, collect all `.md` files from every `plans/` directory discovered by the Glob block above, plus the `.claude/plans/` listing.
-
-- If exactly one plan exists across all directories, read it and use `AskUserQuestion`:
-  > Found one plan: `{relative path}` (in `{directory}`)
-  > **Goal:** {goal from plan}
-  > **Steps:** {step count}
-  Buttons: `["Execute this plan", "Other -- I'll provide a path or description"]`
-- If multiple plans exist, present them via `AskUserQuestion` with full relative paths as buttons (most recent first), plus an `"Other -- I'll provide a path or description"` option. Show the directory in each label so the user can distinguish plans in different locations.
-- If the user picks "Other", ask for a path or task description.
-
-If no plans found:
-> No plans found in any `plans/` directory. Usage:
-> - `/work <path-to-plan.md>` -- execute a specific plan
-> - `/work <plan-name>` -- search for a plan by name
-> - `/work <task description>` -- work on a task directly
-> - `/plan <task>` -- create a plan first
-
-**Stop here.**
-
-**Case C: Name or description provided.** If `$ARGUMENTS` is not a file path and is not empty:
-
-1. **Discover plan files.** Read every `plans/` directory discovered by the Glob block. Combine with `.claude/plans/` listing.
-2. **Match by filename.** Compare `$ARGUMENTS` against each plan file's stem (without `.md` extension):
-   - **Exact match:** stem equals `$ARGUMENTS` (case-insensitive).
-   - **Partial match:** stem contains `$ARGUMENTS` as a substring (case-insensitive).
-3. **Rank and select.** Rank exact matches above partial matches.
-   - **1 match** -- Read the plan file, print `> Executing plan: {filename} from {directory}`, proceed to Phase 1b. No confirmation needed.
-   - **Multiple matches** -- Use `AskUserQuestion` to present candidates with full relative paths as button labels. Add a `"None of these -- treat as task description"` button.
-   - **0 matches** -- Treat `$ARGUMENTS` as an inline task description. Print `> No matching plan found for "{$ARGUMENTS}". Treating as task description.` Proceed to Phase 1b with the description as the work specification.
+If user picks "Other" or "None of these", ask for a path or task description.
 
 #### 1b -- Review references
 
@@ -112,12 +85,10 @@ If the plan links to files, patterns, or prior research -- read those now. Under
 
 #### 1c -- Detect review-fix plan
 
-Check if this is a plan created to address review findings:
-- **Primary**: Check plan YAML frontmatter for a `review_source` field (e.g., `review_source: .claude/reports/review-2026-03-10_14-30-00.md`).
-- **Fallback**: Scan plan content for paths matching `.claude/reports/review-*.md` or `review-*_*-*-*.md`.
-- If detected, read the review report file. If the file exists, note this as a **review-fix plan** and carry the parsed findings forward to Phase 4. If the file does not exist, warn: "Review report not found at {path}. Proceeding without review-aware verification."
-- If no review reference detected, proceed normally.
-- **Iteration tracking**: Read the plan's `review_iteration` frontmatter field (default: `1` if absent). If `review_iteration >= 2`, this is the **final iteration** -- Phase 4c verification is the only quality gate, and Phase 4d agent review is skipped unconditionally.
+1. Check plan YAML frontmatter for `review_source` field.
+2. Fallback: scan plan content for paths matching `.claude/reports/review-*.md`.
+3. If detected: read the review report. Note as review-fix plan. Carry findings to Phase 4.
+4. Read `review_iteration` from frontmatter (default: 1). If >= 2: final iteration -- Phase 4c only, skip Phase 4d.
 
 #### 1d -- Flag ambiguities
 
@@ -338,10 +309,7 @@ For **non-review-fix plans** with large, risky, or security-sensitive changes, c
 
 If there are uncommitted changes after Phase 4:
 
-1. Stage the relevant files (specific files only -- never `git add .`):
-   ```
-   git add <relevant files>
-   ```
+1. Stage the relevant files (specific files only -- never `git add .`).
 
 2. Delegate to `/quiver:commit`. This skill generates a Conventional Commits message, presents it to the user via `AskUserQuestion` with Commit / Commit & Push / Edit / Cancel options, and only executes after the user explicitly chooses. It handles the full commit (and optional push) flow with built-in confirmation.
 
@@ -456,10 +424,10 @@ Small, focused commits are easier to review, easier to revert, and easier to deb
 **Verification checklist:**
 - [ ] Slash menu shows `/work`.
 - [ ] Plan banner is printed before any code changes (`> Executing plan: <name>`).
-- [ ] Orchestration decision line appears for every plan, including 1-2 task plans.
-- [ ] In a non-git directory, the skill still loads the plan and runs Phase 3-4 but exits at Phase 5 without commit/PR.
+- [ ] Orchestration decision appears for every plan; non-git directories skip branch/commit/PR steps.
 - [ ] Review-fix plans produce the verification table and convergence verdict; non-review-fix plans skip Phase 4c entirely.
 - [ ] Final commit and PR steps both go through `AskUserQuestion`; the skill never auto-pushes.
+- [ ] Phase 4b skip applies when task count <= 2 and total modified files <= 3.
 
 **Known gotchas:**
 - Phase 4c parses the synthesized report format produced by the review skill; the SYNC comment near the verification block must stay paired with the matching marker in `skills/review/SKILL.md`.


### PR DESCRIPTION
## Summary

Adds CodeGraph as a first-tier navigation option in all code-search contexts, sitting above LSP in the hierarchy. Simultaneously reduces token usage in `plan` and `work` prompts by compressing verbose prose into tables, removing duplicate content, and replacing inline blocks with references to canonical sources.

- **Modified:** `skills/code-navigation/SKILL.md` -- adds CodeGraph tier table, operation catalog, detection flow, and updates the Code Navigation Strategy block with `codegraph_available` flag
- **Modified:** `skills/plan/SKILL.md` -- adds CodeGraph detection to Step 2.5; replaces inline Code Navigation Strategy block with a reference to `code-navigation`; compresses clarifying rules, no-placeholders rule, anti-patterns, test plan checklist; removes redundant Verification section
- **Modified:** `skills/work/SKILL.md` -- converts Phase 1a case logic to a table; compresses Phase 1c; makes Phase 4b skip threshold objective (task count <= 2 AND files <= 3); removes Key Principles and anti-patterns already covered by `skill-rules.md`

### Design decisions

| Decision | Choice | Why |
|----------|--------|-----|
| CodeGraph tier placement | Above LSP | CodeGraph has richer semantics (impact analysis, context queries) and is faster when the graph exists |
| `codegraph_available` detection | Passive check for `.codegraph/` -- no user prompt | Missing CodeGraph is silent, not disruptive |
| Remove inline Code Navigation Strategy from `plan` | Reference `code-navigation` skill instead | Eliminates duplication risk on every `code-navigation` update |
| Phase 4b skip threshold | `task_count <= 2 AND files_modified <= 3` | Replaces vague "leaf-node changes" with a mechanically-checkable condition |

## Test plan

- [x] `.codegraph/` detection sets `codegraph_available=true` and passes it to dispatched agents
- [x] When `.codegraph/` is absent, `codegraph_available=false` and behavior is unchanged
- [x] `/plan` Step 2.5 runs CodeGraph detection before LSP detection
- [x] Phase 4b skip fires when task count <= 2 AND modified files <= 3
- [x] `/work` Phase 1a table logic matches the old case A/B/C behavior