### PR TITLE
feat: add opencode overlay

### DIFF
--- a/.opencode/agents/architecture-strategist.md
+++ b/.opencode/agents/architecture-strategist.md
@@ -1,0 +1,1 @@
+../../agents/review/architecture-strategist.md

--- a/.opencode/agents/best-practices-researcher.md
+++ b/.opencode/agents/best-practices-researcher.md
@@ -1,0 +1,1 @@
+../../agents/research/best-practices-researcher.md

--- a/.opencode/agents/code-locator.md
+++ b/.opencode/agents/code-locator.md
@@ -1,0 +1,1 @@
+../../agents/research/code-locator.md

--- a/.opencode/agents/code-navigator.md
+++ b/.opencode/agents/code-navigator.md
@@ -1,0 +1,1 @@
+../../agents/research/code-navigator.md

--- a/.opencode/agents/code-tracer.md
+++ b/.opencode/agents/code-tracer.md
@@ -1,0 +1,1 @@
+../../agents/debug/code-tracer.md

--- a/.opencode/agents/codex-code-reviewer.md
+++ b/.opencode/agents/codex-code-reviewer.md
@@ -1,0 +1,1 @@
+../../agents/review/codex-code-reviewer.md

--- a/.opencode/agents/developer-experience-auditor.md
+++ b/.opencode/agents/developer-experience-auditor.md
@@ -1,0 +1,1 @@
+../../agents/review/developer-experience-auditor.md

--- a/.opencode/agents/environment-checker.md
+++ b/.opencode/agents/environment-checker.md
@@ -1,0 +1,1 @@
+../../agents/debug/environment-checker.md

--- a/.opencode/agents/fix-reviewer.md
+++ b/.opencode/agents/fix-reviewer.md
@@ -1,0 +1,1 @@
+../../agents/debug/fix-reviewer.md

--- a/.opencode/agents/log-analyzer.md
+++ b/.opencode/agents/log-analyzer.md
@@ -1,0 +1,1 @@
+../../agents/debug/log-analyzer.md

--- a/.opencode/agents/logic-reviewer.md
+++ b/.opencode/agents/logic-reviewer.md
@@ -1,0 +1,1 @@
+../../agents/review/logic-reviewer.md

--- a/.opencode/agents/plan-reviewer.md
+++ b/.opencode/agents/plan-reviewer.md
@@ -1,0 +1,1 @@
+../../agents/workflow/plan-reviewer.md

--- a/.opencode/agents/project-context-analyst.md
+++ b/.opencode/agents/project-context-analyst.md
@@ -1,0 +1,1 @@
+../../agents/research/project-context-analyst.md

--- a/.opencode/agents/regression-finder.md
+++ b/.opencode/agents/regression-finder.md
@@ -1,0 +1,1 @@
+../../agents/debug/regression-finder.md

--- a/.opencode/agents/report-checker.md
+++ b/.opencode/agents/report-checker.md
@@ -1,0 +1,1 @@
+../../agents/review/report-checker.md

--- a/.opencode/agents/security-audit.md
+++ b/.opencode/agents/security-audit.md
@@ -1,0 +1,1 @@
+../../agents/review/security-audit.md

--- a/.opencode/agents/senior-reviewer.md
+++ b/.opencode/agents/senior-reviewer.md
@@ -1,0 +1,1 @@
+../../agents/review/senior-reviewer.md

--- a/.opencode/agents/stress-tester.md
+++ b/.opencode/agents/stress-tester.md
@@ -1,0 +1,1 @@
+../../agents/review/stress-tester.md

--- a/.opencode/agents/test-reviewer.md
+++ b/.opencode/agents/test-reviewer.md
@@ -1,0 +1,1 @@
+../../agents/review/test-reviewer.md

--- a/.opencode/agents/waste-detector.md
+++ b/.opencode/agents/waste-detector.md
@@ -1,0 +1,1 @@
+../../agents/review/waste-detector.md

--- a/.opencode/commands/brainstorm.md
+++ b/.opencode/commands/brainstorm.md
@@ -1,0 +1,1 @@
+../../skills/brainstorm/SKILL.md

--- a/.opencode/commands/code-navigation.md
+++ b/.opencode/commands/code-navigation.md
@@ -1,0 +1,1 @@
+../../skills/code-navigation/SKILL.md

--- a/.opencode/commands/commit.md
+++ b/.opencode/commands/commit.md
@@ -1,0 +1,1 @@
+../../skills/commit/SKILL.md

