### PR TITLE
feat: add code-locator agent and SessionStart auto-dispatch hook

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -25,6 +25,7 @@
     "./agents/research/best-practices-researcher.md",
     "./agents/research/project-context-analyst.md",
     "./agents/research/code-navigator.md",
+    "./agents/research/code-locator.md",
     "./agents/debug/code-tracer.md",
     "./agents/debug/log-analyzer.md",
     "./agents/debug/regression-finder.md",

--- a/.claude/rules/skill-rules.md
+++ b/.claude/rules/skill-rules.md
@@ -30,6 +30,8 @@ Non-negotiable. Every command must follow all of these. Violations break things.
 
 **R9. No AI attribution.** No `Co-authored-by` or similar in commits/PRs unless the user explicitly requests it.
 
+**R10. `when-to-use:` required for user-facing skills.** Every user-facing skill must include a `when-to-use:` field in its YAML frontmatter. The value must be a single-line double-quoted string (not a multi-line YAML block scalar -- multi-line format produces empty routing entries in the hook). The string must contain: the skill's slash command name as an anchor (e.g. `'/plan'`), at least one concrete quoted user utterance, and the abstract intent category. Exceptions: internal reference skills (code-navigation, orchestrate-agents) and destructive skills (delete-all-handovers, delete-last-handover).
+
 ---
 
 ## Learned Lessons

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Then try `/brainstorm` in any session.
 |-----------|-------|
 | Hooks | 1 |
 | Skills | 19 |
-| Agents | 18 |
+| Agents | 20 |
 
 ## Skills
 
@@ -221,6 +221,7 @@ These skills back the slash-invocable skills above. They are not invoked directl
 |-------|-----------------|
 | `best-practices-researcher` (`quiver:best-practices-researcher`) | Deprecated APIs and outdated patterns versus current library docs |
 | `project-context-analyst` (`quiver:project-context-analyst`) | Prior decisions, past bugs, and churn patterns in this area of the codebase |
+| `code-locator` (`quiver:code-locator`) | Fast file:line locations for "where is X / what calls Y" without heavy mapping |
 
 <!-- agents:research-end -->
 

--- a/agents/research/code-locator.md
+++ b/agents/research/code-locator.md
@@ -1,0 +1,64 @@
+---
+name: code-locator
+description: "Lightweight code locator for high-frequency locate queries -- where is X defined, what calls Y, list all uses of Z, map a directory. Returns a compressed file:line locator table."
+model: haiku
+---
+
+You are a code locator. You find where code lives and report locations -- nothing else. You never edit, never propose fixes, never extract conventions, never judge quality.
+
+## Locate Discipline
+
+1. Load codegraph schemas first when `codegraph_available: true` -- the first tool call is `ToolSearch`; do not call Grep/Glob/Read before it.
+2. Report locations only; never extract conventions or suggest changes.
+3. Read a specific range only to confirm a symbol's location; never read a whole file to summarize it.
+4. No speculation -- report where code is, not what it might do.
+5. Zero results is valid -- output `No match.`, never pad.
+
+## Code Navigation Strategy
+
+You have been provided `codegraph_available` and `lsp_available` flags in your context.
+
+**When `codegraph_available: true`:**
+- First, load codegraph tool schemas by calling ToolSearch with query `"select:mcp__codegraph__codegraph_search,mcp__codegraph__codegraph_context,mcp__codegraph__codegraph_callers,mcp__codegraph__codegraph_callees,mcp__codegraph__codegraph_impact,mcp__codegraph__codegraph_node"`. Codegraph tools are deferred and cannot be called without this step.
+- For finding symbols by name: use codegraph_search first.
+- For understanding what code is relevant to a task: use codegraph_context first.
+- For finding callers of a function: use codegraph_callers first.
+- For finding what a function calls: use codegraph_callees first.
+- For assessing change impact: use codegraph_impact first.
+- For getting source code of a specific symbol: use codegraph_node.
+- If codegraph returns insufficient results, fall through to LSP (if available) then grep.
+- For file discovery and pattern matching: always use Grep/Glob regardless of codegraph.
+
+**When `codegraph_available: false` and `lsp_available: true`:**
+- For finding where a function/class/type is defined: use LSP goToDefinition first.
+- For finding all callers or consumers of a symbol: use LSP findReferences first.
+- For getting a structural overview of a file: use LSP documentSymbol first.
+- If LSP returns empty or unhelpful results for any operation, inform the user:
+  "LSP returned no results for {operation} on `{symbol}` -- falling back to grep-based search."
+  Then use the grep equivalent from the catalog above.
+- For file discovery and pattern matching: always use Grep/Glob regardless of LSP availability.
+
+**When both unavailable:**
+- Use Grep, Glob, and Read for all code navigation.
+
+## Output Contract
+
+```
+<Header>:
+- path/to/file.ext:line -- `symbol` -- <=6 word note
+totals: <counts>.
+```
+
+Rules: file-path first, line attached, symbols backticked, grep-safe with `path:\d+`; group with a one-word header (`Defs:`/`Refs:`/`Callers:`/`Callees:`/`Tests:`/`Imports:`/`Sites:`) when 3+ rows; single hit -> one line, no header; zero hits -> `No match.`; last line is totals (omit when 0 or 1 total). No prose, no Key Patterns / Key Conventions / Gaps.
+
+## Refusals
+
+Asked to fix: `Locate-only. Use a builder/editor or the main thread.`
+Asked for conventions / architecture / quality: `Locate-only. Dispatch quiver:code-navigator for mapping.`
+
+## Anti-Patterns
+
+- Do not call Grep/Read before loading codegraph schemas when `codegraph_available: true`
+- Do not return prose or conventions
+- Do not pad with loosely-related files
+- Do not read whole files to summarize

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -11,6 +11,18 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/session-start-auto-dispatch.sh",
+            "timeout": 30
+          }
+        ]
+      }
     ]
   }
 }

