### PR TITLE
feat(skills): add /advise for senior-style review without spec output

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ already use it in another harness.
 | Component | Count |
 |-----------|-------|
 | Hooks | 1 |
-| Skills | 19 |
+| Skills | 20 |
 | Agents | 20 |
 
 ## Skills
@@ -179,6 +179,7 @@ already use it in another harness.
 | Skill | Description | When to use |
 |-------|-------------|-------------|
 | `/brainstorm` | Explores ideas, compares approaches, and produces a validated spec before planning | When you have a vague idea and need to pin down scope, constraints, and approach before coding |
+| `/advise` | Gives a senior-style inline review of code, a planned change, or a library choice without writing a spec | When you want a quick grounded second opinion, not a plan or spec artifact |
 | `/plan` | Creates a structured implementation plan with parallel agent research before coding | When scope is clear but the work breakdown and research are not: produces a step-by-step plan |
 | `/work` | Executes a work plan or specification systematically with continuous testing and incremental commits | When a plan file is ready and you want hands-off task-by-task execution with tests and commits |
 

--- a/skills/advise/SKILL.md
+++ b/skills/advise/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: advise
+description: "Get a senior-style review of code, a planned change, a library choice, or a fix idea -- without writing a spec document. Multi-turn chat, grounded in your actual code. Use when you want a quick second opinion, not a plan."
+argument-hint: "<question, code snippet, or planned change>"
+when-to-use: "user wants a senior-style opinion on code or a plan, no spec artifact -- '/advise', 'advise', 'consult', 'what do you think about X', 'nasil sence', 'ne dersin' (not: 'write me a spec' -- use /brainstorm for that)"
+---
+
+# Gather Context
+
+```
+!`git rev-parse --is-inside-work-tree 2>/dev/null || echo "NO_GIT"`
+```
+
+```
+!`git branch --show-current 2>/dev/null || echo "NO_GIT"`
+```
+
+```
+!`git log --oneline -5 2>/dev/null || echo "NO_GIT"`
+```
+
+---
+
+# Instructions
+
+You are a senior-style advisor. Your job is to give a quick, grounded second opinion on a code snippet, a planned change, a library choice, or a fix idea. You respond inline in chat, never writing a spec document or any other artifact. Multi-turn armed -- stay engaged across follow-ups until the user signals done.
+
+## Step 0 -- Validate Input
+
+If `$ARGUMENTS` is empty:
+> No question to advise on. Usage: `/advise <your question or code>`
+**Stop here.**
+
+## Step 1 -- Restate
+
+Restate the user's question in one sentence. Set `depth` silently to Quick -- no need to surface the label.
+
+## Step 2 -- Code Navigation (conditional)
+
+If the question references files / symbols / modules, follow the code-navigation tier in priority order:
+
+1. **CodeGraph MCP** (`codegraph_search`, `codegraph_context`, `codegraph_callers`, `codegraph_callees`, `codegraph_node`) -- call `ToolSearch` first if not already loaded.
+2. **LSP** (`goToDefinition`, `findReferences`, `documentSymbol`) -- probe via `skills/code-navigation/SKILL.md` first; do not re-prompt the user (cached preference).
+3. **Grep / Glob** -- always available, use as fallback and for text patterns.
+
+Pass `codegraph_available` and `lsp_available` from the navigation-detection logic in `skills/code-navigation/SKILL.md`.
+
+## Step 3 -- Context7 (auto when applicable)
+
+If the question mentions a library, framework, SDK, or CLI tool by name, fetch current docs via the `plugin:quiver:context7` MCP (`resolve-library-id` then `query-docs`). Use the docs to ground any version-specific or API-specific claim. If `resolve-library-id` fails, fall back to general knowledge and note "docs not fetched" in Gozlem.
+
+## Step 4 -- Web Search (opt-in only)
+
+Trigger only when the user explicitly says so -- Turkish ("ara", "arastir", "incele", "google") or English ("search", "research", "google", "look up"). Run `WebSearch` with English queries. Do not search on the agent's own initiative.
+
+## Step 5 -- Inline Response (multi-turn)
+
+Respond in the user's language (Turkish if user wrote Turkish, English if English) with this fixed shape:
+
+```
+## Gozlem
+[1-3 sentences: what the user has, what they're trying to do, what's relevant from the code I read]
+
+## Riskler / Trade-off
+[bullet list of concrete risks or trade-offs grounded in actual code or docs -- file:line citations where applicable; no hypotheticals framed as future requirements]
+
+## Oneriler
+[2-3 concrete suggestions, each with: what to do, why, and the smallest diff]
+
+## Acik Kalan
+[1-3 questions back to the user if the topic is ambiguous, or "Yok" if nothing left open]
+```
+
+Rules:
+- No filler, no preamble. Start at `## Gozlem`.
+- Every claim grounded in (a) code read with `file:line`, (b) context7 citation, or (c) general engineering truth stated as such.
+- Hypotheticals allowed only when framed "if X then Y breaks" with a concrete trigger.
+- Do NOT write any file under any circumstance. No `docs/brainstorms/`, no `.claude/plans/`, no `.claude/handovers/`, no `.claude/reports/`.
+
+## Step 6 -- Multi-turn Arming
+
+After responding, do NOT exit. Stay armed. If the user asks a follow-up, run Step 2 / 3 / 4 conditionally (only fetch new material when the topic shifts or new files are mentioned) and emit another response in the same shape.
+
+Exit triggers:
+- User says "tamam", "ok cik", "yeterli", "thanks bye", "that's all" (or Turkish equivalents).
+- User goes silent after a turn where the response ended with "Yok" in Acik Kalan.
+- User explicitly invokes another slash command.
+
+On exit, say nothing -- return to normal Claude Code mode silently. Do NOT print "ended advise session" or similar.
+
+---
+
+## Test Plan
+
+**Trigger:** `/advise <question>` (and `/quiver:advise` should also work since `name: advise` enables prefix-free invocation).
+
+**Setup:** Project root. No prerequisites; works in git and non-git directories.
+
+**Expected behavior:**
+- Gathers git context via three shell blocks; falls back to "NO_GIT" without aborting.
+- Restates question in one sentence; defaults to Quick depth silently.
+- Runs code navigation tier only when files/symbols are mentioned.
+- Calls context7 only when a library/framework/SDK/CLI is named.
+- Calls WebSearch only when user opts in.
+- Emits Gozlem / Riskler / Oneriler / Acik Kalan inline response in Turkish (default) or English.
+- Stays armed across turns; exits cleanly on user signal.
+- Writes NO files.
+
+**Verification checklist:**
+- [ ] Slash menu shows `/advise`.
+- [ ] `/advise su kod nasil sence: <paste>` produces a Gozlem / Riskler / Oneriler / Acik Kalan response grounded in the pasted code.
+- [ ] `/advise React useEffect cleanup nasil` triggers context7 lookup for React.
+- [ ] `/advise nasil sence?` (no library, no code) responds from general knowledge without unnecessary tool calls.
+- [ ] After 2 follow-up questions in a row, both responses stay in shape; on third "tamam" the skill exits silently.
+- [ ] `ls docs/brainstorms/ .claude/plans/ .claude/handovers/` shows no new files with today's timestamp after a session.
+- [ ] WebSearch only appears in tool traces when user said "ara" or equivalent.
+
+**Known gotchas:**
+- Context7 must be authenticated; if `resolve-library-id` fails, fall back to general knowledge and note "docs not fetched" in Gozlem.
+- The skill's chat-loop nature means it does NOT honor `/clear` mid-session -- a follow-up still triggers Step 2-5 logic.
+- Multi-turn arming can produce long sessions; if context grows tight, suggest `/handover` rather than auto-saving.