--- a/.opencode/commands/create-agent.md
+++ b/.opencode/commands/create-agent.md
@@ -1,0 +1,1 @@
+../../skills/create-agent/SKILL.md

--- a/.opencode/commands/create-agents-md.md
+++ b/.opencode/commands/create-agents-md.md
@@ -1,0 +1,1 @@
+../../skills/create-agents-md/SKILL.md

--- a/.opencode/commands/create-pr.md
+++ b/.opencode/commands/create-pr.md
@@ -1,0 +1,1 @@
+../../skills/create-pr/SKILL.md

--- a/.opencode/commands/delete-all-handovers.md
+++ b/.opencode/commands/delete-all-handovers.md
@@ -1,0 +1,1 @@
+../../skills/delete-all-handovers/SKILL.md

--- a/.opencode/commands/delete-last-handover.md
+++ b/.opencode/commands/delete-last-handover.md
@@ -1,0 +1,1 @@
+../../skills/delete-last-handover/SKILL.md

--- a/.opencode/commands/handover.md
+++ b/.opencode/commands/handover.md
@@ -1,0 +1,1 @@
+../../skills/handover/SKILL.md

--- a/.opencode/commands/hypothesis-debugging.md
+++ b/.opencode/commands/hypothesis-debugging.md
@@ -1,0 +1,1 @@
+../../skills/hypothesis-debugging/SKILL.md

--- a/.opencode/commands/load-handover.md
+++ b/.opencode/commands/load-handover.md
@@ -1,0 +1,1 @@
+../../skills/load-handover/SKILL.md

--- a/.opencode/commands/orchestrate-agents.md
+++ b/.opencode/commands/orchestrate-agents.md
@@ -1,0 +1,1 @@
+../../skills/orchestrate-agents/SKILL.md

--- a/.opencode/commands/plan.md
+++ b/.opencode/commands/plan.md
@@ -1,0 +1,1 @@
+../../skills/plan/SKILL.md

--- a/.opencode/commands/repair-skill.md
+++ b/.opencode/commands/repair-skill.md
@@ -1,0 +1,1 @@
+../../skills/repair-skill/SKILL.md

--- a/.opencode/commands/report-check.md
+++ b/.opencode/commands/report-check.md
@@ -1,0 +1,1 @@
+../../skills/report-check/SKILL.md

--- a/.opencode/commands/review.md
+++ b/.opencode/commands/review.md
@@ -1,0 +1,1 @@
+../../skills/review/SKILL.md

--- a/.opencode/commands/senior-review.md
+++ b/.opencode/commands/senior-review.md
@@ -1,0 +1,1 @@
+../../skills/senior-review/SKILL.md

--- a/.opencode/commands/visual-companion.md
+++ b/.opencode/commands/visual-companion.md
@@ -1,0 +1,1 @@
+../../skills/visual-companion/SKILL.md

--- a/.opencode/commands/work.md
+++ b/.opencode/commands/work.md
@@ -1,0 +1,1 @@
+../../skills/work/SKILL.md

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "context7": {
+      "type": "remote",
+      "url": "https://mcp.context7.com/mcp"
+    }
+  }
+}

--- a/.opencode/rules/quiver-opencode-compat.md
+++ b/.opencode/rules/quiver-opencode-compat.md
@@ -1,0 +1,55 @@
+# Quiver Opencode Compatibility Rules
+
+These rules apply when running Quiver commands (`/commandname`) or agents (`@agentname`)
+inside Opencode. They explain how to handle Claude Code-specific primitives that have
+no direct equivalent in Opencode.
+
+## 1. AskUserQuestion (interactive choice buttons)
+
+`AskUserQuestion` is a Claude Code tool. Opencode does not have it.
+
+**Replacement:** When a command needs a user decision, present the choices as a numbered
+plain-text list and wait for the user to type their selection number.
+
+Example -- instead of an interactive button prompt:
+```
+Choose an option:
+1. Execute this plan
+2. Create a new branch
+3. Done -- I'll handle the rest
+```
+Then wait for the user to respond with a number before proceeding.
+
+## 2. Agent tool (subagent dispatch)
+
+The `Agent` tool for spawning subagents is Claude Code-specific.
+
+**Replacement:** Use `@agentname` mentions to invoke a specialist agent as a subagent.
+For example, where a command says "dispatch the `senior-reviewer` agent", use
+`@senior-reviewer` in your message. Available agents are listed in `.opencode/agents/`.
+
+Note: Multi-agent orchestration commands (`/review`, `/plan`) use `Agent` tool dispatch
+internally. These commands load and run in Opencode, but subagent dispatch relies on
+Opencode's `@agent` mention behavior instead of parallel Claude Code subagents.
+
+## 3. Shell injection blocks
+
+Inline shell blocks (`` !`command` ``) work identically in Opencode. No adaptation needed.
+
+## 4. Frontmatter fields (when-to-use, name)
+
+`when-to-use:` and `name:` frontmatter fields in command files are Claude Code-specific
+routing metadata. Opencode ignores them. No action needed -- they are harmless.
+
+## 5. Handover file paths
+
+Handover files write to `.claude/handovers/` relative to the project root. This path is
+unchanged in Opencode since it is relative to the project root, not the CLI install path.
+
+## 6. Session hooks (PreCompact, SessionStart)
+
+PreCompact and SessionStart hooks do not fire in Opencode. They are Claude Code lifecycle
+events. Consequence: automatic handover creation on context compaction does not happen.
+
+**Replacement:** Trigger handover creation manually by invoking `/handover` at natural
+breakpoints or before ending a session.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,24 @@ Then try `/brainstorm` in any session.
 - Agent dispatch reads agent persona prompts from `agents/` and executes them inline. The `/review` skill dispatches 5 agents by default, or the full pipeline with `--deep`.
 - The hook script uses `claude -p` for transcript summarization. If the `claude` CLI is not installed, the auto-save hook will silently skip (manual `/handover` still works).
 