--- a/hooks/scripts/session-start-auto-dispatch.sh
+++ b/hooks/scripts/session-start-auto-dispatch.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+main() {
+    routing_lines=""
+
+    for skill_file in "${PLUGIN_ROOT}"/skills/*/SKILL.md; do
+        [ -f "$skill_file" ] || continue
+
+        name=$(awk '/^---/{c++;next} c==1 && /^name:/{gsub(/^name:[[:space:]]*/,""); print; exit}' "$skill_file") || true
+        when_to_use=$(awk '/^---/{c++;next} c==1 && /^when-to-use:/{gsub(/^when-to-use:[[:space:]]*/,""); print; exit}' "$skill_file" | tr -d '"') || true
+
+        [ -z "$name" ] || [ -z "$when_to_use" ] && continue
+
+        routing_lines="${routing_lines}/${name}: ${when_to_use}\n"
+    done
+
+    if [ -z "$routing_lines" ]; then
+        exit 0
+    fi
+
+    printf '<quiver-auto-dispatch>\n'
+    printf 'When user intent matches a trigger, silently invoke the Quiver skill via the Skill tool BEFORE any other response. Follow that skill'"'"'s full instruction set. Do not announce activation.\n'
+    printf '\n'
+    printf "%b" "$routing_lines"
+    printf '</quiver-auto-dispatch>\n'
+}
+
+main || exit 0
+exit 0

--- a/hooks/scripts/session-start-auto-dispatch.sh
+++ b/hooks/scripts/session-start-auto-dispatch.sh
@@ -9,12 +9,12 @@ main() {
     for skill_file in "${PLUGIN_ROOT}"/skills/*/SKILL.md; do
         [ -f "$skill_file" ] || continue
 
-        name=$(awk '/^---/{c++;next} c==1 && /^name:/{gsub(/^name:[[:space:]]*/,""); print; exit}' "$skill_file") || true
-        when_to_use=$(awk '/^---/{c++;next} c==1 && /^when-to-use:/{gsub(/^when-to-use:[[:space:]]*/,""); print; exit}' "$skill_file" | tr -d '"') || true
+        name=$(awk 'BEGIN{c=0} /^---/{c++;next} c==1 && /^name:/{gsub(/^name:[[:space:]]*/,""); print; exit}' "$skill_file") || true
+        when_to_use=$(awk 'BEGIN{c=0} /^---/{c++;next} c==1 && /^when-to-use:/{gsub(/^when-to-use:[[:space:]]*/,""); print; exit}' "$skill_file" | tr -d '"<>') || true
 
         [ -z "$name" ] || [ -z "$when_to_use" ] && continue
 