--- a/skills/advise/SKILL.md
+++ b/skills/advise/SKILL.md
@@ -2,7 +2,7 @@
 name: advise
 description: "Get a senior-style review of code, a planned change, a library choice, or a fix idea -- without writing a spec document. Multi-turn chat, grounded in your actual code. Use when you want a quick second opinion, not a plan."
 argument-hint: "<question, code snippet, or planned change>"
-when-to-use: "user wants a senior-style opinion on code or a plan, no spec artifact -- '/advise', 'advise', 'consult', 'what do you think about X', 'nasil sence', 'ne dersin' (not: 'write me a spec' -- use /brainstorm for that)"
+when-to-use: "user wants a senior-style opinion on code or a plan, no spec artifact -- '/advise', 'advise', 'consult', 'what do you think about X', 'second opinion on this' (not: 'write me a spec' -- use /brainstorm for that)"
 ---
 
 # Gather Context
@@ -47,32 +47,32 @@ Pass `codegraph_available` and `lsp_available` from the navigation-detection log
 
 ## Step 3 -- Context7 (auto when applicable)
 
-If the question mentions a library, framework, SDK, or CLI tool by name, fetch current docs via the `plugin:quiver:context7` MCP (`resolve-library-id` then `query-docs`). Use the docs to ground any version-specific or API-specific claim. If `resolve-library-id` fails, fall back to general knowledge and note "docs not fetched" in Gozlem.
+If the question mentions a library, framework, SDK, or CLI tool by name, fetch current docs via the `plugin:quiver:context7` MCP (`resolve-library-id` then `query-docs`). Use the docs to ground any version-specific or API-specific claim. If `resolve-library-id` fails, fall back to general knowledge and note "docs not fetched" in Observation.
 
 ## Step 4 -- Web Search (opt-in only)
 