+### Opencode
+
+```
+opencode plugin install yagizdo/quiver
+```
+
+Quiver registers 19 slash commands (type `/` to browse) and 20 specialist agents
+(invoke with `@agentname`). Commands read from `.opencode/commands/`, agents from
+`.opencode/agents/`.
+
+> **Note:** `AskUserQuestion` interactive prompts are not available in Opencode.
+> Commands present choices as numbered lists; type the number to select.
+> Multi-agent dispatch (`/review`, `/plan`) works but uses Opencode's `@agent`
+> mention syntax instead of Claude Code's `Agent` tool.
+>
+> **Windows:** Requires `git config core.symlinks true` before cloning (Developer Mode
+> or group policy grant needed).
+
 ## Components
 
 | Component | Count |


### PR DESCRIPTION
## Summary

Adds opencode CLI support by creating a `.opencode/` overlay that wires Quiver's canonical agents and commands into opencode's native discovery paths via symlinks. This follows the same source-of-truth invariant as the Cursor overlay: canonical files are never modified.

- **New:** `.opencode/opencode.json` -- opencode manifest; registers context7 MCP remote server
- **New:** `.opencode/rules/quiver-opencode-compat.md` -- compatibility guide explaining how Claude Code-specific primitives (`AskUserQuestion`, `Agent` tool, hooks) map to opencode equivalents
- **New:** `.opencode/agents/` -- 20 symlinks pointing to `../../agents/**/*.md`
- **New:** `.opencode/commands/` -- 19 symlinks pointing to `../../skills/*/SKILL.md`
- **New:** `.claude/worktrees/agent-*` -- worktree refs from agent dispatch during development
- **Modified:** `README.md` -- adds opencode install section with caveats for `AskUserQuestion` and Windows symlink requirements

### How it works

1. `opencode plugin install yagizdo/quiver` clones the repo into opencode's plugin directory.
2. opencode reads `opencode.json` to discover MCP servers, then walks `.opencode/commands/` for slash commands and `.opencode/agents/` for `@agent` mentions.
3. Symlinks resolve to the canonical skill/agent Markdown files -- no duplication, no drift.
4. The compat rule file (`quiver-opencode-compat.md`) is loaded as a rule by opencode and tells the model how to handle Claude Code-specific tool calls at runtime.

### Design decisions

| Decision | Choice | Why |
|----------|--------|-----|
| Symlinks vs copies | Symlinks | One source of truth; fixes to canonical files propagate instantly |
| Compat rules as a rule file | `.opencode/rules/` | Opencode loads rule files automatically; no skill forking needed |
| context7 via remote MCP | `https://mcp.context7.com/mcp` | Matches existing Claude Code MCP config |

## Test plan

- [ ] `opencode plugin install yagizdo/quiver` succeeds
- [ ] `/review` slash command appears in opencode's `/` menu
- [ ] `@senior-reviewer` agent is invokable
- [ ] context7 MCP connects (verify with a `/review` that triggers a library lookup)
- [ ] Canonical files unchanged: `git diff --stat master...HEAD -- agents/ skills/ hooks/ .claude-plugin/` returns no output
- [ ] Symlinks resolve correctly on macOS and Linux