-        routing_lines="${routing_lines}/${name}: ${when_to_use}\n"
+        routing_lines="${routing_lines}/${name}: ${when_to_use}"$'\n'
     done
 
     if [ -z "$routing_lines" ]; then
@@ -24,7 +24,7 @@ main() {
     printf '<quiver-auto-dispatch>\n'
     printf 'When user intent matches a trigger, silently invoke the Quiver skill via the Skill tool BEFORE any other response. Follow that skill'"'"'s full instruction set. Do not announce activation.\n'
     printf '\n'
-    printf "%b" "$routing_lines"
+    printf '%s' "$routing_lines"
     printf '</quiver-auto-dispatch>\n'
 }
 

--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -2,6 +2,7 @@
 name: brainstorm
 description: "Explore ideas, compare approaches, and produce a validated spec before planning. Use when the user describes what to build, asks how to approach something, proposes a new feature or design change, or needs to explore options before implementation."
 argument-hint: "<idea or feature description>"
+when-to-use: "user wants to explore ideas, compare approaches, or decide what to build -- '/brainstorm', 'brainstorm this', 'help me think through' (not: 'make a plan')"
 ---
 
 # Gather Context

--- a/skills/code-navigation/SKILL.md
+++ b/skills/code-navigation/SKILL.md
@@ -141,6 +141,17 @@ If your agent searches the broader codebase (beyond files it already knows about
 2. Ensure the dispatching skill passes `codegraph_available` and `lsp_available` context to your agent.
 3. Your agent does NOT need to handle LSP detection -- that is the skill's responsibility.
 
+## Locate vs Map
+
+Two agents serve code navigation. Pick by output need:
+
+| Job | Agent | Output |
+|-----|-------|--------|
+| Where is X defined / what calls Y / list uses of Z / map a directory / verify a path | `quiver:code-locator` | Compressed `path:line -- symbol -- note` table |
+| Conventions, patterns, planning context, feature impact | `quiver:code-navigator` | Structured file:role:pattern report with Key Conventions and Gaps |
+
+Both agents use the tier strategy from this skill (codegraph -> LSP -> grep). `code-locator` runs on `haiku` and refuses convention extraction; `code-navigator` runs on `inherit` and emits the full map `/plan` consumes.
+
 ---
 
 ## Test Plan
@@ -164,6 +175,7 @@ If your agent searches the broader codebase (beyond files it already knows about
 - [ ] Project memory ends up with `lsp_preference.md` after the first detection run.
 - [ ] `codegraph_available` flag detected and passed to agents when `.codegraph/` exists.
 - [ ] When `.codegraph/` does not exist, `codegraph_available` is false and behavior is unchanged.
+- [ ] Locate jobs (where is X / what calls Y / list uses / verify paths) dispatch `quiver:code-locator`; map/convention jobs dispatch `quiver:code-navigator`.
 
 **Known gotchas:**
 - LSP availability is cached per project; clearing or installing a new language server requires `forget LSP preference` or manual `lsp_preference.md` removal.

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -2,6 +2,7 @@
 name: commit
 description: Generate a Conventional Commits message, commit, and optionally push to remote.
 argument-hint: "[--push] (auto commit & push without prompting)"
+when-to-use: "user wants to commit changes or write a commit message -- '/commit', 'commit this', 'make a commit', 'git commit', 'commit my changes'"
 ---
 
 # Gather Git Context

--- a/skills/create-agent/SKILL.md
+++ b/skills/create-agent/SKILL.md
@@ -3,6 +3,7 @@ name: create-agent
 description: Scaffold a new Claude Code agent with smart defaults from a natural language description or interactive Q&A.
 argument-hint: "[description] e.g. \"a security reviewer that checks OWASP top 10\" or run without arguments for guided setup"
 disable-model-invocation: true
+when-to-use: "user wants to scaffold a new Quiver agent -- '/create-agent', 'create an agent', 'new agent', 'add an agent', 'scaffold an agent'"
 ---
 
 # Create Agent

--- a/skills/create-agents-md/SKILL.md
+++ b/skills/create-agents-md/SKILL.md
@@ -3,6 +3,7 @@ name: create-agents-md
 description: Generate or rewrite an AGENTS.md file — a high-signal-density operational checklist for AI coding agents.
 argument-hint: Generates project-specific AGENTS.md with constraints, conventions, and gotchas that prevent costly agent mistakes.
 disable-model-invocation: true
+when-to-use: "user wants to generate an AGENTS.md operational checklist -- '/create-agents-md', 'create agents.md', 'generate agents file', 'write AGENTS.md'"
 ---
 
 # Gather Context

--- a/skills/create-pr/SKILL.md
+++ b/skills/create-pr/SKILL.md
@@ -2,6 +2,7 @@
 name: create-pr
 description: "Create a GitHub pull request from the current branch. Use when the user says 'create a pr', 'open pr', 'push and open a pr', 'create pull request', or wants to open a PR from their branch."
 argument-hint: "[--draft] [--base <branch>]"
+when-to-use: "user wants to open a pull request from the current branch -- '/create-pr', 'create a PR', 'open a pull request', 'push and make a PR'"
 ---
 
 # Gather Context

--- a/skills/handover/SKILL.md
+++ b/skills/handover/SKILL.md
@@ -2,6 +2,7 @@
 name: handover
 description: Summarize the current work state and prepare a handover note for the next session.
 disable-model-invocation: true
+when-to-use: "user wants to save session context or wrap up a session -- '/handover', 'save handover', 'create a handover', 'end of session', 'save my progress'"
 ---
 
 # Step 0 — Gather Git Context

--- a/skills/hypothesis-debugging/SKILL.md
+++ b/skills/hypothesis-debugging/SKILL.md
@@ -2,6 +2,7 @@
 name: hypothesis-debugging
 description: "Hypothesis-first debugging -- collects symptoms, generates and tests hypotheses with conditional agent dispatch, falls back to adaptive exploration, and proposes reviewed fixes."
 argument-hint: "<bug description, error message, or 'help me debug X'>"
+when-to-use: "user wants to debug an error, bug, or failure -- '/hypothesis-debugging', 'debug this', 'fix this bug', 'why is this failing', 'help me debug', 'investigate this error'"
 ---
 
 # Gather Context

--- a/skills/load-handover/SKILL.md
+++ b/skills/load-handover/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: load-handover
 description: Load the most recent handover note from the previous session into context.
+when-to-use: "user wants to restore previous session context -- '/load-handover', 'load handover', 'restore session', 'load previous context', 'continue from last session'"
 ---
 
 # Previous Session Handover

--- a/skills/orchestrate-agents/SKILL.md
+++ b/skills/orchestrate-agents/SKILL.md
@@ -266,7 +266,8 @@ flowchart TD
     D -->|Yes| C
     D -->|No| E
 
-    E -->|Codebase exploration| F[quiver:code-navigator]
+    E -->|Find / locate / list / verify| F[quiver:code-locator]
+    E -->|Understand / map / conventions| FA[quiver:code-navigator]
     E -->|Non-codebase read only| G[Explore]
     E -->|Planning/design| H[Plan]
     E -->|Write/modify code or shell commands| I[general-purpose]

--- a/skills/orchestrate-agents/SKILL.md
+++ b/skills/orchestrate-agents/SKILL.md
@@ -161,9 +161,9 @@ Agent(
 
 - **Tools:** Read-only (Glob, Grep, Read, LSP -- no Edit, Write, Agent)
 - **Best for:** Non-codebase read tasks: checking if a specific config file exists, reading raw log output, grep-only operations with no benefit from codegraph
-- **When to use:** Only when the task is pure file I/O with no need for semantic code understanding. For any task that involves finding, mapping, or understanding source code, use `quiver:code-navigator` instead (see rule below).
+- **When to use:** Only when the task is pure file I/O with no need for semantic code understanding. For any task that involves finding, locating, mapping, or understanding source code, use `quiver:code-locator` (for find/locate/list/verify) or `quiver:code-navigator` (for understand/map/conventions) instead (see rule below).
 
-> **Hard rule -- codebase exploration:** Always use `quiver:code-navigator` instead of `Explore` for any task that involves finding, understanding, or mapping source code. `Explore` ignores codegraph semantic tools even when codegraph is available and falls back to grep for everything. `quiver:code-navigator` loads codegraph schemas first, uses semantic search, and falls back to grep only when needed -- fewer tokens, higher precision.
+> **Hard rule -- codebase exploration:** Never use `Explore` for source code tasks. Use `quiver:code-locator` for finding/listing/verifying locations (compressed file:line output, runs on haiku), and `quiver:code-navigator` for understanding/mapping/convention extraction (full structured report, runs on inherit). Both load codegraph schemas first and fall back to grep only when needed -- fewer tokens, higher precision than `Explore`.
 
 ### Plan
 
@@ -197,7 +197,8 @@ Agent(
 
 | Need | Agent Type | Recommended Frontmatter Model |
 |------|-----------|-------------------------------|
-| Find files matching a pattern in source code | `quiver:code-navigator` | `inherit` |
+| Find files matching a pattern in source code | `quiver:code-locator` | `haiku` |
+| Locate a symbol / find callers / list uses / map a directory | `quiver:code-locator` | `haiku` |
 | Understand how a module works | `quiver:code-navigator` | `inherit` |
 | Run shell commands or git operations | `general-purpose` | inherit |
 | Design before implementing | `Plan` | inherit or `opus` |
@@ -513,16 +514,16 @@ Start with a fast, cheap scan, then go deeper only where needed.
 
 ```mermaid
 flowchart TD
-    S1[Scan: code-navigator<br/>Quick overview] -->|identifies hotspots| S2[Deep dive: code-navigator<br/>Analyze hotspots only]
+    S1[Scan: code-locator<br/>Quick overview] -->|identifies hotspots| S2[Deep dive: code-navigator<br/>Analyze hotspots only]
     S2 -->|finds issues| S3[Fix: general-purpose<br/>Targeted fixes]
 ```
 
 ```
 # Step 1: Fast broad scan
 Agent(
-  subagent_type="quiver:code-navigator",
+  subagent_type="quiver:code-locator",
   description="Quick security scan",
-  prompt="Do a quick scan of the entire codebase for obvious security issues. Check for: hardcoded secrets, SQL string concatenation, unescaped user input in HTML, eval() calls, and exposed debug endpoints. Report ONLY file paths and line numbers -- no detailed analysis yet."
+  prompt="Do a quick scan of the entire codebase for obvious security issues. Check for: hardcoded secrets, SQL string concatenation, unescaped user input in HTML, eval() calls, and exposed debug endpoints. Report ONLY file paths and line numbers -- no detailed analysis yet. Surface the locator's table verbatim in your result; do not re-summarize it."
 )
 
 # Step 2: Deep dive only on flagged files (uses Step 1 results)
@@ -768,6 +769,7 @@ If the task is ambiguous and agent selection cannot be determined confidently, a
 - [ ] Agent selection draws from all three discovery roots; project agents override same-named plugin/user agents.
 - [ ] Skill explicitly delegates to the work orchestrator for plan-driven runs instead of duplicating that logic.
 - [ ] Ambiguous tasks produce a single clarifying question, not silent guesses.
+- [ ] Locate / find / list / verify jobs dispatch `quiver:code-locator`; understand / map / convention jobs dispatch `quiver:code-navigator`.
 
 **Known gotchas:**
 - This skill is the GENERAL orchestrator; the WORK skill's `orchestrator.md` is the specialized variant for plan execution. Do not conflate them.

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -60,7 +60,7 @@ Otherwise:
 
 | Complexity | Signals | Agents to Dispatch |
 |------------|---------|-------------------|
-| **Light** | 1-3 files, single layer, well-understood | code-navigator |
+| **Light** | 1-3 files, single layer, well-understood | code-locator |
 | **Standard** | 3-10 files, 2+ layers, moderate unknowns | code-navigator + best-practices-researcher |
 | **Deep** | 10+ files, architectural impact, security/auth/payments, unfamiliar domain | code-navigator + best-practices-researcher + architecture-strategist |
 
@@ -114,9 +114,30 @@ Before dispatching agents, detect navigation capabilities once.
 
 Spawn all qualifying agents simultaneously using multiple Agent tool calls in a single response. Every agent prompt must be **self-contained** -- agents have zero memory of this conversation.
 
-**Review-fix plans: reduced dispatch.** If Step 1 detected review-fix context, the review report already identified the problems and affected files. Skip best-practices-researcher and architecture-strategist -- they add no value when the scope is "fix these specific findings." Dispatch only the code-navigator agent to verify file paths and current patterns are still accurate.
+**Review-fix plans: reduced dispatch.** If Step 1 detected review-fix context, the review report already identified the problems and affected files. Skip best-practices-researcher and architecture-strategist -- they add no value when the scope is "fix these specific findings." Dispatch only the code-locator agent to verify file paths and that current locations are still accurate.
 
-### code-navigator Agent (always dispatched)
+### code-locator Agent (Light + review-fix verify)
+
+```
+Agent(
+  subagent_type="quiver:code-locator",
+  description="Locate files for planning: {short task summary}",
+  prompt="Task: {full task description from Step 1}
+
+  codegraph_available: {true|false from Step 2.5}
+  lsp_available: {true|false from Step 2.5}
+
+  Locate all files related to this task. For each file found, report:
+  1. File path and line (if a specific symbol is the entry point)
+  2. One-line description of its role
+  3. Whether it has an associated test file
+
+  Surface the locator's table verbatim; do not re-summarize it.",
+
+)
+```
+
+### code-navigator Agent (Standard + Deep)
 
 ```
 Agent(
@@ -441,7 +462,8 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 - [ ] Step 6.5 agent dispatch follows skip conditions (Light and review-fix plans skip).
 - [ ] Plan Guard Notes subsection appears in the plan's Context section only when NOTE findings exist.
 - [ ] `codegraph_available` flag detected and passed to agents when `.codegraph/` exists.
+- [ ] Light and review-fix plans dispatch `quiver:code-locator`; Standard/Deep plans dispatch `quiver:code-navigator`.
 
 **Known gotchas:**
-- The code-navigator agent (`agents/research/code-navigator.md`) owns the Code Navigation Strategy. When updating the strategy in `skills/code-navigation/SKILL.md`, update the agent file too.
+- The code-navigator agent (`agents/research/code-navigator.md`) owns the Code Navigation Strategy. When updating the strategy in `skills/code-navigation/SKILL.md`, update the agent file too. `code-locator` (`agents/research/code-locator.md`) also copies this block -- update it there as well.
 - `review_iteration` is determined by counting prior plans with the same `review_source` field; if naming conventions drift, the iteration count can desync.

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -2,6 +2,7 @@
 name: plan
 description: Create a structured implementation plan with parallel agent research before coding.
 argument-hint: "<task description>"
+when-to-use: "user asks to make a plan, structure work, or plan a feature -- '/plan', 'make a plan', 'plan this out', 'how should I approach X'"
 ---
 
 # Gather Context
@@ -60,7 +61,7 @@ Otherwise:
 
 | Complexity | Signals | Agents to Dispatch |
 |------------|---------|-------------------|
-| **Light** | 1-3 files, single layer, well-understood | code-locator |
+| **Light** | 1-3 files, single layer, well-understood | code-navigator |
 | **Standard** | 3-10 files, 2+ layers, moderate unknowns | code-navigator + best-practices-researcher |
 | **Deep** | 10+ files, architectural impact, security/auth/payments, unfamiliar domain | code-navigator + best-practices-researcher + architecture-strategist |
 
@@ -114,30 +115,9 @@ Before dispatching agents, detect navigation capabilities once.
 
 Spawn all qualifying agents simultaneously using multiple Agent tool calls in a single response. Every agent prompt must be **self-contained** -- agents have zero memory of this conversation.
 
-**Review-fix plans: reduced dispatch.** If Step 1 detected review-fix context, the review report already identified the problems and affected files. Skip best-practices-researcher and architecture-strategist -- they add no value when the scope is "fix these specific findings." Dispatch only the code-locator agent to verify file paths and that current locations are still accurate.
+**Review-fix plans: reduced dispatch.** If Step 1 detected review-fix context, the review report already identified the problems and affected files. Skip best-practices-researcher and architecture-strategist -- they add no value when the scope is "fix these specific findings." Dispatch only the code-navigator agent to verify file paths and current patterns are still accurate.
 
-### code-locator Agent (Light + review-fix verify)
-
-```
-Agent(
-  subagent_type="quiver:code-locator",
-  description="Locate files for planning: {short task summary}",
-  prompt="Task: {full task description from Step 1}
-
-  codegraph_available: {true|false from Step 2.5}
-  lsp_available: {true|false from Step 2.5}
-
-  Locate all files related to this task. For each file found, report:
-  1. File path and line (if a specific symbol is the entry point)
-  2. One-line description of its role
-  3. Whether it has an associated test file
-
-  Surface the locator's table verbatim; do not re-summarize it.",
-
-)
-```
-
-### code-navigator Agent (Standard + Deep)
+### code-navigator Agent (always dispatched)
 
 ```
 Agent(
@@ -462,8 +442,7 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 - [ ] Step 6.5 agent dispatch follows skip conditions (Light and review-fix plans skip).
 - [ ] Plan Guard Notes subsection appears in the plan's Context section only when NOTE findings exist.
 - [ ] `codegraph_available` flag detected and passed to agents when `.codegraph/` exists.
-- [ ] Light and review-fix plans dispatch `quiver:code-locator`; Standard/Deep plans dispatch `quiver:code-navigator`.
 
 **Known gotchas:**
-- The code-navigator agent (`agents/research/code-navigator.md`) owns the Code Navigation Strategy. When updating the strategy in `skills/code-navigation/SKILL.md`, update the agent file too. `code-locator` (`agents/research/code-locator.md`) also copies this block -- update it there as well.
+- The code-navigator agent (`agents/research/code-navigator.md`) owns the Code Navigation Strategy. When updating the strategy in `skills/code-navigation/SKILL.md`, update the agent file too.
 - `review_iteration` is determined by counting prior plans with the same `review_source` field; if naming conventions drift, the iteration count can desync.

--- a/skills/repair-skill/SKILL.md
+++ b/skills/repair-skill/SKILL.md
@@ -3,6 +3,7 @@ name: repair-skill
 description: Diagnose and fix a broken skill by analyzing its structure, verifying API references against current docs, and applying targeted repairs.
 argument-hint: "[optional: skill name or description of what broke]"
 disable-model-invocation: true
+when-to-use: "user wants to fix a broken or misbehaving Quiver skill -- '/repair-skill', 'repair skill', 'this skill is broken', 'fix the skill', 'skill not working'"
 ---
 
 # Repair Skill

--- a/skills/report-check/SKILL.md
+++ b/skills/report-check/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: report-check
 description: Analyze a review report for quality -- detects noise, false positives, overkill suggestions, and findings that exist to appear thorough. Usage: /report-check <path-to-report>
+when-to-use: "user wants to audit a review report for noise or false positives -- '/report-check', 'check this report', 'is this review good', 'verify the review findings'"
 ---
 
 # Gather Context

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -3,6 +3,7 @@ name: review
 description: Run a multi-agent code review. Default fast mode (5 agents); pass --deep for full pipeline (all agents + quality check + senior review). Pass --with-codex for cross-model coverage.
 argument-hint: "[PR/MR URL | --base <branch>] [--deep] [--output <path>] [--set-output <path>] [--terminal] [--comment-pr] [--with-codex]"
 disable-model-invocation: true
+when-to-use: "user wants a multi-agent code review of a PR or diff -- '/review', 'review my changes', 'review this PR', 'code review', 'audit the diff' (not: 'senior review')"
 ---
 
 # Gather Context

--- a/skills/senior-review/SKILL.md
+++ b/skills/senior-review/SKILL.md
@@ -2,6 +2,7 @@
 name: senior-review
 description: "Pragmatic senior developer code review -- evaluates code quality, risks, and conventions through a team lead lens. Standalone or integrated into /review pipeline."
 argument-hint: "[--quick] [#PR_NUMBER | PR_URL]"
+when-to-use: "user wants a quick targeted single-pass senior developer review -- '/senior-review', 'senior review', 'quick review', 'fast review', 'single-pass review'"
 ---
 
 # Gather Context

--- a/skills/visual-companion/SKILL.md
+++ b/skills/visual-companion/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: visual-companion
 description: Browser-based visual brainstorming companion for showing mockups, diagrams, and visual options. Use when brainstorm topics involve UI/UX, layout, architecture diagrams, or any content better understood visually.
+when-to-use: "user wants visual mockups, UI diagrams, or architecture sketches -- '/visual-companion', 'show me a diagram', 'sketch this UI', 'visualize this', 'open visual companion'"
 ---
 
 # Visual Companion

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -2,6 +2,7 @@
 name: work
 description: "Execute a work plan or specification systematically -- read the plan, set up a branch, implement tasks with continuous testing, commit incrementally, and ship a PR. Use when you have a plan file, spec, or task list ready to execute."
 argument-hint: "<plan file path or task description>"
+when-to-use: "user wants to execute a saved plan or implement tasks step by step -- '/work', 'start implementation', 'execute the plan', 'work through these tasks'"
 ---
 
 # Gather Context


### PR DESCRIPTION
## Summary

Two related features: a new `code-locator` agent (Haiku-powered) for fast file:line lookups, and a `SessionStart` hook that injects intent-based skill routing into every new session.

- **New:** `agents/research/code-locator.md` -- Haiku locate agent; returns compressed `path:line` table, refuses convention extraction
- **New:** `hooks/scripts/session-start-auto-dispatch.sh` -- reads 15 skill `when-to-use:` fields, emits `<quiver-auto-dispatch>` block on startup
- **Modified:** `hooks/hooks.json` -- adds `SessionStart` entry (matcher: startup, timeout: 30)
- **Modified:** 15 `skills/*/SKILL.md` -- each gains a `when-to-use:` frontmatter field
- **Modified:** `skills/code-navigation`, `orchestrate-agents`, `plan` -- routing tables updated to dispatch `code-locator` for find/locate/list jobs

### How it works

**code-locator:**
1. Dispatched for Light complexity and locate-only queries (find/list/verify)
2. Loads codegraph schemas first, falls back to LSP then grep
3. Returns compact `path:line -- symbol -- note` table; refuses conventions or architecture notes

**session-start-auto-dispatch:**
1. On session startup, loops over `skills/*/SKILL.md`
2. Extracts `name:` and `when-to-use:` from YAML frontmatter using awk (frontmatter-scoped, `|| true` guards)
3. Prints `<quiver-auto-dispatch>` block listing `/skill-name: trigger` for each of the 15 user-facing skills
4. Destructive and internal skills excluded by omitting `when-to-use:` from their frontmatter

### Design decisions

| Decision | Choice | Why |
|----------|--------|-----|
| code-locator model | `haiku` | Locate queries are mechanical; fast and cheap |
| Routing output format | Factual inventory | Imperative framing triggers Claude's prompt-injection defenses |
| when-to-use format | Single-line double-quoted string | Multi-line YAML produces empty entries in awk extraction |
| SessionStart matcher | `startup` only | Prevents re-injection on resume/clear/compact |
| Hook timeout | 30s | File-reads only; PreCompact uses 180s because it calls `claude -p` |

## Test plan

- [ ] `bash -n hooks/scripts/session-start-auto-dispatch.sh` exits 0
- [ ] Integration test emits `<quiver-auto-dispatch>` with exactly 15 entries; destructive/internal skills absent
- [ ] `python3 -c "import json,sys; json.load(sys.stdin)" < hooks/hooks.json` exits 0
- [ ] `grep 'when-to-use:' skills/*/SKILL.md | wc -l` returns 15
- [ ] `grep 'R10' .claude/rules/skill-rules.md` returns the new rule
- [ ] In a Claude Code session: intent triggers correct skill without explicit slash command