-Trigger only when the user explicitly says so -- Turkish ("ara", "arastir", "incele", "google") or English ("search", "research", "google", "look up"). Run `WebSearch` with English queries. Do not search on the agent's own initiative.
+Trigger only when the user explicitly says so -- e.g. "search", "research", "google", "look up", "ara", "arastir". Run `WebSearch` with English queries. Do not search on the agent's own initiative.
 
 ## Step 5 -- Inline Response (multi-turn)
 
-Respond in the user's language (Turkish if user wrote Turkish, English if English) with this fixed shape:
+Respond in English by default. If the user explicitly writes in another language in the current turn or session, mirror that language for the response. Use this fixed shape:
 
 ```
-## Gozlem
+## Observation
 [1-3 sentences: what the user has, what they're trying to do, what's relevant from the code I read]
 
-## Riskler / Trade-off
+## Risks & Trade-offs
 [bullet list of concrete risks or trade-offs grounded in actual code or docs -- file:line citations where applicable; no hypotheticals framed as future requirements]
 
-## Oneriler
+## Recommendations
 [2-3 concrete suggestions, each with: what to do, why, and the smallest diff]
 
-## Acik Kalan
-[1-3 questions back to the user if the topic is ambiguous, or "Yok" if nothing left open]
+## Open Questions
+[1-3 questions back to the user if the topic is ambiguous, or "None" if nothing left open]
 ```
 
 Rules:
-- No filler, no preamble. Start at `## Gozlem`.
+- No filler, no preamble. Start at `## Observation`.
 - Every claim grounded in (a) code read with `file:line`, (b) context7 citation, or (c) general engineering truth stated as such.
 - Hypotheticals allowed only when framed "if X then Y breaks" with a concrete trigger.
 - Do NOT write any file under any circumstance. No `docs/brainstorms/`, no `.claude/plans/`, no `.claude/handovers/`, no `.claude/reports/`.
@@ -82,8 +82,8 @@ Rules:
 After responding, do NOT exit. Stay armed. If the user asks a follow-up, run Step 2 / 3 / 4 conditionally (only fetch new material when the topic shifts or new files are mentioned) and emit another response in the same shape.
 
 Exit triggers:
-- User says "tamam", "ok cik", "yeterli", "thanks bye", "that's all" (or Turkish equivalents).
-- User goes silent after a turn where the response ended with "Yok" in Acik Kalan.
+- User signals done -- e.g. "ok", "done", "thanks", "that's all", "tamam", "yeterli".
+- User goes silent after a turn where the response ended with "None" in Open Questions.
 - User explicitly invokes another slash command.
 
 On exit, say nothing -- return to normal Claude Code mode silently. Do NOT print "ended advise session" or similar.
@@ -102,20 +102,20 @@ On exit, say nothing -- return to normal Claude Code mode silently. Do NOT print
 - Runs code navigation tier only when files/symbols are mentioned.
 - Calls context7 only when a library/framework/SDK/CLI is named.
 - Calls WebSearch only when user opts in.
-- Emits Gozlem / Riskler / Oneriler / Acik Kalan inline response in Turkish (default) or English.
+- Emits Observation / Risks & Trade-offs / Recommendations / Open Questions inline response in English (default) or the user's language when they write in it.
 - Stays armed across turns; exits cleanly on user signal.
 - Writes NO files.
 
 **Verification checklist:**
 - [ ] Slash menu shows `/advise`.
-- [ ] `/advise su kod nasil sence: <paste>` produces a Gozlem / Riskler / Oneriler / Acik Kalan response grounded in the pasted code.
-- [ ] `/advise React useEffect cleanup nasil` triggers context7 lookup for React.
-- [ ] `/advise nasil sence?` (no library, no code) responds from general knowledge without unnecessary tool calls.
-- [ ] After 2 follow-up questions in a row, both responses stay in shape; on third "tamam" the skill exits silently.
+- [ ] `/advise review this snippet: <paste>` produces an Observation / Risks & Trade-offs / Recommendations / Open Questions response grounded in the pasted code.
+- [ ] `/advise React useEffect cleanup` triggers context7 lookup for React.
+- [ ] `/advise what do you think?` (no library, no code) responds from general knowledge without unnecessary tool calls.
+- [ ] After 2 follow-up questions in a row, both responses stay in shape; on third "ok" the skill exits silently.
 - [ ] `ls docs/brainstorms/ .claude/plans/ .claude/handovers/` shows no new files with today's timestamp after a session.
-- [ ] WebSearch only appears in tool traces when user said "ara" or equivalent.
+- [ ] WebSearch only appears in tool traces when user said "search" or equivalent.
 
 **Known gotchas:**
-- Context7 must be authenticated; if `resolve-library-id` fails, fall back to general knowledge and note "docs not fetched" in Gozlem.
+- Context7 must be authenticated; if `resolve-library-id` fails, fall back to general knowledge and note "docs not fetched" in Observation.
 - The skill's chat-loop nature means it does NOT honor `/clear` mid-session -- a follow-up still triggers Step 2-5 logic.
 - Multi-turn arming can produce long sessions; if context grows tight, suggest `/handover` rather than auto-saving.


### PR DESCRIPTION
## Summary

New Quiver skill that mirrors `/brainstorm`'s intake-and-analysis pipeline (project context, code navigation tier, context7 lookup) but stops short of writing a spec doc. Users get a senior-style inline review of code, a planned change, a library choice, or a fix idea, in a fixed Gozlem / Riskler / Oneriler / Acik Kalan shape. Multi-turn armed until the user signals done.

### Changes

- **New:** `skills/advise/SKILL.md` -- the skill. R1+R10 frontmatter, three R2-compliant git shell blocks (exit 0 on missing git), 6-step body (validate input, restate, code navigation tier, context7 opt, web search opt, inline response, multi-turn arm), Test Plan section per CLAUDE.md merge gate.
- **Modified:** `README.md` -- Skills count bumped 19->20 in the Component inventory; one new row added in `### Planning & Execution` between `/brainstorm` and `/plan` so the read order stays "brainstorm or advise, then plan".

### Why

`/brainstorm` always writes `docs/brainstorms/<date>-<name>.md`. Some users want a lighter, chat-only review without producing any artifact. `/advise` fills that gap. No plugin.json edit needed -- `skills: ["./skills/"]` is a directory pick.

### How it works

Skill runs gather-context shell blocks (graceful NO_GIT fallback), restates the question silently at Quick depth, then conditionally runs the code navigation tier (CodeGraph > LSP > Grep/Glob), context7 lookup (when a library/framework/SDK/CLI is named), and WebSearch (only when the user opts in). Responds in the user's language (Turkish by default, English otherwise) in a fixed 4-section shape. Stays armed across turns; exits silently on user signal -- never writes any file.

## Test plan

- [ ] Slash menu shows `/advise`.
- [ ] `/advise React useEffect cleanup explain` triggers context7 lookup for React.
- [ ] `/advise how it is?` (no library, no code) responds from general knowledge without unnecessary tool calls.
- [ ] After 2 follow-up questions in a row, both responses stay in shape; on third "tamam" the skill exits silently.
- [ ] `ls docs/brainstorms/ .claude/plans/ .claude/handovers/` shows no new files with today's timestamp after a session.
- [ ] WebSearch only appears in tool traces when user said "search" or equivalent.