### PR TITLE
Add the /design, /design-build, and /design-verify pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,9 @@ Dependencies: `bash`, `claude` CLI.
 ## Architecture
 
 - **`.claude-plugin/`** — Plugin manifest (`plugin.json`) and marketplace listing (`marketplace.json`). Defines name, version, hook/skill/agent registration, and MCP servers.
-- **`skills/`** — 18 skill directories (each contains `SKILL.md`). Each `SKILL.md` carries YAML front-matter (`name`, `description`) and is a self-contained prompt; the `name` field doubles as the slash invocation (`/handover`, `/review`, etc.). **Exception:** `visual-companion` also contains `server.py`, a runtime executable -- this is the only skill with non-prompt code.
-- **`agents/`** — 16 agent definitions organized by category (`review/`, `research/`, `debug/`). Agents are persona prompts spawned as subagents.
-- **`hooks/`** — `hooks.json` registers event hooks; `scripts/` holds implementations. Currently one hook: PreCompact (fires before context compaction).
+- **`skills/`** — 25 skill directories (each contains `SKILL.md`). Each `SKILL.md` carries YAML front-matter (`name`, `description`) and is a self-contained prompt; the `name` field doubles as the slash invocation (`/handover`, `/review`, etc.). **Exception:** `visual-companion` also contains `server.py`, a runtime executable -- this is the only skill with non-prompt code.
+- **`agents/`** — 20 agent definitions organized by category (`review/`, `research/`, `debug/`). Agents are persona prompts spawned as subagents.
+- **`hooks/`** — `hooks.json` registers event hooks; `scripts/` holds implementations. Two hooks: PreCompact (fires before context compaction, saves a handover) and SessionStart (emits the skill routing block from every skill's `when-to-use`).
 - **Storage** — Handover files are written to `<project>/.claude/handovers/`.
 - **Rules** — `.claude/rules/` contains `skill-rules.md` (hard rules and learned lessons for skills, formerly `command-rules.md`), `review-agent-rules.md`, `cli-overlay-rules.md`, and `readme-structure.md`.
 - **External MCP** — Context7 MCP server (`plugin.json` > `mcpServers`) provides real-time library documentation lookups for review agents.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ already use it in another harness.
 | Component | Count |
 |-----------|-------|
 | Hooks | 1 |
-| Skills | 22 |
+| Skills | 24 |
 | Agents | 20 |
 
 ## What Do I Use?
@@ -103,6 +103,21 @@ already use it in another harness.
 | Situation | Command | What happens |
 |-----------|---------|--------------|
 | I want to build a project from a description without touching it myself | `/ship` | Deep planning Q&A (outcomes, scope, stack, verification), then autonomous loop: code + test + review + fix until done. Manifest at `docs/ship/<project>-manifest.md` |
+
+### Implementing a Design
+
+| Situation | Command | What happens |
+|-----------|---------|--------------|
+| A Figma frame is ready to become code | `/design` | Reads the selected nodes through the figma-bridge MCP, maps Figma variables onto the project's own theme tokens, and writes a self-contained plan to `.claude/plans/` |
+| Design plan is ready, want it built pixel-accurate | `/design-build` | Implements each node against its embedded spec, captures the running UI, compares it to the Figma reference, and fixes deviations under a bounded retry budget |
+
+```
+/design                    # extract whatever is selected in Figma
+/design 4029:12345         # extract a specific node by ID
+/design-build              # pick a design plan and build it
+```
+
+`/design` is the only half that talks to Figma. The plan carries every measurement, token, and layout anchor it produced, so `/design-build` runs with Figma disconnected. Setup is in [External Dependencies](#external-dependencies).
 
 ### Reviewing Code
 
@@ -226,6 +241,27 @@ This plugin includes a [Context7](https://context7.com) MCP server for real-time
 - `query-docs`: Get documentation for a specific library
 
 Supports 100+ frameworks including Rails, React, Next.js, Vue, Django, Laravel, and more. Library/framework names from your codebase are sent to the service only during review agent execution (e.g., best-practices checks), not at plugin load time.
+
+### figma-bridge (optional, for `/design`)
+
+`/design` reads Figma through the [figma-mcp-bridge](https://github.com/gethopp/figma-mcp-bridge) MCP server. It is not bundled in `plugin.json` -- the bridge also needs a Figma plugin installed by hand, so auto-starting the server alone would only get you halfway. Set it up once:
+
+1. Add the server to your MCP config:
+
+   ```json
+   {
+     "figma-bridge": {
+       "command": "npx",
+       "args": ["-y", "@gethopp/figma-mcp-bridge"]
+     }
+   }
+   ```
+
+2. Download the Figma plugin from the [releases page](https://github.com/gethopp/figma-mcp-bridge/releases), then in Figma: **Plugins > Development > Import plugin from manifest**.
+
+3. Run the plugin inside the Figma file you want to read and leave it open. It connects to the server over a WebSocket; closing it drops the connection mid-extraction.
+
+`/design` only calls the bridge's read tools. `/design-build` never calls it at all. Every other Quiver skill works without it.
 
 ## Uninstall
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ already use it in another harness.
 
 | Component | Count |
 |-----------|-------|
-| Hooks | 1 |
-| Skills | 24 |
+| Hooks | 2 |
+| Skills | 25 |
 | Agents | 20 |
 
 ## What Do I Use?
@@ -109,15 +109,17 @@ already use it in another harness.
 | Situation | Command | What happens |
 |-----------|---------|--------------|
 | A Figma frame is ready to become code | `/design` | Reads the selected nodes through the figma-bridge MCP, maps Figma variables onto the project's own theme tokens, and writes a self-contained plan to `.claude/plans/` |
-| Design plan is ready, want it built pixel-accurate | `/design-build` | Implements each node against its embedded spec, captures the running UI, compares it to the Figma reference, and fixes deviations under a bounded retry budget |
+| Design plan is ready, want it built pixel-accurate | `/design-build` | Implements each node against its embedded spec, then fixes whatever `/design-verify` reports, under a bounded retry budget |
+| Built UI is on screen, want to know how far off it is | `/design-verify` | Captures the running app, normalizes both images to a common logical width, measures the deviations, and writes a report to disk |
 
 ```
 /design                    # extract whatever is selected in Figma
 /design 4029:12345         # extract a specific node by ID
 /design-build              # pick a design plan and build it
+/design-verify             # measure a built screen against its spec
 ```
 
-`/design` is the only half that talks to Figma. The plan carries every measurement, token, and layout anchor it produced, so `/design-build` runs with Figma disconnected. Setup is in [External Dependencies](#external-dependencies).
+`/design` is the only stage that talks to Figma. The plan carries every measurement, token, and layout anchor it produced, so `/design-build` runs with Figma disconnected and `/design-verify` measures against the plan alone. Each stage stands on its own: `/design-verify` works against any file with a `### Node Specs` section, including a hand-written measurement spec, and needs no screenshot and no installed comparison tool. Setup is in [External Dependencies](#external-dependencies).
 
 ### Reviewing Code
 
@@ -173,6 +175,7 @@ Re-review detection: if you run `/review` again on the same branch after fixing 
 | Hook | Event | Description |
 |------|-------|-------------|
 | `pre-compact-handover` | PreCompact | Summarizes the conversation and saves a handover before the CLI compacts context |
+| `session-start-auto-dispatch` | SessionStart | Reads every skill's `when-to-use` and emits a routing block so intent matches invoke the right skill |
 
 > The hook keeps the 3 most recent handovers in `.claude/handovers/` and prunes older ones automatically. Filenames are timestamps, so sort order is lexicographic.
 
@@ -261,7 +264,19 @@ Supports 100+ frameworks including Rails, React, Next.js, Vue, Django, Laravel, 
 
 3. Run the plugin inside the Figma file you want to read and leave it open. It connects to the server over a WebSocket; closing it drops the connection mid-extraction.
 
-`/design` only calls the bridge's read tools. `/design-build` never calls it at all. Every other Quiver skill works without it.
+`/design` only calls the bridge's read tools. `/design-build` and `/design-verify` never call it at all. Every other Quiver skill works without it.
+
+### ImageMagick (optional, for `/design-verify`)
+
+`/design-verify` works with nothing installed -- it reads the built UI against the spec and marks the report low confidence. Installing ImageMagick upgrades that structural read into a measured differing-pixel count:
+
+```
+brew install imagemagick
+```
+
+The skill probes `magick -version` and `magick -list metric`, picks the `PDC` metric when the build has it, and records which comparison path produced each report. Nothing breaks without it; the reports simply carry fewer numbers.
+
+Device capture is optional in the same way. `/design-verify` uses `xcrun simctl` for iOS simulators, `adb` for Android, `pymobiledevice3` for physical iOS devices, and the Playwright MCP for web -- whichever is already on the machine. Each absent tool prints one install hint and the run continues down to the next option.
 
 ## Uninstall
 

--- a/skills/design-build/SKILL.md
+++ b/skills/design-build/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: design-build
+description: "Execute a design plan produced by /design -- implements each node against its embedded measurement spec, captures the running UI, compares it to the Figma reference, and fixes deviations under a bounded retry budget. Runs with Figma disconnected; the plan carries every number it needs."
+argument-hint: "<path to a *-design-plan.md, or empty to pick one>"
+when-to-use: "user wants to build a design plan into working pixel-accurate UI -- '/design-build', 'build the design plan', 'implement the figma plan', 'make it match the design', 'fix the pixel differences'"
+---
+
+# Gather Context
+
+```
+!`git rev-parse --is-inside-work-tree 2>/dev/null || echo "NO_GIT"`
+```
+
+```
+!`git branch --show-current 2>/dev/null || echo "NO_GIT"`
+```
+
+```
+!`git status --short 2>/dev/null || echo "NO_GIT"`
+```
+
+---
+
+# Instructions
+
+You are a design implementation specialist. You take a plan written by `/design`, build it, then prove it matches by capturing the running UI and comparing it against the Figma reference screenshots. You do not open Figma -- the plan is self-contained.
+
+**Announce:** "Using the design-build skill to implement the design plan."
+
+## Phase 0 -- Git Availability
+
+If a gather-context block returned `NO_GIT`, this directory is not a git repository.
+Print: `> No git repository detected -- skipping branch and commit steps.`
+Proceed. Skip branch creation in Phase 2 and all commit steps in Phase 4.
+
+## Phase 1 -- Load the Plan
+
+**Path given.** If `$ARGUMENTS` ends in `.md` or contains `/`, read that file.
+
+**No arguments.** Use the Glob tool on `.claude/plans/*-design-plan.md`. Treat an empty result as none found.
+
+- One match: read it and print `> Executing design plan: {filename}`.
+- Several matches: use `AskUserQuestion` with one button per plan, most recent first, plus `"Other -- I'll give a path"`.
+- No matches: print
+  ```
+  > No design plan found. Run /design first to extract a Figma design into a plan.
+  ```
+  **Stop here.**
+
+**Validate the plan.** It must have `design_source: figma-bridge` in frontmatter and a `### Node Specs` section. If either is missing, print:
+```
+> {filename} is not a design plan. It has no Node Specs section. Run /design to
+> produce one, or pass a design plan path explicitly.
+```
+**Stop here.**
+
+**Check the references.** Every path under `screenshot_dir` named in a node spec must exist on disk. If any are missing, print which ones and continue -- those nodes fall back to spec-versus-code comparison in Phase 4.
+
+## Phase 2 -- Capture Target
+
+Pick the capture method **once**, up front, by reading the project. Do not walk a ladder of attempts.
+
+Detect the project type from manifest files at the project root:
+
+| Signal | Project type |
+|--------|--------------|
+| `pubspec.yaml` | Flutter |
+| `package.json` with `next`, `react`, `vue`, `svelte`, `astro`, or `vite` | Web |
+| `index.html` at root with no JS manifest | Web |
+| `*.xcodeproj`, `*.xcworkspace`, or `Package.swift` with UI targets | iOS native |
+| `build.gradle` or `build.gradle.kts` with an Android plugin | Android native |
+
+Then resolve the capture method:
+
+| Project type | Capture method |
+|--------------|----------------|
+| Web | Playwright or Puppeteer MCP screenshot |
+| iOS native, simulator | `simulator_screenshot` from the `xc-interact` MCP |
+| iOS native, physical device | `idevicescreenshot` (libimobiledevice) |
+| Android native, emulator or physical device | `adb exec-out screencap -p > <path>` |
+| Flutter | resolve the run target first, see below |
+
+**Flutter run target.** Run `flutter devices` with the Bash tool and read the output:
+- An Android device or emulator is attached: use `adb exec-out screencap -p`. This works for emulators and physical devices alike.
+- Only an iOS simulator is attached: use `simulator_screenshot` from `xc-interact`.
+- Only a physical iOS device is attached: use `idevicescreenshot`. Probe it once with `which idevicescreenshot` via the Bash tool. If absent, print:
+  ```
+  > No screenshot capture available for a physical iOS device.
+  > Install it with: brew install libimobiledevice
+  > Continuing with spec-versus-code comparison instead.
+  ```
+- Both Android and iOS targets are attached: use `AskUserQuestion`.
+  > Which device should the design be verified against?
+
+  Build one button per attached device from the `flutter devices` output.
+- Nothing attached: fall back to spec-versus-code.
+
+**MCP schema loading.** If the chosen method needs a deferred MCP tool, load its schema once with `ToolSearch` before the first capture. Do not reload per task.
+
+**Spec-versus-code fallback.** When no capture method resolves, verification for every task is a careful read of the written code against the node spec: every measurement, token, and anchor checked by hand. Print:
+```
+> No UI capture available -- verifying against the spec by reading the code.
+```
+
+Record the chosen method. Print `> Capture target: {method}`.
+
+## Phase 3 -- Branch
+
+Skip entirely if `NO_GIT`.
+
+If the current branch is the default branch (`master` or `main`), create a feature branch named `design/<slug>` from the plan's slug. Otherwise stay on the current branch.
+
+## Phase 4 -- Build Loop
+
+Work the plan's `### Tasks` in order. New-token tasks come first -- later tasks reference those tokens.
+
+For each task:
+
+### 4a -- Implement
+
+Read the node specs the task names. Write the code using the plan's literal values and the Token Map. Match the project's component conventions from the plan's `### Stack and Conventions` section.
+
+**Layout reconciliation is mandatory.** Before writing any centering, alignment, or positioning code, check whether the node has a `Reconciliation:` line in its spec.
+
+- **Reconciliation line present with a precedent `file:line`.** Read that file range. Use the same mechanism. Do not substitute a simpler one that happens to compile -- the precedent exists because the simple version produces the wrong result.
+- **Reconciliation line present, no precedent (`No precedent found`).** Derive a solution from the layout chrome mechanism the plan records under `### Stack and Conventions`. The rule: center within the region the chrome excludes, never within the full screen. Concretely, that means constraining the content to the chrome-excluded region and centering inside that constraint, rather than centering at page level and hoping the chrome cancels out. Add a short comment naming what the content is centered within, so the next reader does not simplify it back into a page-level center.
+- **No Reconciliation line.** The anchor is either a flow position or a plain edge inset. Implement it directly.
+
+Follow the plan's File Map. Do not create files the plan does not list.
+
+### 4b -- Capture and Compare
+
+Skip to 4c with a `spec-check` result when the capture method is spec-versus-code.
+
+1. Get the app into the state that shows this task's node. Build and launch or reload as the stack requires.
+2. Capture a screenshot with the Phase 2 method. Save it to `.claude/plans/assets/<slug>/actual/<task-id>.png`.
+3. Read the capture and the Figma reference named in the node spec's `Reference:` line.
+4. Compare against the spec, in this order. Report each as a deviation with its measured delta:
+   - **Anchor** -- is the node positioned relative to the right region? Measure its center against the chrome-excluded region's center. This is the first check because it is the one that silently fails.
+   - **Box** -- width, height, and insets against the spec numbers.
+   - **Spacing** -- gaps and padding.
+   - **Typography** -- size, weight, line height, color.
+   - **Fill, stroke, radius, effects.**
+
+A deviation of 2px or less on any single measurement is within tolerance. Anything larger is a deviation to fix.
+
+### 4c -- Fix, Bounded
+
+If there are no deviations, go to 4d.
+
+Otherwise fix the largest deviation first, then recapture and recompare. **Three attempts maximum per task**, counting the initial implementation as attempt one.
+
+After the third attempt still leaves deviations, **stop and ask**. Do not keep looping. Call `AskUserQuestion`:
+
+> Task {id} still differs from the design after 3 attempts:
+> {one line per remaining deviation with its measured delta}
+
+Buttons: `["Accept as-is -- note it and move on", "I'll describe the fix", "Try 3 more attempts", "Skip this task"]`
+
+- **Accept as-is:** record the remaining deviations in the final summary and continue to 4d.
+- **I'll describe the fix:** take the user's description, apply it, recapture once, then continue to 4d regardless of the result.
+- **Try 3 more attempts:** reset the counter and return to the top of 4c. This is the only way the budget grows -- it is never extended automatically.
+- **Skip this task:** revert this task's changes, mark it skipped, continue to the next task.
+
+### 4d -- Commit
+
+Skip if `NO_GIT`.
+
+Stage only the files this task touched. Never `git add .`. Never stage the plan or anything under `screenshot_dir`.
+
+Commit with a Conventional Commits message scoped to the task, for example `feat(wallet): add balance card matching design spec`. No push. No AI attribution.
+
+## Phase 5 -- Summary
+
+Print a table:
+
+| Task | Status | Fidelity |
+|------|--------|----------|
+| 1 | done | matched |
+| 2 | done | 2 deviations accepted |
+| 3 | skipped | -- |
+
+Then list every accepted deviation with its measured delta and the file it lives in, so the user can decide later whether to revisit.
+
+Print the branch name and the commit count. Do not open a pull request -- that is `/create-pr`.
+
+---
+
+## Anti-Patterns
+
+Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
+
+- **Don't** call figma-bridge tools. This skill runs with Figma disconnected; the plan carries the data.
+- **Don't** probe capture methods one by one. Phase 2 picks one from the project type.
+- **Don't** loop capture-and-fix without a bound. Three attempts, then ask.
+- **Don't** extend the retry budget on your own. Only the user's "Try 3 more attempts" resets it.
+- **Don't** replace a precedent mechanism with a simpler one because it compiles. The precedent is in the plan because the simple version is what looks wrong.
+- **Don't** center at page level when a Reconciliation line names a chrome-excluded region.
+- **Don't** adjust the plan's numbers to match what the code happens to produce. Fix the code.
+- **Don't** stage the plan file or the screenshot assets.
+
+---
+
+## Test Plan
+
+**Trigger:** `/design-build`, `/design-build .claude/plans/2026-08-16-wallet-design-plan.md`, `/quiver:design-build`
+
+**Setup:**
+- A design plan written by `/design` with at least two tasks, one node carrying a `Reconciliation:` line, and reference PNGs present under `screenshot_dir`.
+- A runnable project matching one of the Phase 2 signals.
+
+**Expected behavior:**
+1. All three shell blocks exit 0 in a git repo and in a non-git directory.
+2. With no design plan on disk, Phase 1 prints the `/design` pointer and stops.
+3. A plan lacking `design_source: figma-bridge` or `### Node Specs` is rejected with a message; no code is written.
+4. Phase 2 resolves exactly one capture method from the project type and prints it. No sequential probing occurs.
+5. A Flutter project with both an Android and an iOS target attached asks which device via `AskUserQuestion`.
+6. A physical iOS target with `idevicescreenshot` absent prints the brew hint and falls back to spec-versus-code.
+7. With no capture method available, every task verifies by reading code against the spec, and the skill says so once.
+8. A node with a `Reconciliation:` line and a precedent `file:line` causes that file range to be read before the positioning code is written.
+9. A node with a `Reconciliation:` line and `No precedent found` produces content constrained to the chrome-excluded region, with a comment naming what it centers within.
+10. Deviations of 2px or less are within tolerance and do not trigger a fix.
+11. After three failed attempts on one task, `AskUserQuestion` appears with the four options. The loop never continues silently.
+12. "Try 3 more attempts" resets the counter; nothing else does.
+13. Each completed task produces exactly one commit; the plan and `screenshot_dir` are never staged.
+14. Phase 5 prints the status table and lists every accepted deviation with its delta.
+
+**Verification checklist:**
+- [ ] `/design-build` and `/quiver:design-build` both appear in the slash menu after plugin reload.
+- [ ] All three `!` blocks exit 0 with `NO_GIT` output in a non-git directory.
+- [ ] No figma-bridge tool is called anywhere in this skill.
+- [ ] Capture method is chosen once in Phase 2, never re-probed per task.
+- [ ] The retry budget is capped at 3 and only the user can reset it.
+- [ ] The bounded-retry prompt uses `AskUserQuestion`, not plain text.
+- [ ] Commits stage task files only; no `git add .`; plan and assets excluded.
+- [ ] No AI attribution in any commit message.
+- [ ] `when-to-use:` is a single-line double-quoted string.
+- [ ] No `CLAUDE_PLUGIN_ROOT` reference anywhere in this file.
+- [ ] No Unicode characters or emoji in this file.
+- [ ] No `$()`, variable assignment, or `if/else` inside any `!` block.
+
+**Known gotchas:**
+- `adb exec-out screencap -p` covers Android emulators and physical devices identically -- no separate physical-device path is needed there. iOS is the asymmetric case: the simulator has an MCP tool, a physical device needs `idevicescreenshot` from libimobiledevice.
+- `flutter devices` output is the only reliable way to know which platform a Flutter run targets. The manifest alone cannot tell you.
+- Anchor deviations are the ones that look "almost right" and read as fine in a quick glance. Check the anchor before the box, or a wrong-region centering hides behind correct dimensions.
+- The 2px tolerance is per single measurement, not cumulative. Four separate 2px deviations still add up to a visibly wrong layout, so recheck the anchor when several small deviations cluster.
+- Screenshot captures land under `.claude/plans/assets/<slug>/actual/`. If `.claude/` is gitignored they stay local, which is intended -- never stage them.
+- Reverting a skipped task's changes only removes what that task wrote. A task that a later task depends on cannot be cleanly skipped; when that happens, say so rather than leaving a half-built dependency.

--- a/skills/design-build/SKILL.md
+++ b/skills/design-build/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: design-build
-description: "Execute a design plan produced by /design -- implements each node against its embedded measurement spec, captures the running UI, compares it to the Figma reference, and fixes deviations under a bounded retry budget. Runs with Figma disconnected; the plan carries every number it needs."
+description: "Execute a design plan produced by /design -- implements each node against its embedded measurement spec, delegates fidelity measurement to /design-verify, and fixes the reported deviations under a bounded retry budget. Runs with Figma disconnected; the plan carries every number it needs."
 argument-hint: "<path to a *-design-plan.md, or empty to pick one>"
 when-to-use: "user wants to build a design plan into working pixel-accurate UI -- '/design-build', 'build the design plan', 'implement the figma plan', 'make it match the design', 'fix the pixel differences'"
 ---
@@ -23,7 +23,7 @@ when-to-use: "user wants to build a design plan into working pixel-accurate UI -
 
 # Instructions
 
-You are a design implementation specialist. You take a plan written by `/design`, build it, then prove it matches by capturing the running UI and comparing it against the Figma reference screenshots. You do not open Figma -- the plan is self-contained.
+You are a design implementation specialist. You take a plan written by `/design`, build it, hand the fidelity measurement to `/design-verify`, and fix what its report says is off. You do not open Figma -- the plan is self-contained -- and you do not capture or measure anything yourself.
 
 **Announce:** "Using the design-build skill to implement the design plan."
 
@@ -31,7 +31,7 @@ You are a design implementation specialist. You take a plan written by `/design`
 
 If a gather-context block returned `NO_GIT`, this directory is not a git repository.
 Print: `> No git repository detected -- skipping branch and commit steps.`
-Proceed. Skip branch creation in Phase 2 and all commit steps in Phase 4.
+Proceed. Skip branch creation in Phase 2 and all commit steps in Phase 3d.
 
 ## Phase 1 -- Load the Plan
 
@@ -54,71 +54,49 @@ Proceed. Skip branch creation in Phase 2 and all commit steps in Phase 4.
 ```
 **Stop here.**
 
-**Check the references.** Every path under `screenshot_dir` named in a node spec must exist on disk. If any are missing, print which ones and continue -- those nodes fall back to spec-versus-code comparison in Phase 4.
+**Check the references.** Every path under `screenshot_dir` named in a node spec must exist on disk. If any are missing, print which ones and continue. What a missing reference means for verification is `/design-verify`'s decision, not this skill's.
 
-## Phase 2 -- Capture Target
+### Frontmatter fields this skill reads
 
-Pick the capture method **once**, up front, by reading the project. Do not walk a ladder of attempts.
+The plan schema is declared once, in `skills/design/SKILL.md` Step 9. This skill does not
+reproduce that fence. It reads these fields and applies these defaults when a field is
+absent:
 
-Detect the project type from manifest files at the project root:
+| Field | Used for | Default when absent |
+|-------|----------|---------------------|
+| `commit_strategy` | Phase 3d's commit policy | `none` |
+| `verify_gate` | which command must pass before a commit | `none` |
+| `screenshot_dir` | where the deviation reports land | `.claude/plans/assets/<slug>/`, slug derived from the plan filename |
 
-| Signal | Project type |
-|--------|--------------|
-| `pubspec.yaml` | Flutter |
-| `package.json` with `next`, `react`, `vue`, `svelte`, `astro`, or `vite` | Web |
-| `index.html` at root with no JS manifest | Web |
-| `*.xcodeproj`, `*.xcworkspace`, or `Package.swift` with UI targets | iOS native |
-| `build.gradle` or `build.gradle.kts` with an Android plugin | Android native |
+Plans written before these fields existed carry none of them, and they live in
+`.claude/plans/`, which is gitignored -- no migration can reach them. The defaults are
+load-bearing, not defensive styling. Default `commit_strategy` to `none` specifically:
+an older plan predates the question being asked, so the user never consented to a commit.
 
-Then resolve the capture method:
-
-| Project type | Capture method |
-|--------------|----------------|
-| Web | Playwright or Puppeteer MCP screenshot |
-| iOS native, simulator | `simulator_screenshot` from the `xc-interact` MCP |
-| iOS native, physical device | `idevicescreenshot` (libimobiledevice) |
-| Android native, emulator or physical device | `adb exec-out screencap -p > <path>` |
-| Flutter | resolve the run target first, see below |
-
-**Flutter run target.** Run `flutter devices` with the Bash tool and read the output:
-- An Android device or emulator is attached: use `adb exec-out screencap -p`. This works for emulators and physical devices alike.
-- Only an iOS simulator is attached: use `simulator_screenshot` from `xc-interact`.
-- Only a physical iOS device is attached: use `idevicescreenshot`. Probe it once with `which idevicescreenshot` via the Bash tool. If absent, print:
-  ```
-  > No screenshot capture available for a physical iOS device.
-  > Install it with: brew install libimobiledevice
-  > Continuing with spec-versus-code comparison instead.
-  ```
-- Both Android and iOS targets are attached: use `AskUserQuestion`.
-  > Which device should the design be verified against?
-
-  Build one button per attached device from the `flutter devices` output.
-- Nothing attached: fall back to spec-versus-code.
-
-**MCP schema loading.** If the chosen method needs a deferred MCP tool, load its schema once with `ToolSearch` before the first capture. Do not reload per task.
-
-**Spec-versus-code fallback.** When no capture method resolves, verification for every task is a careful read of the written code against the node spec: every measurement, token, and anchor checked by hand. Print:
-```
-> No UI capture available -- verifying against the spec by reading the code.
-```
-
-Record the chosen method. Print `> Capture target: {method}`.
-
-## Phase 3 -- Branch
+## Phase 2 -- Branch
 
 Skip entirely if `NO_GIT`.
 
 If the current branch is the default branch (`master` or `main`), create a feature branch named `design/<slug>` from the plan's slug. Otherwise stay on the current branch.
 
-## Phase 4 -- Build Loop
+## Phase 3 -- Build Loop
 
 Work the plan's `### Tasks` in order. New-token tasks come first -- later tasks reference those tokens.
 
 For each task:
 
-### 4a -- Implement
+### 3a -- Implement
 
 Read the node specs the task names. Write the code using the plan's literal values and the Token Map. Match the project's component conventions from the plan's `### Stack and Conventions` section.
+
+Three spec lines override the raw measurements when they are present:
+
+- **`Fit:`** wins over `Box:` on any axis it marks `fill`. The `Box:` number is what that
+  axis measured at one frame size; writing it as a fixed dimension produces a component
+  that is wrong at every other width. Implement `fill` as the framework's fill mechanism.
+- **`Content:`** is the literal copy, and its i18n decision is binding. When it names a
+  key, add the key and reference it. Never invent or paraphrase copy.
+- **`Route:`** is where the node lives at runtime. Build it so that route reaches it.
 
 **Layout reconciliation is mandatory.** Before writing any centering, alignment, or positioning code, check whether the node has a `Reconciliation:` line in its spec.
 
@@ -128,27 +106,31 @@ Read the node specs the task names. Write the code using the plan's literal valu
 
 Follow the plan's File Map. Do not create files the plan does not list.
 
-### 4b -- Capture and Compare
+### 3b -- Verify
 
-Skip to 4c with a `spec-check` result when the capture method is spec-versus-code.
+This skill does not capture and does not compare. It delegates, then reads a file.
 
-1. Get the app into the state that shows this task's node. Build and launch or reload as the stack requires.
-2. Capture a screenshot with the Phase 2 method. Save it to `.claude/plans/assets/<slug>/actual/<task-id>.png`.
-3. Read the capture and the Figma reference named in the node spec's `Reference:` line.
-4. Compare against the spec, in this order. Report each as a deviation with its measured delta:
-   - **Anchor** -- is the node positioned relative to the right region? Measure its center against the chrome-excluded region's center. This is the first check because it is the one that silently fails.
-   - **Box** -- width, height, and insets against the spec numbers.
-   - **Spacing** -- gaps and padding.
-   - **Typography** -- size, weight, line height, color.
-   - **Fill, stroke, radius, effects.**
+1. Invoke the `design-verify` skill with the plan path, this task's node IDs, this task's
+   ID, and mode `build`:
+   `/design-verify <plan path> --nodes <this task's node IDs> --task <task id> --mode build`
+2. Read `<screenshot_dir>/verify/<task-id>.md`.
 
-A deviation of 2px or less on any single measurement is within tolerance. Anything larger is a deviation to fix.
+**An absent report file means the verify step did not run.** That is the only thing it
+means -- a clean verification still writes a report. Treat the task as `spec-check`,
+record that verification did not run, and continue to 3d. Do not loop, do not re-invoke,
+and do not infer that the task passed.
 
-### 4c -- Fix, Bounded
+All capture resolution, image normalization, metric selection, check order, and tolerance
+live in `/design-verify`. They are not restated here, and this skill does not second-guess
+them.
 
-If there are no deviations, go to 4d.
+### 3c -- Fix, Bounded
 
-Otherwise fix the largest deviation first, then recapture and recompare. **Three attempts maximum per task**, counting the initial implementation as attempt one.
+If the report lists no deviations, go to 3d.
+
+Otherwise fix the largest delta in the report's deviation table first, then re-run 3b --
+re-invoke `design-verify` and re-read the report. **Three attempts maximum per task**,
+counting the initial implementation as attempt one.
 
 After the third attempt still leaves deviations, **stop and ask**. Do not keep looping. Call `AskUserQuestion`:
 
@@ -157,20 +139,38 @@ After the third attempt still leaves deviations, **stop and ask**. Do not keep l
 
 Buttons: `["Accept as-is -- note it and move on", "I'll describe the fix", "Try 3 more attempts", "Skip this task"]`
 
-- **Accept as-is:** record the remaining deviations in the final summary and continue to 4d.
-- **I'll describe the fix:** take the user's description, apply it, recapture once, then continue to 4d regardless of the result.
-- **Try 3 more attempts:** reset the counter and return to the top of 4c. This is the only way the budget grows -- it is never extended automatically.
+- **Accept as-is:** record the remaining deviations in the final summary and continue to 3d.
+- **I'll describe the fix:** take the user's description, apply it, re-run 3b once, then continue to 3d regardless of the result.
+- **Try 3 more attempts:** reset the counter and return to the top of 3c. This is the only way the budget grows -- it is never extended automatically.
 - **Skip this task:** revert this task's changes, mark it skipped, continue to the next task.
 
-### 4d -- Commit
+### 3d -- Gate, then Commit
 
-Skip if `NO_GIT`.
+**Verification gate.** Read `verify_gate` from the plan frontmatter.
 
-Stage only the files this task touched. Never `git add .`. Never stage the plan or anything under `screenshot_dir`.
+- `build` -- run the project's build command.
+- `test` -- run the project's test command.
+- `none` (the default) -- no gate; go straight to the commit policy.
 
-Commit with a Conventional Commits message scoped to the task, for example `feat(wallet): add balance card matching design spec`. No push. No AI attribution.
+A failing gate **blocks the commit**. Feed the failure output back into 3c as a
+deviation and re-enter the fix loop under the same 3-attempt budget. Never commit past a
+failing gate, and never commit a task the gate has not cleared.
 
-## Phase 5 -- Summary
+**Commit policy.** Read `commit_strategy` from the plan frontmatter. The user chose this
+at plan time, so nothing here asks again.
+
+- `none` (the default) -- write no commit. Say so once, on the first task:
+  `> commit_strategy: none -- changes stay in the working tree.` Do not repeat it per
+  task.
+- `per-task` -- skip if `NO_GIT`. Stage only the files this task touched. Never
+  `git add .`. Never stage the plan or anything under `screenshot_dir`. Commit with a
+  Conventional Commits message scoped to the task, for example
+  `feat(wallet): add balance card matching design spec`. No push. No AI attribution.
+- `single` -- accumulate. Commit nothing here; after the last task, make one commit
+  covering every file the run touched, with a Conventional Commits message scoped to the
+  plan. Same staging rules, same exclusions, no push, no AI attribution.
+
+## Phase 4 -- Summary and Handoff
 
 Print a table:
 
@@ -180,9 +180,22 @@ Print a table:
 | 2 | done | 2 deviations accepted |
 | 3 | skipped | -- |
 
-Then list every accepted deviation with its measured delta and the file it lives in, so the user can decide later whether to revisit.
+Then list every accepted deviation with its measured delta and the file it lives in, so the user can decide later whether to revisit. Name the deviation report path for each task, so the measurements stay reachable after this run ends.
 
-Print the branch name and the commit count. Do not open a pull request -- that is `/create-pr`.
+Print the branch name and the commit count.
+
+Then call `AskUserQuestion`:
+
+> Build finished. What next?
+
+Buttons: `["Review the changes -- /review", "Commit -- /commit", "Open a PR -- /create-pr", "Stop here"]`
+
+- **Review the changes:** invoke the `review` skill.
+- **Commit:** invoke the `commit` skill.
+- **Open a PR:** invoke the `create-pr` skill.
+- **Stop here:** stop.
+
+Do not open a pull request directly -- `/create-pr` owns that.
 
 ---
 
@@ -191,13 +204,19 @@ Print the branch name and the commit count. Do not open a pull request -- that i
 Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 
 - **Don't** call figma-bridge tools. This skill runs with Figma disconnected; the plan carries the data.
-- **Don't** probe capture methods one by one. Phase 2 picks one from the project type.
-- **Don't** loop capture-and-fix without a bound. Three attempts, then ask.
+- **Don't** capture or compare here. 3b delegates to `/design-verify` and reads its report.
+- **Don't** restate `/design-verify`'s capture commands, tolerance, or check order. One copy, in one file.
+- **Don't** treat an absent deviation report as a pass. A clean verification still writes a report.
+- **Don't** loop the fix cycle without a bound. Three attempts, then ask.
 - **Don't** extend the retry budget on your own. Only the user's "Try 3 more attempts" resets it.
 - **Don't** replace a precedent mechanism with a simpler one because it compiles. The precedent is in the plan because the simple version is what looks wrong.
 - **Don't** center at page level when a Reconciliation line names a chrome-excluded region.
+- **Don't** write a `fill` axis as the literal `Box:` number.
 - **Don't** adjust the plan's numbers to match what the code happens to produce. Fix the code.
+- **Don't** commit when `commit_strategy` is absent or `none`. Absence means the user was never asked.
+- **Don't** commit past a failing verification gate.
 - **Don't** stage the plan file or the screenshot assets.
+- **Don't** restate the plan frontmatter schema. `skills/design/SKILL.md` Step 9 declares it; this file lists only the fields it reads.
 
 ---
 
@@ -207,31 +226,37 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 
 **Setup:**
 - A design plan written by `/design` with at least two tasks, one node carrying a `Reconciliation:` line, and reference PNGs present under `screenshot_dir`.
-- A runnable project matching one of the Phase 2 signals.
+- A second, legacy plan carrying none of `commit_strategy`, `verify_gate`, or `screenshot_dir`.
+- A runnable project.
 
 **Expected behavior:**
 1. All three shell blocks exit 0 in a git repo and in a non-git directory.
 2. With no design plan on disk, Phase 1 prints the `/design` pointer and stops.
 3. A plan lacking `design_source: figma-bridge` or `### Node Specs` is rejected with a message; no code is written.
-4. Phase 2 resolves exactly one capture method from the project type and prints it. No sequential probing occurs.
-5. A Flutter project with both an Android and an iOS target attached asks which device via `AskUserQuestion`.
-6. A physical iOS target with `idevicescreenshot` absent prints the brew hint and falls back to spec-versus-code.
-7. With no capture method available, every task verifies by reading code against the spec, and the skill says so once.
-8. A node with a `Reconciliation:` line and a precedent `file:line` causes that file range to be read before the positioning code is written.
-9. A node with a `Reconciliation:` line and `No precedent found` produces content constrained to the chrome-excluded region, with a comment naming what it centers within.
-10. Deviations of 2px or less are within tolerance and do not trigger a fix.
+4. The legacy plan loads and builds on the documented defaults, committing nothing.
+5. A node with a `Fit:` axis of `fill` is implemented with the framework's fill mechanism, not the `Box:` literal.
+6. A node with a `Content:` line carrying an i18n key produces that key, never invented copy.
+7. 3b invokes `/design-verify` with mode `build` and reads `<screenshot_dir>/verify/<task-id>.md`. No capture command runs in this skill.
+8. An absent deviation report is recorded as `spec-check` and does not loop or read as a pass.
+9. A node with a `Reconciliation:` line and a precedent `file:line` causes that file range to be read before the positioning code is written.
+10. A node with a `Reconciliation:` line and `No precedent found` produces content constrained to the chrome-excluded region, with a comment naming what it centers within.
 11. After three failed attempts on one task, `AskUserQuestion` appears with the four options. The loop never continues silently.
 12. "Try 3 more attempts" resets the counter; nothing else does.
-13. Each completed task produces exactly one commit; the plan and `screenshot_dir` are never staged.
-14. Phase 5 prints the status table and lists every accepted deviation with its delta.
+13. `verify_gate: build` or `test` runs that command before the commit; a failure blocks the commit and re-enters 3c.
+14. `commit_strategy: none` or absent writes no commit and says so exactly once.
+15. `commit_strategy: per-task` produces one commit per task; `single` produces exactly one commit after the last task. The plan and `screenshot_dir` are never staged.
+16. Phase 4 prints the status table, lists every accepted deviation with its delta and report path, and ends with the four-button handoff.
 
 **Verification checklist:**
 - [ ] `/design-build` and `/quiver:design-build` both appear in the slash menu after plugin reload.
 - [ ] All three `!` blocks exit 0 with `NO_GIT` output in a non-git directory.
 - [ ] No figma-bridge tool is called anywhere in this skill.
-- [ ] Capture method is chosen once in Phase 2, never re-probed per task.
+- [ ] No capture command, tolerance value, or check order appears anywhere in this file.
+- [ ] No screenshot binary or capture MCP server is named anywhere in this file.
+- [ ] The plan frontmatter fence is not reproduced; only the fields this skill reads are listed, each with a default.
 - [ ] The retry budget is capped at 3 and only the user can reset it.
 - [ ] The bounded-retry prompt uses `AskUserQuestion`, not plain text.
+- [ ] No commit is written when `commit_strategy` is absent.
 - [ ] Commits stage task files only; no `git add .`; plan and assets excluded.
 - [ ] No AI attribution in any commit message.
 - [ ] `when-to-use:` is a single-line double-quoted string.
@@ -240,9 +265,8 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 - [ ] No `$()`, variable assignment, or `if/else` inside any `!` block.
 
 **Known gotchas:**
-- `adb exec-out screencap -p` covers Android emulators and physical devices identically -- no separate physical-device path is needed there. iOS is the asymmetric case: the simulator has an MCP tool, a physical device needs `idevicescreenshot` from libimobiledevice.
-- `flutter devices` output is the only reliable way to know which platform a Flutter run targets. The manifest alone cannot tell you.
-- Anchor deviations are the ones that look "almost right" and read as fine in a quick glance. Check the anchor before the box, or a wrong-region centering hides behind correct dimensions.
-- The 2px tolerance is per single measurement, not cumulative. Four separate 2px deviations still add up to a visibly wrong layout, so recheck the anchor when several small deviations cluster.
-- Screenshot captures land under `.claude/plans/assets/<slug>/actual/`. If `.claude/` is gitignored they stay local, which is intended -- never stage them.
+- The retry budget is a cross-file loop: 3c counts attempts here, but each attempt's measurement happens in `/design-verify`. The counter never lives in the report file -- it is this skill's state.
+- An absent deviation report and a report with zero deviations mean opposite things. `/design-verify` writes a report on every path precisely so the difference is unambiguous.
+- Deviation reports and captures land under `.claude/plans/assets/<slug>/`. If `.claude/` is gitignored they stay local, which is intended -- never stage them.
 - Reverting a skipped task's changes only removes what that task wrote. A task that a later task depends on cannot be cleanly skipped; when that happens, say so rather than leaving a half-built dependency.
+- `commit_strategy: single` still has to skip when `NO_GIT`. The accumulate branch is easy to write as if git is always present.

--- a/skills/design-build/SKILL.md
+++ b/skills/design-build/SKILL.md
@@ -77,7 +77,17 @@ an older plan predates the question being asked, so the user never consented to 
 
 Skip entirely if `NO_GIT`.
 
-If the current branch is the default branch (`master` or `main`), create a feature branch named `design/<slug>` from the plan's slug. Otherwise stay on the current branch.
+If the current branch is not the default branch (`master` or `main`), stay on it. Nothing below runs.
+
+On the default branch, resolve `design/<slug>` from the plan's slug, then check two things before touching it:
+
+1. **Uncommitted work.** The third gather-context block already holds `git status --short`. If it is non-empty, do not switch branches -- a checkout carries those changes onto the new branch or fails outright. Stay put and print:
+   `> Uncommitted changes present -- building on {current branch} instead of creating design/<slug>.`
+2. **The branch already exists.** Run `git rev-parse --verify design/<slug>` with the Bash tool. A re-run of the same plan hits this every time, and `git checkout -b` aborts on it.
+   - Exists: `git checkout design/<slug>` and print `> Continuing on existing branch design/<slug>.`
+   - Does not exist: `git checkout -b design/<slug>`.
+
+Read `git branch --show-current` back afterwards and print the branch the build actually runs on. A silent checkout failure otherwise puts the whole run on the default branch.
 
 ## Phase 3 -- Build Loop
 
@@ -110,15 +120,34 @@ Follow the plan's File Map. Do not create files the plan does not list.
 
 This skill does not capture and does not compare. It delegates, then reads a file.
 
-1. Invoke the `design-verify` skill with the plan path, this task's node IDs, this task's
+1. **Note the report's current state.** Read `<screenshot_dir>/verify/<task-id>.md` if it
+   exists and keep its `created:` value. Absent is a state too -- record that instead.
+2. Invoke the `design-verify` skill with the plan path, this task's node IDs, this task's
    ID, and mode `build`:
    `/design-verify <plan path> --nodes <this task's node IDs> --task <task id> --mode build`
-2. Read `<screenshot_dir>/verify/<task-id>.md`.
+3. Re-read `<screenshot_dir>/verify/<task-id>.md`.
 
-**An absent report file means the verify step did not run.** That is the only thing it
-means -- a clean verification still writes a report. Treat the task as `spec-check`,
-record that verification did not run, and continue to 3d. Do not loop, do not re-invoke,
-and do not infer that the task passed.
+**The report path is fixed per task, so the file's existence proves nothing on a re-run.**
+A verify that aborts before writing -- a shut-down simulator, a bad plan path, a denied
+permission -- leaves the previous attempt's report exactly where the new one would go.
+Compare `created:` against the value noted in step 1. Unchanged, or still absent, means
+this attempt's verification did not run: treat the task as `unverified`, record that, and
+continue to 3d. Do not loop, do not re-invoke, and do not read the stale deviations as
+current -- doing so spends the retry budget re-fixing a delta that was already fixed.
+
+**Classify the report before acting on it.** Deviation rows are not the only signal:
+
+| Report state | Status |
+|--------------|--------|
+| deviation rows present | go to 3c |
+| empty table, `comparison_path: imagemagick-*`, `confidence: high` | `matched` -- go to 3d |
+| empty table, any other `comparison_path`, `confidence: low`, or nodes listed as skipped under `## Notes` | `unverified` -- record the reason from the report, go to 3d |
+| `created:` unchanged, or the file is absent | `unverified` (verification did not run) -- go to 3d |
+
+**An empty deviation table is not by itself a pass.** `spec-check` means nothing was
+compared, `confidence: low` means the comparison could not be trusted, and a node under
+`## Notes` was never captured at all. Every one of those produces an empty table, and
+reporting any of them as `matched` claims a fidelity measurement that never happened.
 
 All capture resolution, image normalization, metric selection, check order, and tolerance
 live in `/design-verify`. They are not restated here, and this skill does not second-guess
@@ -126,9 +155,11 @@ them.
 
 ### 3c -- Fix, Bounded
 
-If the report lists no deviations, go to 3d.
+There are two ways in: 3b classified the report as carrying deviation rows, or 3d's gate
+failed and handed its output here as the deviation. `matched` and `unverified` never
+enter -- both go straight to 3d.
 
-Otherwise fix the largest delta in the report's deviation table first, then re-run 3b --
+Fix the largest delta in the report's deviation table first, then re-run 3b --
 re-invoke `design-verify` and re-read the report. **Three attempts maximum per task**,
 counting the initial implementation as attempt one.
 
@@ -139,10 +170,12 @@ After the third attempt still leaves deviations, **stop and ask**. Do not keep l
 
 Buttons: `["Accept as-is -- note it and move on", "I'll describe the fix", "Try 3 more attempts", "Skip this task"]`
 
-- **Accept as-is:** record the remaining deviations in the final summary and continue to 3d.
+- **Accept as-is:** record the remaining deviations in the final summary and continue to 3d. When this loop was entered from a gate failure, 3d does not re-run the gate -- see the gate budget below.
 - **I'll describe the fix:** take the user's description, apply it, re-run 3b once, then continue to 3d regardless of the result.
 - **Try 3 more attempts:** reset the counter and return to the top of 3c. This is the only way the budget grows -- it is never extended automatically.
-- **Skip this task:** revert this task's changes, mark it skipped, continue to the next task.
+- **Skip this task:** undo what this task wrote, mark it skipped, continue to the next task. Undo has one mechanism per environment, and none of them is `git revert` -- under the default `commit_strategy: none` there is no commit to revert:
+  - **Git available:** `git restore -- <files this task modified>` for tracked files, then delete the files this task created. Take that file list from 3a's own record of what it wrote, never from `git status` -- an earlier task's uncommitted work sits in the same tree and is not this task's to undo.
+  - **`NO_GIT`, or any file this task shares with an earlier task:** undo nothing. Leave the code in place, mark the task `skipped (changes left in place)`, and name those files in the Phase 4 summary. Hand-unpicking interleaved edits is worse than the half-built state, and there is no restore point to fall back to.
 
 ### 3d -- Gate, then Commit
 
@@ -152,9 +185,18 @@ Buttons: `["Accept as-is -- note it and move on", "I'll describe the fix", "Try 
 - `test` -- run the project's test command.
 - `none` (the default) -- no gate; go straight to the commit policy.
 
-A failing gate **blocks the commit**. Feed the failure output back into 3c as a
-deviation and re-enter the fix loop under the same 3-attempt budget. Never commit past a
-failing gate, and never commit a task the gate has not cleared.
+**The gate runs at most twice per task.** Run it; on a failure, feed the failure output
+back into 3c as a deviation and re-enter the fix loop under the same 3-attempt budget;
+then run it one final time. That second run is the last for this task whatever it returns.
+
+Record the outcome as this task's **gate verdict**, `cleared` or `failed`. Everything
+downstream reads the verdict; the gate itself never runs a third time.
+
+3c's "Accept as-is" returns here with the verdict already `failed`. **Do not re-run the
+gate on that path** -- re-running it re-enters 3c, which returns here, which re-runs it.
+The 3-attempt budget bounds 3c's internal loop, not the 3c-to-3d cycle, so a gate failing
+for a reason this task cannot fix (a pre-existing compile error elsewhere) would otherwise
+have no exit but "Skip this task".
 
 **Commit policy.** Read `commit_strategy` from the plan frontmatter. The user chose this
 at plan time, so nothing here asks again.
@@ -162,25 +204,36 @@ at plan time, so nothing here asks again.
 - `none` (the default) -- write no commit. Say so once, on the first task:
   `> commit_strategy: none -- changes stay in the working tree.` Do not repeat it per
   task.
-- `per-task` -- skip if `NO_GIT`. Stage only the files this task touched. Never
-  `git add .`. Never stage the plan or anything under `screenshot_dir`. Commit with a
-  Conventional Commits message scoped to the task, for example
+- `per-task` -- skip if `NO_GIT`. Skip when this task's gate verdict is `failed`, and say
+  which task and why. Otherwise stage only the files this task touched. Never `git add .`.
+  Never stage the plan or anything under `screenshot_dir`. Commit with a Conventional
+  Commits message scoped to the task, for example
   `feat(wallet): add balance card matching design spec`. No push. No AI attribution.
 - `single` -- accumulate. Commit nothing here; after the last task, make one commit
   covering every file the run touched, with a Conventional Commits message scoped to the
   plan. Same staging rules, same exclusions, no push, no AI attribution.
+  **Enforce the gate verdicts at that point.** Under `single` there is no per-task commit
+  for a failing gate to block, so a task the gate rejected would otherwise ride into the
+  final commit alongside the cleared ones. If any task's verdict is `failed`, write no
+  commit at all: print each failed task with its gate output and leave everything in the
+  working tree. Splitting the commit is not an option -- a later task builds on an earlier
+  one's files, so the cleared subset is not independently committable.
 
 ## Phase 4 -- Summary and Handoff
 
 Print a table:
 
-| Task | Status | Fidelity |
-|------|--------|----------|
-| 1 | done | matched |
-| 2 | done | 2 deviations accepted |
-| 3 | skipped | -- |
+| Task | Status | Fidelity | Gate |
+|------|--------|----------|------|
+| 1 | done | matched | cleared |
+| 2 | done | 2 deviations accepted | cleared |
+| 3 | done | unverified (spec-check, no capture tooling) | failed |
+| 4 | skipped (changes left in place) | -- | -- |
 
-Then list every accepted deviation with its measured delta and the file it lives in, so the user can decide later whether to revisit. Name the deviation report path for each task, so the measurements stay reachable after this run ends.
+`matched` means a measured comparison found no deviations. Anything 3b classified as
+`unverified` prints as `unverified` with the reason from the report -- never as `matched`.
+
+Then list every accepted deviation with its measured delta and the file it lives in, so the user can decide later whether to revisit. Name the deviation report path for each task, so the measurements stay reachable after this run ends. Name every task whose changes were left in place after a skip.
 
 Print the branch name and the commit count.
 
@@ -207,14 +260,18 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 - **Don't** capture or compare here. 3b delegates to `/design-verify` and reads its report.
 - **Don't** restate `/design-verify`'s capture commands, tolerance, or check order. One copy, in one file.
 - **Don't** treat an absent deviation report as a pass. A clean verification still writes a report.
+- **Don't** treat an empty deviation table as a pass either. Read `comparison_path` and `confidence` first.
+- **Don't** trust a report at the task's path without checking `created:` against the value noted before the invocation. The path is fixed, so a stale report sits exactly where a fresh one would.
 - **Don't** loop the fix cycle without a bound. Three attempts, then ask.
+- **Don't** re-run the gate after "Accept as-is". That is the 3c-to-3d cycle the attempt budget does not bound.
 - **Don't** extend the retry budget on your own. Only the user's "Try 3 more attempts" resets it.
 - **Don't** replace a precedent mechanism with a simpler one because it compiles. The precedent is in the plan because the simple version is what looks wrong.
 - **Don't** center at page level when a Reconciliation line names a chrome-excluded region.
 - **Don't** write a `fill` axis as the literal `Box:` number.
 - **Don't** adjust the plan's numbers to match what the code happens to produce. Fix the code.
 - **Don't** commit when `commit_strategy` is absent or `none`. Absence means the user was never asked.
-- **Don't** commit past a failing verification gate.
+- **Don't** commit past a failing verification gate. Under `single` that means withholding the whole accumulate commit, not skipping one task's files.
+- **Don't** answer "Skip this task" with `git revert`. The default strategy writes no commit, so there is nothing to revert.
 - **Don't** stage the plan file or the screenshot assets.
 - **Don't** restate the plan frontmatter schema. `skills/design/SKILL.md` Step 9 declares it; this file lists only the fields it reads.
 
@@ -237,14 +294,17 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 5. A node with a `Fit:` axis of `fill` is implemented with the framework's fill mechanism, not the `Box:` literal.
 6. A node with a `Content:` line carrying an i18n key produces that key, never invented copy.
 7. 3b invokes `/design-verify` with mode `build` and reads `<screenshot_dir>/verify/<task-id>.md`. No capture command runs in this skill.
-8. An absent deviation report is recorded as `spec-check` and does not loop or read as a pass.
+8. An absent deviation report is recorded as `unverified` and does not loop or read as a pass. A report whose `created:` is unchanged after the invocation is recorded the same way, and its stale deviations are not re-fixed.
+8b. A report with an empty deviation table and `comparison_path: spec-check` (or `confidence: low`, or a node listed under `## Notes`) is recorded as `unverified`, never `matched`.
+8c. On the default branch with an existing `design/<slug>`, the run checks that branch out instead of failing at `git checkout -b`. With a dirty working tree it stays on the current branch and says so.
 9. A node with a `Reconciliation:` line and a precedent `file:line` causes that file range to be read before the positioning code is written.
 10. A node with a `Reconciliation:` line and `No precedent found` produces content constrained to the chrome-excluded region, with a comment naming what it centers within.
 11. After three failed attempts on one task, `AskUserQuestion` appears with the four options. The loop never continues silently.
 12. "Try 3 more attempts" resets the counter; nothing else does.
-13. `verify_gate: build` or `test` runs that command before the commit; a failure blocks the commit and re-enters 3c.
+13. `verify_gate: build` or `test` runs that command before the commit; a failure blocks the commit and re-enters 3c. The gate runs at most twice per task, and "Accept as-is" after a gate failure moves on instead of re-running it -- a permanently failing gate never loops.
 14. `commit_strategy: none` or absent writes no commit and says so exactly once.
-15. `commit_strategy: per-task` produces one commit per task; `single` produces exactly one commit after the last task. The plan and `screenshot_dir` are never staged.
+15. `commit_strategy: per-task` produces one commit per task, skipping any task whose gate verdict is `failed`; `single` produces exactly one commit after the last task, and none at all if any task's gate failed. The plan and `screenshot_dir` are never staged.
+15b. "Skip this task" restores the modified files and deletes the created ones when git is available, and leaves them in place with a stated reason under `NO_GIT` or on files an earlier task also wrote.
 16. Phase 4 prints the status table, lists every accepted deviation with its delta and report path, and ends with the four-button handoff.
 
 **Verification checklist:**
@@ -255,6 +315,9 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 - [ ] No screenshot binary or capture MCP server is named anywhere in this file.
 - [ ] The plan frontmatter fence is not reproduced; only the fields this skill reads are listed, each with a default.
 - [ ] The retry budget is capped at 3 and only the user can reset it.
+- [ ] The gate runs at most twice per task and never re-runs after "Accept as-is".
+- [ ] Report freshness is checked by `created:`, not by the file existing.
+- [ ] Every empty-table outcome is classified from `comparison_path` and `confidence`.
 - [ ] The bounded-retry prompt uses `AskUserQuestion`, not plain text.
 - [ ] No commit is written when `commit_strategy` is absent.
 - [ ] Commits stage task files only; no `git add .`; plan and assets excluded.
@@ -268,5 +331,6 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 - The retry budget is a cross-file loop: 3c counts attempts here, but each attempt's measurement happens in `/design-verify`. The counter never lives in the report file -- it is this skill's state.
 - An absent deviation report and a report with zero deviations mean opposite things. `/design-verify` writes a report on every path precisely so the difference is unambiguous.
 - Deviation reports and captures land under `.claude/plans/assets/<slug>/`. If `.claude/` is gitignored they stay local, which is intended -- never stage them.
-- Reverting a skipped task's changes only removes what that task wrote. A task that a later task depends on cannot be cleanly skipped; when that happens, say so rather than leaving a half-built dependency.
+- Undoing a skipped task's changes only removes what that task wrote, and only when git can restore them. A task whose files an earlier task also touched cannot be cleanly skipped; when that happens, say so rather than hand-unpicking interleaved edits.
+- The verification report path is fixed per task, so a failed re-verify is invisible from the filesystem alone. `created:` is the only thing that separates this attempt's report from the last one's.
 - `commit_strategy: single` still has to skip when `NO_GIT`. The accumulate branch is easy to write as if git is always present.

--- a/skills/design-verify/SKILL.md
+++ b/skills/design-verify/SKILL.md
@@ -113,23 +113,39 @@ expected, not an error.
 None of these is mandatory. Walk them in order and stop at the first that produces an
 image:
 
-1. **A supplied screenshot** -- `--screenshot <path>`, when the file exists.
+1. **A supplied screenshot** -- `--screenshot <path>` when the file exists, or a file
+   already sitting at this run's conventional capture path,
+   `<screenshot_dir>/actual/<task-id>.png`. Both are user-supplied input; neither runs a
+   capture command.
 2. **An automatic capture** -- the per-target commands below.
 3. **A spec-versus-code read** -- no image at all. Read the written code against the node
    spec: every measurement, token, and anchor checked by hand. The report is marked
    `spec-check` and low confidence.
 
-`capture_preference` routes into that ladder, and its three values are three distinct
-paths:
+**An explicit `--screenshot` wins over `capture_preference`.** A path the user typed on
+the command line is a stronger signal than a preference stored at plan time, so level 1
+runs before the preference is consulted, on every value including `skip`. A supplied file
+is not a capture attempt, and `skip` only forbids capture attempts.
+
+With no `--screenshot`, `capture_preference` routes into the ladder, and its three values
+are three distinct paths:
 
 - `skip` -- go straight to level 3. No capture is attempted, so no build-and-launch cycle
   runs. This is the cheap path for a plan whose UI is not runnable right now.
-- `manual` -- level 1 only. A supplied path is expected; without one, fall to level 3
-  rather than capturing.
+- `manual` -- level 1 only, including the conventional path. The user drops screenshots at
+  `<screenshot_dir>/actual/<task-id>.png` and both modes find them there with no question
+  asked -- which is what makes `manual` reachable inside a build loop that may not be
+  interrupted. When neither source produces a file, print once:
+  ```
+  > capture_preference: manual and no screenshot supplied. Drop one at
+  > <screenshot_dir>/actual/<task-id>.png and re-run, or continue on the spec read.
+  ```
+  then fall to level 3 rather than capturing.
 - `auto` -- the full ladder.
 
-When mode is `standalone` and no screenshot was supplied and automatic capture found no
-tooling, make the offer **once** before falling to level 3, with `AskUserQuestion`:
+When mode is `standalone`, level 1 produced no image, and either automatic capture found
+no tooling or `capture_preference` is `manual`, make the offer **once** before falling to
+level 3, with `AskUserQuestion`:
 
 > No capture tooling resolved. A screenshot would turn this into a measured comparison
 > instead of a spec read.
@@ -138,9 +154,42 @@ Buttons: `["Verify against the spec by reading the code", "I'll supply a screens
 
 When mode is `build`, skip that question and fall through silently.
 
-### Per-target capture commands
+### Resolve the target once per run
 
-Resolve the target **once per run**, not per node.
+Resolve the target once, before the first capture, never per node. Detect the project
+type from its manifest, then take the first live target in that type's order:
+
+| Manifest at the project root | Project type | Target order |
+|------------------------------|--------------|--------------|
+| `pubspec.yaml` | Flutter | the device named by `flutter devices --machine`, then that device's platform row below |
+| `*.xcodeproj`, `*.xcworkspace`, or `Package.swift` | iOS | iOS simulator, then physical iOS device |
+| `build.gradle` or `build.gradle.kts` declaring an Android plugin | Android | Android emulator or device |
+| `package.json` naming `next`, `react`, `vue`, `svelte`, or `vite` | Web | Web |
+
+Then resolve the tie:
+
+- **One live target:** use it.
+- **Several live** -- a booted simulator and an attached phone, or `flutter devices
+  --machine` returning more than one entry. In `standalone` mode ask with
+  `AskUserQuestion`, one button per live target. In `build` mode never ask: take the
+  first live target in the order above and name the choice in the report's
+  `capture_method`.
+- **No manifest matches:** walk the four command rows below top to bottom and take the
+  first target whose absence probe reports something live.
+
+An Android capture compared against an iOS-frame export produces a deviation on every
+row, so the resolved target is recorded in the report rather than left implicit.
+
+### Where captures land
+
+Every capture command writes to `<screenshot_dir>/actual/<task-id>.png`, with `<task-id>`
+resolved exactly as Phase 6 resolves it. Create `<screenshot_dir>/actual/` with `mkdir -p`
+before the first capture: `adb ... > <path>` fails on a missing parent directory, and the
+failure reads as a device problem.
+
+In the commands below, `<path>` is that file.
+
+### Per-target capture commands
 
 | Target | Capture command | Absence probe |
 |--------|-----------------|---------------|
@@ -215,30 +264,67 @@ against the larger, pads with virtual pixels, and returns a plausible-looking nu
 silently includes the padded region. An unnormalized comparison produces a wrong answer
 that looks like a right one.
 
-1. **Compute the common logical width.** Take the reference width from the plan's
-   `figma_frame_size` and the capture's logical size from the device. When
-   `figma_frame_size` is absent, skip normalization entirely and mark the report low
-   confidence -- do not guess a frame size.
-2. **Scale-only difference** (same aspect ratio, different pixel dimensions):
+**The two sides do not start from the same origin, and each needs its own normalization.**
+
+- **The reference PNG is node-clipped.** `/design` exports it with `clip: true` at
+  `screenshot_scale`, so the file holds the node's own box at that scale -- not the frame.
+  Its logical size is the node's `Box:` width and height.
+- **A device capture is the whole screen** at the device's pixel ratio. Its logical size
+  is the frame, not the node.
+
+Intermediates land beside the capture: `<screenshot_dir>/actual/<task-id>-ref.png`,
+`-norm.png`, and `-crop.png`.
+
+1. **Normalize the reference to the node's logical box.** Take `w` and `h` from the node
+   spec's `Box:` line. The reference is that box at `screenshot_scale`, so this is a
+   scale-only resize and the aspect ratio already matches:
    ```
-   magick <in.png> -resize 'WxH!' <out.png>
+   magick <reference.png> -resize '<w>x<h>!' <ref.png>
    ```
    The `!` is required; without it ImageMagick preserves aspect ratio and the output does
-   not land on the requested size.
-3. **Aspect-ratio difference** (a taller device than the Figma frame):
+   not land on the requested size. **Never resize the reference to `figma_frame_size`.**
+   It is not a frame image. Stretching a node crop to frame dimensions, then cropping it
+   again at the node's absolute coordinates, reads a region that lies outside the original
+   node entirely -- every delta downstream is a geometry artifact, and the fix loop then
+   edits working code to chase it.
+2. **Normalize the capture to the frame's logical size**, from `figma_frame_size`. When
+   `figma_frame_size` is absent, skip normalization entirely and mark the report low
+   confidence -- do not guess a frame size.
+   - **Scale-only difference** (same aspect ratio, different pixel dimensions):
+     ```
+     magick <capture.png> -resize 'WxH!' <norm.png>
+     ```
+   - **Aspect-ratio difference** (a taller device than the Figma frame):
+     ```
+     magick <capture.png> -background none -gravity NorthWest -extent WxH <norm.png>
+     ```
+     Pad, do not resize. `-resize` across differing aspect ratios stretches the image and
+     shifts every element, so every measured delta afterwards is wrong. Gravity must be
+     `NorthWest`: `Center` shifts content by half the size delta on both axes, which
+     silently invalidates every anchor measurement.
+3. **Crop the normalized capture to the node's box**, in logical px, from the same `Box:`
+   line -- absolute `x`, `y`, `w`, `h`:
    ```
-   magick <in.png> -background none -gravity NorthWest -extent WxH <out.png>
+   magick <norm.png> -crop '<w>x<h>+<x>+<y>' +repage <crop.png>
    ```
-   Pad, do not resize. `-resize` across differing aspect ratios stretches the image and
-   shifts every element, so every measured delta afterwards is wrong. Gravity must be
-   `NorthWest`: `Center` shifts content by half the size delta on both axes, which
-   silently invalidates every anchor measurement.
-4. **Crop both images to the node's bounding box** in logical px, from the node spec's
-   `Box:` line.
+   `+repage` is required; without it the crop keeps the original canvas geometry and every
+   later `identify` reports the frame size instead of the crop.
+   **The reference is never cropped.** It is already the node.
+4. **Confirm both sides ended up the same size** before comparing:
+   ```
+   magick identify -format '%wx%h ' <ref.png> <crop.png>
+   ```
+   Two different sizes mean the crop coordinates or the frame size are wrong. Say which,
+   mark the report low confidence, and do not compare anyway -- a mismatch here is exactly
+   the padded-comparison failure this phase exists to prevent.
 
-Without ImageMagick, do the equivalent reasoning structurally: state the reference size,
-the capture size, and the scale factor between them in the report, and treat every
-measurement you read off the image as relative to that factor.
+A capture that is already node-scoped -- a Playwright element screenshot taken with
+`element` and `target` -- skips steps 2 and 3 and resizes straight to the node's logical
+box, like the reference.
+
+Without ImageMagick, do the equivalent reasoning structurally: state the node box, the
+reference size, the capture size, and the scale factor between them in the report, and
+treat every measurement you read off the image as relative to that factor.
 
 ## Phase 5 -- Compare
 
@@ -271,7 +357,7 @@ magick -list metric
 ### Run the comparison
 
 ```
-magick compare -metric PDC -fuzz 5% -alpha off <a.png> <b.png> null: 2>&1
+magick compare -metric PDC -fuzz 5% -alpha off <ref.png> <crop.png> null: 2>&1
 ```
 
 Four facts about this command, each of which changes the result if ignored:
@@ -293,6 +379,33 @@ question this skill is not asking.
 
 Without ImageMagick, read the two normalized crops structurally against the spec and mark
 the report's comparison path `structural`.
+
+### From the metric to the measurements
+
+**The metric is a screening number, not a measurement.** It answers one question -- does
+this node's crop differ from its reference at all, and across how many pixels -- and it
+cannot answer any of the questions in the check order below. A pixel count carries no box
+height and no font size. Record it in the report as `diff_pixels` and use it only as the
+gate:
+
+- **`diff_pixels` is 0**, or `magick compare` exited 0 (everything within `-fuzz`): the
+  node matches. Write a report with an empty deviation table and stop. Do not measure
+  fields.
+- **`diff_pixels` is greater than 0**: run the check order, and fill each `Measured` cell
+  from the source named below. Never fill a `Measured` cell from `diff_pixels` -- it is
+  one number for the whole node and cannot be divided across rows.
+
+Each field group has exactly one measurement source:
+
+| Field group | Measured from | How |
+|-------------|---------------|-----|
+| `box.width`, `box.height` | the normalized capture crop | `magick <crop.png> -alpha off -fuzz 5% -trim -format '%wx%h' info:` -- the trimmed content size, already in logical px |
+| `anchor.x`, `anchor.y` | the crop's content within the crop box | trim as above with `-format '%wx%h%O'`; `%O` gives the trimmed content's offset inside the crop, and the node's measured center is that offset plus half the trimmed size, plus the crop's own `x`/`y` |
+| `spacing` | the normalized capture crop | measure the gap between two adjacent trimmed child regions in the crop, in logical px |
+| `typography`, `paint` | the implementation source | no pixel operation returns a font weight, a token name, or a radius value. Read the code the build wrote against the spec line, and mark these rows `source: code` in the report |
+
+The 2px tolerance below applies to these per-field deltas. It never applies to
+`diff_pixels`, which is a count, not a distance.
 
 ### Check order
 
@@ -324,7 +437,8 @@ Write to `<screenshot_dir>/verify/<task-id>.md`, where `<task-id>` is:
 - the `--task` value when mode is `build`,
 - the node ID (with `:` replaced by `-`) when mode is `standalone`.
 
-Create the `verify/` directory if it does not exist.
+Create `<screenshot_dir>/verify/` if it does not exist. (`<screenshot_dir>/actual/` was
+already created in Phase 3, before the first capture.)
 
 Fixed report shape -- identical in both modes, so a human reading a standalone report and
 `/design-build` reading a composed one see the same file:
@@ -338,6 +452,7 @@ capture_method: ios-simulator | android-adb | ios-device | web-playwright | supp
 comparison_path: imagemagick-pdc | imagemagick-ae | structural | spec-check
 confidence: high | low
 normalized: true | false
+diff_pixels: 18432 | none
 created: YYYY-MM-DD HH:MM:SS
 ---
 
@@ -345,15 +460,16 @@ created: YYYY-MM-DD HH:MM:SS
 
 Reference: .claude/plans/assets/wallet/4029-12345.png
 Capture:   .claude/plans/assets/wallet/actual/3.png
-Normalized to: 375x812 logical px (reference 375x812, capture 1179x2556 at 3x)
+Normalized to: 327x48 logical px, the node box
+  (reference 654x96 at 2x, capture 1179x2556 at 3x -> frame 375x812 -> crop +24+320)
 
 ## Deviations
 
-| Field | Expected | Measured | Delta |
-|-------|----------|----------|-------|
-| anchor.y | centered in Body content box (376) | 402 | +26 px |
-| box.height | 48 | 56 | +8 px |
-| typography.size | 16 | 14 | -2 px |
+| Field | Expected | Measured | Delta | Source |
+|-------|----------|----------|-------|--------|
+| anchor.y | centered in Body content box (376) | 402 | +26 px | crop |
+| box.height | 48 | 56 | +8 px | crop |
+| typography.size | 16 | 14 | -2 px | code |
 
 ## Notes
 
@@ -364,12 +480,22 @@ Rules for the report:
 
 - **Every delta is stated in logical px**, computed after normalization. A delta measured
   on unnormalized images is not a delta, it is a scale artifact.
+- **Every row names its `Source`** -- `crop` for a value read off the normalized crop,
+  `code` for a value read from the implementation. A row with no source is a guess.
+- **`diff_pixels` records the screening metric**, or `none` when no metric ran. It is
+  never a `Measured` value.
 - **`confidence: low`** whenever normalization was skipped, the comparison path is
-  `spec-check`, or `figma_frame_size` was absent.
+  `spec-check` or `structural`, `figma_frame_size` was absent, or the two normalized
+  sides did not end up the same size.
 - **A clean run still writes a report.** Zero deviations produces the same file with an
   empty deviation table and a line saying so. An absent report file therefore means
   exactly one thing: the verify step did not run. Nothing else may be inferred from a
   missing file.
+- **An empty table is not by itself a pass.** "Measured and matched" and "never measured"
+  both produce an empty table, and the frontmatter is what separates them: a pass carries
+  `comparison_path: imagemagick-*` with `confidence: high`, while an unmeasured run
+  carries `spec-check` or `structural`, or `confidence: low`, and lists every skipped node
+  under `## Notes` with its reason. Readers key on those fields, never on the row count.
 - **Read the file back after writing it** and confirm it exists (rule L3 in
   `.claude/rules/skill-rules.md`). A silent write failure would read downstream as "verify
   did not run", which is the wrong conclusion.
@@ -401,6 +527,17 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
   measurements and `screenshot_dir` carries the reference images.
 - **Don't** measure before normalizing. A dimension mismatch does not error -- it pads and
   returns a wrong number that looks right.
+- **Don't** resize the reference PNG to `figma_frame_size` or crop it by the node's
+  absolute box. It is exported node-clipped, so it is already the node.
+- **Don't** fill a `Measured` cell from the comparison metric. It is one count for the
+  whole node; per-field values come from the crop or from the code.
+- **Don't** run a capture command without resolving `<path>` first. Every capture lands at
+  `<screenshot_dir>/actual/<task-id>.png`, under a directory created with `mkdir -p`.
+- **Don't** let `capture_preference` override an explicit `--screenshot`. A typed path
+  outranks a stored preference.
+- **Don't** capture from whichever target answers first when several are live. Resolve the
+  target from the project manifest, then ask (standalone) or take the ordered first
+  (build).
 - **Don't** treat `magick compare` exit code 1 as a failure. It means the images differ,
   which is the entire point of running it.
 - **Don't** use `-metric AE` without probing `magick -list metric` for `PDC` first. On
@@ -433,11 +570,17 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 2. A plan with `### Node Specs` but no `design_source` is accepted and verified.
 3. A file with no `### Node Specs` section is rejected with a message; nothing is written.
 4. A plan missing all five new frontmatter fields loads on the documented defaults.
-5. `--screenshot <path>` is used directly; no capture is attempted.
-6. With `capture_preference: skip`, no capture command runs at all and the report's
-   comparison path is `spec-check`.
-7. With `capture_preference: manual` and no supplied path, the run falls to the spec read
-   rather than capturing.
+5. `--screenshot <path>` is used directly; no capture is attempted. It is used even when
+   the plan carries `capture_preference: skip`.
+6. With `capture_preference: skip` and no `--screenshot`, no capture command runs at all
+   and the report's comparison path is `spec-check`.
+7. With `capture_preference: manual`, a file already at
+   `<screenshot_dir>/actual/<task-id>.png` is used in both modes with no question asked.
+   With no such file and no supplied path, the run prints the drop-here line once and
+   falls to the spec read rather than capturing.
+7b. With a booted iOS simulator and an attached Android device both live, `standalone`
+    asks which to use and `build` takes the manifest-ordered first, recording it as
+    `capture_method`.
 8. With no capture tooling installed, each absent tool prints exactly one install line and
    the run reaches a written report.
 9. An iOS simulator capture succeeds with no `xc-interact` MCP configured.
@@ -446,10 +589,18 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 11. `--mode standalone` makes the manual-screenshot offer once; `--mode build` never does.
 12. Normalization runs before any measurement, and every delta in the report is in
     logical px.
+12b. The reference is resized to the node's `Box:` size and never cropped; the capture is
+     resized to `figma_frame_size` and then cropped at the node's absolute box. Both
+     sides `identify` to the same size before the comparison runs.
 13. `PDC` is selected when `magick -list metric` lists it; `AE` only when it does not.
 14. `magick compare` exit code 1 produces deviations, never an error.
-15. A run with zero deviations still writes a report file.
+14b. `diff_pixels` appears in the report frontmatter, and no `Measured` cell repeats it.
+     Every deviation row carries a `Source` of `crop` or `code`.
+15. A run with zero deviations still writes a report file, with
+    `comparison_path: imagemagick-*` and `confidence: high` when it was actually measured.
 16. The report is read back after writing and its path is printed.
+17. Captures and their intermediates land under `<screenshot_dir>/actual/`, which is
+    created before the first capture runs.
 
 **Verification checklist:**
 - [ ] `/design-verify` and `/quiver:design-verify` both appear in the slash menu after plugin reload.
@@ -458,6 +609,9 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 - [ ] The plan frontmatter fence is not reproduced anywhere in this file.
 - [ ] Every field this skill reads is listed with its default when absent.
 - [ ] No capture probe appears inside a `` !`...` `` block.
+- [ ] Every capture command's `<path>` resolves to `<screenshot_dir>/actual/<task-id>.png`.
+- [ ] The reference normalization targets the node box, never `figma_frame_size`.
+- [ ] Every field group in the check order has a named measurement source.
 - [ ] No figma-bridge tool is called anywhere in this file.
 - [ ] The report is written in both modes and in every comparison path.
 - [ ] `when-to-use:` is a single-line double-quoted string.
@@ -477,6 +631,11 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 - `-gravity Center` on `-extent` shifts content by half the size delta on both axes. Every
   anchor measurement taken afterwards is off by that amount, and the images still look
   correct side by side.
+- The reference PNG is node-clipped, not a frame render. Treating it as a frame -- resize
+  to `figma_frame_size`, then crop at the node's absolute coordinates -- reads a region
+  outside the node, and the resulting deltas look like real design drift.
+- `-crop` without `+repage` leaves the original canvas geometry attached. The file looks
+  cropped in a viewer while `identify` still reports the frame size.
 - `idevicescreenshot` still exists and still runs on iOS 17+; it just never returns an
   image. An empty output file, not an error, is the symptom.
 - `adb shell screencap -p` writes a file that opens in some viewers and fails in others,

--- a/skills/design-verify/SKILL.md
+++ b/skills/design-verify/SKILL.md
@@ -1,0 +1,485 @@
+---
+name: design-verify
+description: "Measure a built UI against its design measurement spec -- captures the running app when capture tooling exists, normalizes both images to a common logical width, compares them, and writes a deviation report to disk. Works standalone against any plan carrying a Node Specs section, and never requires a screenshot, an MCP server, or an installed comparison tool."
+argument-hint: "<path to a plan with a Node Specs section> [--screenshot <path>] [--nodes <id,id>] [--task <id>] [--mode standalone|build]"
+when-to-use: "user wants to check whether built UI matches its design spec -- '/design-verify', 'does this match the design', 'check the pixel accuracy', 'compare the screen to the Figma reference', 'measure the deviations from the spec'"
+---
+
+# Gather Context
+
+```
+!`git rev-parse --is-inside-work-tree 2>/dev/null || echo "NO_GIT"`
+```
+
+```
+!`git branch --show-current 2>/dev/null || echo "NO_GIT"`
+```
+
+---
+
+# Instructions
+
+You are a design fidelity inspector. You measure what was built against what was
+specified, and you write down the differences. You do not implement fixes and you do not
+open Figma. Your output is a deviation report on disk that either a human or
+`/design-build` reads.
+
+Three things you never do: demand a screenshot, demand an installed tool, or stop because
+one is missing. Every absent capability degrades to a lower-confidence path and the run
+continues.
+
+**Announce:** "Using the design-verify skill to measure the build against the spec."
+
+## Phase 0 -- Git Availability
+
+If a gather-context block returned `NO_GIT`, this directory is not a git repository.
+Print: `> No git repository detected -- skipping branch context.`
+Proceed. Nothing in this skill requires git.
+
+## Phase 1 -- Arguments and Mode
+
+Parse `$ARGUMENTS`:
+
+| Argument | Meaning | Default |
+|----------|---------|---------|
+| first bare path ending in `.md` | the plan to verify against | Glob fallback, see Phase 2 |
+| `--screenshot <path>` | a capture the user already has | none |
+| `--nodes <id,id>` | restrict verification to these node IDs | every node in the plan |
+| `--task <id>` | names the report file | the first node ID |
+| `--mode standalone` or `--mode build` | who is running this | `standalone` |
+
+**Mode arrives as an argument. Never detect the caller.** There is no inspection of the
+conversation, the transcript, or any other skill's state to decide which mode applies.
+`standalone` is the default because a human typing `/design-verify` passes no mode.
+
+The only behavioral difference between the two modes:
+
+- `standalone` may make the one-time offer to supply a screenshot manually (Phase 3).
+- `build` never offers it, because that question belongs at plan time, and interrupting a
+  build loop to ask it is the interruption the plan-time preference exists to prevent.
+
+Everything else -- capture, normalization, comparison, the report shape -- is identical.
+
+## Phase 2 -- Load the Plan
+
+**Path given.** If `$ARGUMENTS` contains a path ending in `.md`, read that file.
+
+**No path given.** Use the Glob tool on `.claude/plans/*-design-plan.md`. Treat an empty
+result as none found.
+
+- One match: read it and print `> Verifying against: {filename}`.
+- Several matches: use `AskUserQuestion` with one button per plan, most recent first,
+  plus `"Other -- I'll give a path"`.
+- No matches: print
+  ```
+  > No plan found. /design-verify needs a file with a ### Node Specs section -- a plan
+  > written by /design, or a hand-written measurement spec in the same shape.
+  ```
+  **Stop here.**
+
+**Validate on `### Node Specs` and nothing else.** The file is acceptable when it contains
+a `### Node Specs` section carrying at least one node block. A hand-written measurement
+spec is equivalent input to a Figma extraction, so this skill never requires
+`design_source`, `figma_file_key`, or any other Figma-derived field. If the section is
+missing, print:
+
+```
+> {filename} has no ### Node Specs section, so there is nothing to measure against.
+> Run /design to produce one, or pass a file that carries node measurements.
+```
+
+**Stop here.**
+
+### Frontmatter fields this skill reads
+
+The plan schema is declared once, in `skills/design/SKILL.md` Step 9. This skill does not
+reproduce that fence. It reads these fields and applies these defaults when a field is
+absent:
+
+| Field | Used for | Default when absent |
+|-------|----------|---------------------|
+| `figma_frame_size` | the reference logical width and height every normalization resolves against | none -- normalization is skipped and the report is marked low confidence |
+| `screenshot_scale` | the scale the reference images were exported at | `2` |
+| `screenshot_dir` | where reference images and the report live | `.claude/plans/assets/<slug>/`, slug derived from the plan filename |
+| `capture_preference` | which capture path Phase 3 takes | `auto` |
+
+A plan written before these fields existed loads cleanly on the defaults. Absence is
+expected, not an error.
+
+## Phase 3 -- Resolve the Capture
+
+### Input precedence
+
+None of these is mandatory. Walk them in order and stop at the first that produces an
+image:
+
+1. **A supplied screenshot** -- `--screenshot <path>`, when the file exists.
+2. **An automatic capture** -- the per-target commands below.
+3. **A spec-versus-code read** -- no image at all. Read the written code against the node
+   spec: every measurement, token, and anchor checked by hand. The report is marked
+   `spec-check` and low confidence.
+
+`capture_preference` routes into that ladder, and its three values are three distinct
+paths:
+
+- `skip` -- go straight to level 3. No capture is attempted, so no build-and-launch cycle
+  runs. This is the cheap path for a plan whose UI is not runnable right now.
+- `manual` -- level 1 only. A supplied path is expected; without one, fall to level 3
+  rather than capturing.
+- `auto` -- the full ladder.
+
+When mode is `standalone` and no screenshot was supplied and automatic capture found no
+tooling, make the offer **once** before falling to level 3, with `AskUserQuestion`:
+
+> No capture tooling resolved. A screenshot would turn this into a measured comparison
+> instead of a spec read.
+
+Buttons: `["Verify against the spec by reading the code", "I'll supply a screenshot path"]`
+
+When mode is `build`, skip that question and fall through silently.
+
+### Per-target capture commands
+
+Resolve the target **once per run**, not per node.
+
+| Target | Capture command | Absence probe |
+|--------|-----------------|---------------|
+| iOS simulator | `xcrun simctl io booted screenshot --type=png <path>` | `xcrun simctl list devices booted -j`, parse the JSON for a non-empty booted list |
+| Android emulator or device | `adb -s <SERIAL> exec-out screencap -p > <path>` | `adb devices -l`, parse the device lines |
+| Physical iOS device | `pymobiledevice3 developer dvt screenshot <path>`, or `pymobiledevice3 developer core-device screen-capture screenshot <path>` on iOS 17+ | `idevice_id -l`, parse the output for a UDID |
+| Flutter | resolve the run target from `flutter devices --machine`, then use that platform's row above | parse the JSON array's length, never the exit code |
+| Web | Playwright MCP `browser_take_screenshot` with `filename`; add `element` and `target` for a clipped capture | `ToolSearch` for `browser_take_screenshot` |
+
+Notes that change what these commands mean:
+
+- **`adb exec-out`, not `adb shell`.** `shell` mangles the binary PNG stream with CRLF
+  translation and produces a corrupt file that still writes successfully.
+- **`pymobiledevice3`, not `idevicescreenshot`.** Apple moved the screenshot relay onto
+  RemoteXPC over an RSD tunnel; libimobiledevice has no RSD implementation, so
+  `idevicescreenshot` does not work on iOS 17 or later regardless of what it prints.
+- **Playwright, not Puppeteer.** The reference Puppeteer MCP server is archived. In the
+  Playwright MCP the element parameter is `target` (renamed from `ref`), and `fullPage`
+  cannot be combined with an element screenshot.
+- **No MCP server is required for any native target.** The simulator, emulator, and
+  physical-device paths are plain CLI commands run with the Bash tool.
+
+### Exit codes lie here -- route on parsed output
+
+Every one of these tools has a non-standard exit convention:
+
+- `xcrun simctl io booted screenshot` exits **148** when nothing is booted.
+- `adb exec-out` with no device attached exits **255**, while `adb devices -l` exits 0
+  even when the list is empty.
+- `flutter devices --machine` prints `[]` and exits **0** when nothing is attached, so
+  detection reads the array length. Each device object also carries
+  `capabilities.screenshot` as a boolean -- the cheapest per-target capability probe
+  available.
+
+**Route on parsed output, never on exit status.**
+
+Run every probe with the **Bash tool**, mid-run, never inside a `` !`...` `` block. These
+are non-git commands, and lesson L1 in `.claude/rules/skill-rules.md` forbids `||` with
+non-git commands inside those blocks -- the permission parser splits on `||` and evaluates
+each side independently.
+
+### Missing tooling is informational, never terminal
+
+When a tool is absent, print exactly one line naming what to install, then continue down
+the precedence ladder:
+
+```
+> pymobiledevice3 not found -- install with: pipx install pymobiledevice3
+> Continuing without a device capture.
+```
+
+Do not print an install hint more than once per run. Do not stop.
+
+### Reaching the screen
+
+Use each node's `Route:` line from the plan to get the app onto the right screen before
+capturing. When a node's `Route:` line is absent or reads
+`not independently reachable`, skip the capture for that node and record the reason in
+the report rather than capturing whatever screen happens to be open.
+
+Print the resolved path once: `> Capture: {method}` or `> Capture: none -- spec check`.
+
+## Phase 4 -- Normalize
+
+**Normalization runs before any measurement.** This is not an optimization step that can
+be skipped when the images look close.
+
+A capture and a Figma export almost never share dimensions. The capture is a device
+screenshot at the device's pixel ratio; the export is the frame at `screenshot_scale`.
+ImageMagick 7 does not error on a dimension mismatch -- it aligns the smaller image
+against the larger, pads with virtual pixels, and returns a plausible-looking number that
+silently includes the padded region. An unnormalized comparison produces a wrong answer
+that looks like a right one.
+
+1. **Compute the common logical width.** Take the reference width from the plan's
+   `figma_frame_size` and the capture's logical size from the device. When
+   `figma_frame_size` is absent, skip normalization entirely and mark the report low
+   confidence -- do not guess a frame size.
+2. **Scale-only difference** (same aspect ratio, different pixel dimensions):
+   ```
+   magick <in.png> -resize 'WxH!' <out.png>
+   ```
+   The `!` is required; without it ImageMagick preserves aspect ratio and the output does
+   not land on the requested size.
+3. **Aspect-ratio difference** (a taller device than the Figma frame):
+   ```
+   magick <in.png> -background none -gravity NorthWest -extent WxH <out.png>
+   ```
+   Pad, do not resize. `-resize` across differing aspect ratios stretches the image and
+   shifts every element, so every measured delta afterwards is wrong. Gravity must be
+   `NorthWest`: `Center` shifts content by half the size delta on both axes, which
+   silently invalidates every anchor measurement.
+4. **Crop both images to the node's bounding box** in logical px, from the node spec's
+   `Box:` line.
+
+Without ImageMagick, do the equivalent reasoning structurally: state the reference size,
+the capture size, and the scale factor between them in the report, and treat every
+measurement you read off the image as relative to that factor.
+
+## Phase 5 -- Compare
+
+### Select the metric
+
+Probe availability first, with the Bash tool:
+
+```
+magick -version
+```
+
+Exit 127 means ImageMagick is absent. This is also a clean IM7-versus-IM6 discriminator,
+because IM6 never shipped a `magick` binary.
+
+Then probe which metric to use:
+
+```
+magick -list metric
+```
+
+- **`PDC` present:** use it. `PDC` (pixel difference count) was added in 7.1.2-20 and is
+  the current way to get a differing-pixel count.
+- **`PDC` absent:** fall back to `AE` -- but only on these older builds, where `AE` still
+  means a differing-pixel count. **Do not use `-metric AE` without this probe.**
+  ImageMagick 7.1.2-27 silently redefined `AE` as a normalized per-channel absolute-error
+  magnitude with no deprecation warning, and 7.1.2-28 normalized it further. On a current
+  build, `AE` returns a number that is not a pixel count and reads as a suspiciously small
+  deviation.
+
+### Run the comparison
+
+```
+magick compare -metric PDC -fuzz 5% -alpha off <a.png> <b.png> null: 2>&1
+```
+
+Four facts about this command, each of which changes the result if ignored:
+
+1. **The metric goes to stderr, not stdout, with no trailing newline.** Capturing stdout
+   alone yields an empty string. The `2>&1` above is what makes the number readable.
+2. **Exit code 1 means "the images differ but the comparison succeeded."** That is the
+   normal path for any real comparison, not a failure. Exit 2 is a hard error -- a
+   missing file, an unreadable format, an unknown metric. Exit 0 means the images are
+   within the fuzz tolerance.
+3. **`-fuzz` must precede the input files.** Placed after them it is silently ignored,
+   and it is honored only by `AE`, `PDC`, `PAE`, and `MAE`.
+4. **`-alpha off` is required on both sides.** PNG alpha participates in the metric, so
+   an opaque device capture compared against a transparent Figma export reports every
+   single pixel as differing.
+
+Omit `-subimage-search`. It always takes the slow path for these metrics and answers a
+question this skill is not asking.
+
+Without ImageMagick, read the two normalized crops structurally against the spec and mark
+the report's comparison path `structural`.
+
+### Check order
+
+Check in this order, and report each miss as a deviation with its measured delta:
+
+1. **Anchor** -- is the node positioned relative to the right region? Measure its center
+   against the chrome-excluded region's center from the node spec's `Anchor:` line.
+   **This is first because it is the check that silently passes.** A node centered in the
+   wrong region reads as correct at a glance while every single dimension checks out.
+2. **Box** -- width, height, and insets against the spec numbers. Where the node spec's
+   `Fit:` line says an axis is `fill`, verify the fill behavior, not the literal number
+   on the `Box:` line -- that number is what the axis measured at one frame size.
+3. **Spacing** -- gaps and padding.
+4. **Typography** -- size, weight, line height, color.
+5. **Paint** -- fill, stroke, radius, effects.
+
+**Tolerance is 2 logical px per single measurement.** Anything larger is a deviation.
+
+The tolerance is per measurement, not cumulative. Four separate 2px deviations still add
+up to a visibly wrong layout, so when several small in-tolerance deviations cluster on one
+node, recheck the anchor -- clustered small deltas are the signature of a node placed
+relative to the wrong region, where each individual dimension passes and the composition
+does not.
+
+## Phase 6 -- Write the Deviation Report
+
+Write to `<screenshot_dir>/verify/<task-id>.md`, where `<task-id>` is:
+
+- the `--task` value when mode is `build`,
+- the node ID (with `:` replaced by `-`) when mode is `standalone`.
+
+Create the `verify/` directory if it does not exist.
+
+Fixed report shape -- identical in both modes, so a human reading a standalone report and
+`/design-build` reading a composed one see the same file:
+
+```markdown
+---
+plan: .claude/plans/2026-08-17-wallet-design-plan.md
+task_id: 3
+nodes: ["4029:12345"]
+capture_method: ios-simulator | android-adb | ios-device | web-playwright | supplied | none
+comparison_path: imagemagick-pdc | imagemagick-ae | structural | spec-check
+confidence: high | low
+normalized: true | false
+created: YYYY-MM-DD HH:MM:SS
+---
+
+# Deviation Report -- <NodeName> (`4029:12345`)
+
+Reference: .claude/plans/assets/wallet/4029-12345.png
+Capture:   .claude/plans/assets/wallet/actual/3.png
+Normalized to: 375x812 logical px (reference 375x812, capture 1179x2556 at 3x)
+
+## Deviations
+
+| Field | Expected | Measured | Delta |
+|-------|----------|----------|-------|
+| anchor.y | centered in Body content box (376) | 402 | +26 px |
+| box.height | 48 | 56 | +8 px |
+| typography.size | 16 | 14 | -2 px |
+
+## Notes
+
+- Node `4029:12400` skipped: no Route: line in the spec, screen not reachable.
+```
+
+Rules for the report:
+
+- **Every delta is stated in logical px**, computed after normalization. A delta measured
+  on unnormalized images is not a delta, it is a scale artifact.
+- **`confidence: low`** whenever normalization was skipped, the comparison path is
+  `spec-check`, or `figma_frame_size` was absent.
+- **A clean run still writes a report.** Zero deviations produces the same file with an
+  empty deviation table and a line saying so. An absent report file therefore means
+  exactly one thing: the verify step did not run. Nothing else may be inferred from a
+  missing file.
+- **Read the file back after writing it** and confirm it exists (rule L3 in
+  `.claude/rules/skill-rules.md`). A silent write failure would read downstream as "verify
+  did not run", which is the wrong conclusion.
+
+Print: `> Deviation report: {path} ({N} deviations, confidence {high|low})`.
+
+## Phase 7 -- Summarize
+
+When mode is `build`, stop here. The caller reads the file.
+
+When mode is `standalone`, print the deviation table inline, then call
+`AskUserQuestion`:
+
+> {N} deviations measured against the spec. What next?
+
+Buttons: `["Fix them -- run /design-build", "Just show me the report", "Stop here"]`
+
+- **Fix them:** invoke the `design-build` skill with the plan path.
+- **Just show me the report:** print the report body and stop.
+- **Stop here:** stop.
+
+---
+
+## Anti-Patterns
+
+Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
+
+- **Don't** call figma-bridge tools. This skill never opens Figma; the plan carries the
+  measurements and `screenshot_dir` carries the reference images.
+- **Don't** measure before normalizing. A dimension mismatch does not error -- it pads and
+  returns a wrong number that looks right.
+- **Don't** treat `magick compare` exit code 1 as a failure. It means the images differ,
+  which is the entire point of running it.
+- **Don't** use `-metric AE` without probing `magick -list metric` for `PDC` first. On
+  current builds `AE` is no longer a pixel count.
+- **Don't** route on exit status for any capture tool. 148, 255, and a successful 0 on an
+  empty device list all mean something other than what they look like.
+- **Don't** detect which skill invoked this one. Mode is an argument.
+- **Don't** demand a screenshot. Every path degrades to a spec read.
+- **Don't** block on a missing tool. One install hint, then continue.
+- **Don't** put a capture probe inside a `` !`...` `` block. Non-git commands with `||`
+  fail the permission parser (lesson L1).
+- **Don't** skip writing the report when there are no deviations. A missing file must mean
+  only that the step did not run.
+
+---
+
+## Test Plan
+
+**Trigger:** `/design-verify`, `/design-verify .claude/plans/2026-08-17-wallet-design-plan.md --mode build --task 3`, `/quiver:design-verify`
+
+**Setup:**
+- A plan carrying a `### Node Specs` section with at least one node that has `Box:`,
+  `Anchor:`, and `Route:` lines.
+- For the measured path: reference PNGs under `screenshot_dir` and a runnable app.
+- For the fallback paths: the same plan with no reference images, and a machine with no
+  ImageMagick and no device tooling.
+
+**Expected behavior:**
+1. Both shell blocks exit 0 in a git repo and in a non-git directory.
+2. A plan with `### Node Specs` but no `design_source` is accepted and verified.
+3. A file with no `### Node Specs` section is rejected with a message; nothing is written.
+4. A plan missing all five new frontmatter fields loads on the documented defaults.
+5. `--screenshot <path>` is used directly; no capture is attempted.
+6. With `capture_preference: skip`, no capture command runs at all and the report's
+   comparison path is `spec-check`.
+7. With `capture_preference: manual` and no supplied path, the run falls to the spec read
+   rather than capturing.
+8. With no capture tooling installed, each absent tool prints exactly one install line and
+   the run reaches a written report.
+9. An iOS simulator capture succeeds with no `xc-interact` MCP configured.
+10. `xcrun simctl` exiting 148, `adb` exiting 255, and `flutter devices --machine`
+    printing `[]` with exit 0 are all routed from parsed output, not exit status.
+11. `--mode standalone` makes the manual-screenshot offer once; `--mode build` never does.
+12. Normalization runs before any measurement, and every delta in the report is in
+    logical px.
+13. `PDC` is selected when `magick -list metric` lists it; `AE` only when it does not.
+14. `magick compare` exit code 1 produces deviations, never an error.
+15. A run with zero deviations still writes a report file.
+16. The report is read back after writing and its path is printed.
+
+**Verification checklist:**
+- [ ] `/design-verify` and `/quiver:design-verify` both appear in the slash menu after plugin reload.
+- [ ] Both `!` blocks exit 0 with `NO_GIT` output in a non-git directory.
+- [ ] Validation checks `### Node Specs` only -- never `design_source`.
+- [ ] The plan frontmatter fence is not reproduced anywhere in this file.
+- [ ] Every field this skill reads is listed with its default when absent.
+- [ ] No capture probe appears inside a `` !`...` `` block.
+- [ ] No figma-bridge tool is called anywhere in this file.
+- [ ] The report is written in both modes and in every comparison path.
+- [ ] `when-to-use:` is a single-line double-quoted string.
+- [ ] No `CLAUDE_PLUGIN_ROOT` reference anywhere in this file.
+- [ ] No Unicode characters or emoji in this file.
+- [ ] No `$()`, variable assignment, or `if/else` inside any `!` block.
+
+**Known gotchas:**
+- `magick compare` writes its metric to stderr with no trailing newline. Reading stdout
+  returns an empty string and looks like a zero-deviation result.
+- ImageMagick redefined `-metric AE` in 7.1.2-27 without a deprecation warning. Any skill
+  or script written before that release returns a wrong number on a current build rather
+  than failing.
+- A dimension mismatch is the dangerous case precisely because it does not error.
+  ImageMagick pads the smaller image with virtual pixels and reports a number that
+  includes the padding.
+- `-gravity Center` on `-extent` shifts content by half the size delta on both axes. Every
+  anchor measurement taken afterwards is off by that amount, and the images still look
+  correct side by side.
+- `idevicescreenshot` still exists and still runs on iOS 17+; it just never returns an
+  image. An empty output file, not an error, is the symptom.
+- `adb shell screencap -p` writes a file that opens in some viewers and fails in others,
+  because the CRLF translation corrupts the stream. `exec-out` is the only correct form.
+- `flutter devices --machine` is a hidden flag. It exits 0 whether or not a device is
+  attached, so an exit-status check reports success against an empty list.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -122,9 +122,16 @@ Run these against the resolved `fileKey`:
      record the resolved location as `screenshot_dir` in the plan frontmatter. Do not
      assume the server's working directory is the project root.
    - **Writes use flag `wx` and throw on an existing file.** Before writing, list the
-     target directory. When a file of the same name already exists, delete it first or
-     write a suffixed name (`<node-id>-2.png`). A second `/design` run against the same
-     node must not throw.
+     target directory. When a file of the same name already exists, **write a suffixed
+     name** (`<node-id>-2.png`, incrementing until the name is free). A second `/design`
+     run against the same node must not throw.
+
+     **Never delete the existing file.** Step 9 has not yet asked whether this run
+     overwrites the previous plan, and an existing plan's `Reference:` lines and `###
+     Assets` rows point at these exact paths. Deleting here would answer that question
+     destructively before it is asked: the user could still choose "Write a new plan
+     file", keeping a plan whose images had already been replaced with a different
+     design's. Suffixing costs disk and keeps both plans readable.
 
    Record every exported file with its node ID, node name, and final path. Step 9 writes
    them into the plan's `### Assets` section.
@@ -515,7 +522,7 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 - **Don't** skip the anchor computation because the node "is obviously centered". Centered inside what is the whole question.
 - **Don't** invent a codebase precedent. If code-navigator found none, say none was found.
 - **Don't** write a `fill` axis as the literal measured width. The measurement is what that axis happened to be at one frame size; the fit is the intent.
-- **Don't** export an asset over an existing file. The bridge writes with flag `wx` and throws -- list the directory first.
+- **Don't** export an asset over an existing file, and don't delete one to make room. The bridge writes with flag `wx` and throws -- list the directory first and suffix the name. An existing plan still references the old file, and Step 9's overwrite question has not been asked yet.
 - **Don't** restate the plan frontmatter schema in another skill. Step 9's fence is the only declaration; consumers list the fields they read.
 - **Don't** compare a `VARIABLE_ALIAS` as if it were a value. Follow the alias chain to a literal first.
 - **Don't** dispatch a prompt containing `{true|false}`. `codegraph_available` and `lsp_available` are resolved to literals before Step 6 dispatches.
@@ -539,7 +546,7 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 5. A node ID passed as `4029-12345` is normalized to `4029:12345` before any tool call.
 6. With nothing selected and no ID argument, Step 3 prints the selection instruction and stops.
 7. Step 4 writes reference PNGs into `.claude/plans/assets/<slug>/` at scale 2, plus one file per icon and image leaf node (`.svg` for vectors, `.png` at scale 3 otherwise).
-8. Re-running `/design` against a node whose asset already exists does not throw -- the existing file is removed or the new name is suffixed.
+8. Re-running `/design` against a node whose asset already exists does not throw, and does not delete the existing file -- the new export takes a suffixed name and the previous plan's references still resolve.
 9. A `save_screenshots` sandbox rejection prints the reported sandbox root and writes there, recording it as `screenshot_dir`.
 10. Step 5 emits an Anchor line for every node, and a Reconciliation line for every node whose anchor references excluded chrome.
 11. Step 6 resolves `codegraph_available` from a Glob on `.codegraph/*` and dispatches exactly one `quiver:code-navigator` agent, with literals in the prompt, and waits without polling.
@@ -578,7 +585,7 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 - Instance-child node IDs use the `I12740:17806;12740:17793` form. Passing only the leading segment returns the wrong node.
 - `.claude/plans/assets/` holds binary PNGs. If the project gitignores `.claude/`, the screenshots are local-only, which is intended.
 - The plugin must stay running in Figma for the whole extraction. Closing it mid-run drops the WebSocket and later calls fail.
-- `save_screenshots` writes with flag `wx`. It throws on an existing file rather than overwriting, which is why a second run against the same node fails unless the directory is listed first.
+- `save_screenshots` writes with flag `wx`. It throws on an existing file rather than overwriting, which is why a second run against the same node fails unless the directory is listed first. Suffixing rather than deleting matters because Step 4 runs before Step 9's overwrite question -- deleting would strip an existing plan's reference images no matter which way the user answered it.
 - `save_screenshots` sandboxes `outputPath` to the MCP server's working directory, which is not always the project root. A rejection is a path problem, not a permissions problem.
 - `save_screenshots` infers the format from the `outputPath` extension. Passing a `format` that disagrees with the extension throws, and `scale` is ignored entirely for SVG and PDF.
 - `get_screenshot` returns base64 inside a JSON text blob rather than an inline image, so nothing in this skill can see it. Visual work goes through `save_screenshots` and a subsequent Read.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -1,0 +1,366 @@
+---
+name: design
+description: "Extract a Figma design into a pixel-exact implementation plan -- reads the selected nodes through the figma-bridge MCP, maps Figma variables onto the project's existing theme tokens, and writes a self-contained plan to .claude/plans/ that /design-build executes without touching Figma again."
+argument-hint: "<node id, or a short description of what to build>"
+when-to-use: "user wants to turn a Figma design into code -- '/design', 'implement this Figma design', 'build the screen I selected in Figma', 'turn this Figma node into code', 'pixel perfect from Figma'"
+---
+
+# Gather Context
+
+```
+!`git rev-parse --is-inside-work-tree 2>/dev/null || echo "NO_GIT"`
+```
+
+```
+!`git branch --show-current 2>/dev/null || echo "NO_GIT"`
+```
+
+---
+
+# Instructions
+
+You are a design extraction specialist. Your job is to pull an exact measurement spec out of Figma, reconcile it against the project's real layout system and token system, and write an implementation plan that carries every number it needs. You do NOT write implementation code -- `/design-build` does that, and it must be able to do so with Figma disconnected.
+
+**Announce:** "Using the design skill to extract the Figma spec."
+
+## Step 0 -- Git Availability
+
+If a gather-context block returned `NO_GIT`, this directory is not a git repository.
+Print: `> No git repository detected -- skipping branch context.`
+Proceed. Nothing in this skill requires git.
+
+## Step 1 -- Bridge Availability
+
+The figma-bridge MCP tools are deferred. Load the read-side schemas before use:
+
+Call `ToolSearch` with query:
+`"select:mcp__figma-bridge__list_files,mcp__figma-bridge__get_selection,mcp__figma-bridge__get_node,mcp__figma-bridge__get_design_context,mcp__figma-bridge__get_variable_defs,mcp__figma-bridge__get_styles,mcp__figma-bridge__save_screenshots"`
+
+If `ToolSearch` returns no figma-bridge tools, the MCP server is not configured. Print exactly:
+
+```
+> figma-bridge MCP is not available. Two pieces are needed:
+>
+>   1. MCP server -- add to your MCP config:
+>        command: npx
+>        args: ["-y", "@gethopp/figma-mcp-bridge"]
+>
+>   2. Figma plugin -- download from
+>      https://github.com/gethopp/figma-mcp-bridge/releases
+>      then in Figma: Plugins > Development > Import plugin from manifest
+>
+> Run the plugin inside the Figma file you want to read, then retry /design.
+```
+
+**Stop here.**
+
+Never call the figma-bridge write tools (`create_*`, `set_*`, `delete_nodes`, `duplicate_nodes`, `reparent_nodes`, `group_nodes`, `ungroup_node`). This skill is read-only against Figma.
+
+## Step 2 -- File Selection
+
+Call `list_files`.
+
+- **Empty result (`[]`):** no Figma file is connected. Print:
+  ```
+  > No Figma file connected. Open the figma-mcp-bridge plugin inside the Figma
+  > file you want to read (Plugins > Development > figma-mcp-bridge), leave it
+  > running, then retry /design.
+  ```
+  **Stop here.**
+- **Exactly one file:** use its `fileKey` for every later call. Print `> Connected file: {fileName}`.
+- **More than one file:** use `AskUserQuestion`.
+  > Multiple Figma files are connected. Which one holds the design?
+
+  Build one button per file using its `fileName`. Carry the chosen `fileKey` into every later call -- when more than one file is connected, `fileKey` is required by every bridge tool.
+
+## Step 3 -- Node Selection
+
+Resolve the target nodes in this order:
+
+1. **`$ARGUMENTS` contains a node ID.** Accept both `4029:12345` and instance-child form `I12740:17806;12740:17793`. Figma share URLs write IDs with a hyphen (`4029-12345`); the bridge rejects hyphens, so normalize every hyphen between two digit runs into a colon before calling any tool.
+2. **Otherwise call `get_selection`.** Use whatever is selected on the Figma canvas.
+3. **Selection is empty and no ID was given.** Print:
+   ```
+   > Nothing selected in Figma. Select the frame or component you want built,
+   > then retry /design. You can also pass a node ID directly:
+   >   /design 4029:12345
+   ```
+   **Stop here.**
+
+Print the resolved targets: `> Extracting {N} node(s): {names}`.
+
+If more than 8 top-level nodes are selected, use `AskUserQuestion`:
+> {N} nodes are selected. Extracting all of them produces a very large plan.
+
+Buttons: `["Extract all {N}", "Extract only the top-level frames", "Let me reselect in Figma"]`
+
+On "Let me reselect", stop and tell the user to retry after narrowing the selection.
+
+## Step 4 -- Extraction
+
+Run these against the resolved `fileKey`:
+
+1. `get_design_context` with `depth: 4` -- the summarized tree. This establishes the parent chain and sibling order for every target.
+2. `get_node` for each target node ID -- full detail. Recurse into children that carry their own visual treatment (text, fills, strokes, effects, distinct auto-layout). Do not recurse into pure spacer nodes.
+3. `get_variable_defs` -- every local variable collection, its modes, and its resolved values. These are the design tokens.
+4. `get_styles` -- local paint/text/effect styles, for nodes that reference a style instead of a variable.
+5. `save_screenshots` for the target nodes into `.claude/plans/assets/<slug>/`, PNG at `scale: 2`, `clip: true`. `<slug>` is a kebab-case name derived from the top-level node name. These files are the visual reference `/design-build` compares against.
+
+Record for every extracted node:
+
+- Node ID, name, type
+- Absolute box: `x`, `y`, `width`, `height`
+- Parent chain, with each ancestor's box
+- Auto-layout: direction, item spacing, padding (top/right/bottom/left), primary and counter axis alignment, sizing mode per axis
+- Constraints when auto-layout is absent
+- Typography: family, weight, size, line height, letter spacing, alignment, text case, decoration
+- Fills, strokes (weight and alignment), corner radii per corner, effects (shadow offsets, blur, spread, color, opacity)
+- Opacity, blend mode, clipping, rotation
+- Variable or style binding per property, when present
+
+Numbers go into the plan exactly as Figma reports them. Do not round, do not convert units, do not "clean up" a 17px gap into 16px. If a value looks like a design mistake, write the Figma value and add a `Note:` line beside it.
+
+## Step 5 -- Layout Frame Reconciliation
+
+This is the step that decides whether the build looks right or subtly wrong.
+
+Figma coordinates are absolute within the page. Code positions elements inside a layout tree whose origin, and whose available height, are usually not the same. The classic failure: a card is visually centered between an app bar and a bottom navigation bar in Figma, the implementation writes a page-level center, and the card lands too close to the app bar because the page-level frame includes the chrome that Figma's visual centering excluded.
+
+For every extracted node, compute and record an **Anchor**:
+
+1. Identify the node's **effective container** -- the nearest ancestor that actually bounds it. Walk up the parent chain and stop at the first ancestor that either has auto-layout, clips content, or has a fill or stroke marking it as a surface.
+2. Compute the effective container's **content box**: its own box minus its padding, and minus any sibling chrome that occupies a full edge (top bars, bottom bars, tab bars, safe-area spacers). Chrome is identified by a sibling that spans the container's full width (or full height) and sits flush against one edge.
+3. Express the node's position **relative to that content box**, on both axes, as one of:
+   - `centered` -- node center is within 1px of the content box center on that axis
+   - `centered +N` -- centered but offset by N px
+   - `start +N` / `end +N` -- pinned to an edge with an N px inset
+   - `stretch` -- node fills the axis
+   - `flow index N` -- the container is auto-layout and the node is the Nth child; position is a consequence of the flow, not an anchor
+4. Name the excluded chrome explicitly, with its measured size.
+
+Write the result as a single readable line, for example:
+
+```
+Anchor: horizontally centered in Body content box; vertically centered +12
+        (Body content box = 375x588, excludes AppBar 56 top and NavBar 80 bottom)
+```
+
+A node whose anchor is `flow index N` needs no reconciliation -- the container's auto-layout produces the position. A node whose anchor is `centered` inside a content box that excludes chrome is the case that must be flagged, because a naive implementation will get it wrong.
+
+For every node whose anchor references excluded chrome, add a **Reconciliation** line to its spec naming what the implementation must center within -- the chrome-excluded region, not the full screen.
+
+## Step 6 -- Codebase Grounding
+
+Dispatch the `quiver:code-navigator` agent. The prompt must be self-contained -- the agent has no memory of this conversation.
+
+```
+Agent(
+  subagent_type="quiver:code-navigator",
+  description="Map theme and layout patterns for design implementation",
+  prompt="Task: a Figma design is about to be implemented as code in this project.
+  Map the existing systems the implementation must reuse.
+
+  codegraph_available: {true|false -- set true if .codegraph/ exists at project root}
+  lsp_available: {true|false}
+
+  Report:
+
+  1. DESIGN TOKENS -- every file that defines colors, spacing, typography, radii,
+     shadows, or breakpoints as named values. For each, give the file path, the
+     naming convention, and 3-5 example entries with their literal values.
+
+  2. LAYOUT CHROME -- how screens declare persistent chrome (app bars, bottom
+     navigation, tab bars, safe areas, sidebars, headers). Give file paths and the
+     exact mechanism used.
+
+  3. CHROME-EXCLUDED CENTERING PRECEDENT -- find any existing screen or component
+     that centers content inside a region that excludes chrome, rather than inside
+     the full screen. This is the highest-value item in this report. For each hit,
+     give the file path, the line range, and the exact mechanism (a layout widget,
+     an inset calculation, a constraint, a CSS rule). If there is no such
+     precedent anywhere in the codebase, say so explicitly -- do not invent one.
+
+  4. COMPONENT CONVENTIONS -- where UI components live, how they are named, how
+     styles are attached, and whether there is an existing component that already
+     matches any of these Figma node names: {list of extracted node names}.
+
+  5. STACK -- language, UI framework and version, styling approach.
+
+  Cite file:line for every claim. Do not report a path you did not read.",
+)
+```
+
+Wait for the agent. Do not poll and do not schedule a wakeup -- the harness notifies on completion.
+
+## Step 7 -- Token Mapping
+
+Build a mapping table from every Figma variable and style used by the extracted nodes onto the project's tokens found in Step 6.
+
+Match on resolved value first, then on name similarity. A value match is authoritative; a name match with a differing value is not a match.
+
+For every Figma variable that has **no** project token with the same value, use `AskUserQuestion`. Batch up to 4 unmapped variables per call.
+
+> `{figma variable name}` = `{value}` has no matching token in `{token file}`. How should it be implemented?
+
+Buttons per variable: `["Map to {closest existing token} ({its value})", "Add a new token to {token file}", "Write the raw value inline"]`
+
+Never write a raw value silently. If the user picks "Add a new token", record the proposed token name and target file in the plan as an explicit task -- `/design-build` creates it.
+
+Produce the final map:
+
+| Figma | Value | Implementation | Source |
+|-------|-------|----------------|--------|
+| `text/primary` | `#111827` | `colors.textPrimary` | existing, `lib/theme/colors.dart:14` |
+| `space/gutter` | `20` | `spacing.gutter` | new, add to `lib/theme/spacing.dart` |
+| -- | `#3A7BD5` | raw `#3A7BD5` | user chose inline |
+
+## Step 8 -- Write the Plan
+
+Write to `.claude/plans/YYYY-MM-DD-<slug>-design-plan.md` (use `date '+%Y-%m-%d'` for the prefix).
+
+**Language rule:** the plan is always written in English, regardless of the conversation language.
+
+**Self-containment rule:** `/design-build` runs with Figma disconnected. Every number, token, anchor, and reconciliation note it needs must be inside this file or inside `screenshot_dir`. A plan that says "see the Figma node" is broken.
+
+Frontmatter:
+
+```yaml
+---
+name: <slug>-design-plan
+design_source: figma-bridge
+figma_file_key: <fileKey>
+figma_file_name: <fileName>
+figma_node_ids: ["4029:12345", "4029:12400"]
+screenshot_dir: .claude/plans/assets/<slug>/
+stack: <language>, <framework> <version>
+created: YYYY-MM-DD
+---
+```
+
+Body sections, in order:
+
+### Goal
+One sentence: what screen or component gets built, and where it lives.
+
+### Stack and Conventions
+From Step 6. Where components live, how styles attach, which token files apply.
+
+### Token Map
+The table from Step 7, verbatim. Mark every `new` row -- those become tasks.
+
+### Layout Reconciliation
+List every node whose anchor references excluded chrome. For each: the anchor line, the chrome measurements, the codebase precedent from Step 6 item 3 with its `file:line`, and the mechanism to use. When Step 6 found no precedent, write `No precedent found` and state what the implementation should try instead, derived from the layout chrome mechanism in Step 6 item 2.
+
+### Node Specs
+One block per node, in tree order:
+
+```
+#### <NodeName> (`4029:12345`)
+
+- Type: FRAME
+- Parent chain: Screen > Body > Content
+- Anchor: horizontally centered in Body content box; vertically centered +12
+  (Body content box = 375x588, excludes AppBar 56 top and NavBar 80 bottom)
+- Reconciliation: center within the chrome-excluded region, not the screen.
+  Follow lib/screens/wallet_screen.dart:88-104.
+- Box: absolute x 24 y 320 w 327 h 48; relative to Body content box x 24 y 264
+- Layout: auto-layout HORIZONTAL, gap 8, padding 16/12/16/12,
+  main axis CENTER, cross axis CENTER, sizing HUG x FIXED
+- Typography: Inter SemiBold 16/24, letter-spacing -0.2
+- Fill: colors.surface (Figma surface/default #FFFFFF)
+- Stroke: 1 INSIDE, colors.border (Figma border/subtle #E5E7EB)
+- Radius: 12 12 12 12 -> radii.md
+- Effects: drop shadow 0 1 2 blur 3 rgba(0,0,0,0.05) -> shadows.sm
+- Reference: .claude/plans/assets/<slug>/4029-12345.png
+```
+
+Omit properties the node does not have. Never write a placeholder.
+
+### File Map
+- Create: `exact/path.ext` -- one-line purpose
+- Modify: `exact/path.ext` -- what changes
+- Test: `exact/path.ext` -- which test file
+
+### Tasks
+Numbered. Each task names its files, its node IDs, and its acceptance criterion. Order: new tokens first, then leaf components, then composition, then the screen. Each task is 2-10 minutes and independently verifiable.
+
+### Acceptance Criteria
+One criterion per task, plus one fidelity criterion per top-level node stated in measurable terms, for example: "the card's vertical center sits within 2px of the chrome-excluded region's center".
+
+## Step 9 -- Verify and Hand Off
+
+1. Read the plan file back. Confirm it exists and that the Node Specs section carries real numbers.
+2. Confirm no raw `{...}` placeholder text survives anywhere in the file.
+3. Confirm every screenshot referenced under `screenshot_dir` exists on disk.
+4. Print: `> Design plan saved: .claude/plans/{filename} ({N} nodes, {M} tasks).`
+
+Then call `AskUserQuestion`:
+
+> Plan saved. What next?
+
+Buttons: `["Build it now -- run /design-build", "Review the plan first", "Stop here"]`
+
+- **Build it now:** invoke the `design-build` skill with the saved plan path.
+- **Review the plan first:** print the plan body and stop.
+- **Stop here:** stop.
+
+---
+
+## Anti-Patterns
+
+Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
+
+- **Don't** write implementation code. This skill extracts and plans.
+- **Don't** call any figma-bridge write tool. Read-only against Figma, always.
+- **Don't** round or normalize Figma measurements. A 17px gap is 17px in the plan.
+- **Don't** reference Figma node data that is not embedded in the plan. `/design-build` runs with the bridge disconnected.
+- **Don't** silently write a raw color or dimension when no token matches. Ask.
+- **Don't** skip the anchor computation because the node "is obviously centered". Centered inside what is the whole question.
+- **Don't** invent a codebase precedent. If code-navigator found none, say none was found.
+
+---
+
+## Test Plan
+
+**Trigger:** `/design`, `/design 4029:12345`, `/quiver:design`
+
+**Setup:**
+- figma-bridge MCP server configured, plugin running inside a Figma file.
+- A frame selected in Figma that sits inside a parent containing top and bottom chrome.
+- A project with at least one token file.
+
+**Expected behavior:**
+1. Both shell blocks exit 0 in a git repo and in a non-git directory.
+2. With the MCP absent, Step 1 prints the two-part install block and stops -- no partial plan is written.
+3. With the MCP present but no file connected, `list_files` returns `[]` and Step 2 prints the plugin instruction and stops.
+4. With more than one file connected, Step 2 asks which file via `AskUserQuestion` and passes `fileKey` to every later call.
+5. A node ID passed as `4029-12345` is normalized to `4029:12345` before any tool call.
+6. With nothing selected and no ID argument, Step 3 prints the selection instruction and stops.
+7. Step 4 writes PNGs into `.claude/plans/assets/<slug>/` at scale 2.
+8. Step 5 emits an Anchor line for every node, and a Reconciliation line for every node whose anchor references excluded chrome.
+9. Step 6 dispatches exactly one `quiver:code-navigator` agent and waits without polling.
+10. Step 7 asks before writing any raw value, batching up to 4 unmapped variables per `AskUserQuestion` call.
+11. Step 8 writes the plan with `design_source`, `figma_file_key`, `figma_node_ids`, and `screenshot_dir` in frontmatter.
+12. Step 9 reads the plan back, verifies the screenshots exist, and offers the handoff via `AskUserQuestion`.
+
+**Verification checklist:**
+- [ ] `/design` and `/quiver:design` both appear in the slash menu after plugin reload.
+- [ ] Both `!` blocks exit 0 with `NO_GIT` output in a non-git directory.
+- [ ] No figma-bridge write tool is ever called.
+- [ ] The saved plan contains no raw `{...}` placeholder text.
+- [ ] Every node spec block carries literal numbers, not references to Figma.
+- [ ] Every screenshot named in the plan exists at that path.
+- [ ] Unmapped Figma variables produce an `AskUserQuestion`, never a silent raw value.
+- [ ] Anchor lines name the excluded chrome and its measured size.
+- [ ] `when-to-use:` is a single-line double-quoted string.
+- [ ] No `CLAUDE_PLUGIN_ROOT` reference anywhere in this file.
+- [ ] No Unicode characters or emoji in this file.
+- [ ] No `$()`, variable assignment, or `if/else` inside any `!` block.
+
+**Known gotchas:**
+- Figma share URLs use a hyphen in node IDs (`4029-12345`); the bridge tool schema rejects hyphens. Normalization in Step 3 is mandatory, not optional.
+- When more than one Figma file is connected, every bridge tool requires `fileKey`. Omitting it fails at call time, not at plan time.
+- `get_design_context` returns a summarized tree. It is not a substitute for `get_node` -- the summary drops most visual properties.
+- Instance-child node IDs use the `I12740:17806;12740:17793` form. Passing only the leading segment returns the wrong node.
+- `.claude/plans/assets/` holds binary PNGs. If the project gitignores `.claude/`, the screenshots are local-only, which is intended.
+- The plugin must stay running in Figma for the whole extraction. Closing it mid-run drops the WebSocket and later calls fail.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -104,7 +104,30 @@ Run these against the resolved `fileKey`:
 2. `get_node` for each target node ID -- full detail. Recurse into children that carry their own visual treatment (text, fills, strokes, effects, distinct auto-layout). Do not recurse into pure spacer nodes.
 3. `get_variable_defs` -- every local variable collection, its modes, and its resolved values. These are the design tokens.
 4. `get_styles` -- local paint/text/effect styles, for nodes that reference a style instead of a variable.
-5. `save_screenshots` for the target nodes into `.claude/plans/assets/<slug>/`, PNG at `scale: 2`, `clip: true`. `<slug>` is a kebab-case name derived from the top-level node name. These files are the visual reference `/design-build` compares against.
+5. `save_screenshots` for the target nodes into `.claude/plans/assets/<slug>/`, PNG at `scale: 2`, `clip: true`. `<slug>` is a kebab-case name derived from the top-level node name. These files are the visual reference `/design-verify` compares against.
+
+   Then export every icon and image leaf node reached in item 2. The bridge infers the
+   format from the `outputPath` extension, and passing a conflicting explicit `format`
+   throws:
+
+   - Vector nodes (`VECTOR`, `BOOLEAN_OPERATION`, icon components): `.svg` outputPath.
+     `scale` is ignored for SVG and PDF.
+   - Everything else (raster fills, photos): `.png` at `scale: 3`.
+
+   Two mechanical guards, both from the bridge's actual behavior:
+
+   - **`outputPath` is sandboxed to the MCP server's working directory.** Attempt the
+     write to `.claude/plans/assets/<slug>/`. If the call reports the path is outside the
+     working directory, print the sandbox root it reported, write there instead, and
+     record the resolved location as `screenshot_dir` in the plan frontmatter. Do not
+     assume the server's working directory is the project root.
+   - **Writes use flag `wx` and throw on an existing file.** Before writing, list the
+     target directory. When a file of the same name already exists, delete it first or
+     write a suffixed name (`<node-id>-2.png`). A second `/design` run against the same
+     node must not throw.
+
+   Record every exported file with its node ID, node name, and final path. Step 9 writes
+   them into the plan's `### Assets` section.
 
 Record for every extracted node:
 
@@ -151,6 +174,12 @@ For every node whose anchor references excluded chrome, add a **Reconciliation**
 
 ## Step 6 -- Codebase Grounding
 
+First resolve `codegraph_available`. Use the Glob tool on `.codegraph/*` at the project
+root. A non-empty result resolves it to the literal `true`; an empty result resolves it
+to the literal `false`. Resolve `lsp_available` the same way, from whether the LSP tool
+is present in this session. Both values go into the prompt below as literals -- a
+dispatched prompt containing `{true|false}` is a bug, not a template.
+
 Dispatch the `quiver:code-navigator` agent. The prompt must be self-contained -- the agent has no memory of this conversation.
 
 ```
@@ -160,8 +189,8 @@ Agent(
   prompt="Task: a Figma design is about to be implemented as code in this project.
   Map the existing systems the implementation must reuse.
 
-  codegraph_available: {true|false -- set true if .codegraph/ exists at project root}
-  lsp_available: {true|false}
+  codegraph_available: <literal true or false, resolved above>
+  lsp_available: <literal true or false, resolved above>
 
   Report:
 
@@ -186,6 +215,27 @@ Agent(
 
   5. STACK -- language, UI framework and version, styling approach.
 
+  6. ICON AND ASSET SYSTEM -- where icons and images live, how they are referenced
+     from UI code (an icon font, an SVG component, a raw asset path, a generated
+     manifest), and the naming convention. Give the directory and 2-3 example
+     references with their file:line.
+
+  7. I18N SYSTEM -- whether user-facing strings go through a translation layer. If
+     one exists, give the key convention, the file that holds the keys, and one
+     example of a string being resolved in a UI file. If there is none, say so
+     explicitly -- that answer decides whether copy is inlined or keyed.
+
+  8. THEME MODE MECHANISM -- how the project switches between light, dark, or any
+     other theme mode. Give the file that declares the modes and the mechanism a
+     component uses to read the current mode's value.
+
+  9. RESPONSIVE CONVENTION -- breakpoints, adaptive layout helpers, or a fixed
+     design width the project scales from. Give file:line and the exact values.
+
+  10. RUNTIME REACHABILITY -- the routing mechanism and how a screen is reached at
+      runtime. Give the router file, the route-declaration form, and one worked
+      example: the literal route or navigation call that opens an existing screen.
+
   Cite file:line for every claim. Do not report a path you did not read.",
 )
 ```
@@ -198,29 +248,108 @@ Build a mapping table from every Figma variable and style used by the extracted 
 
 Match on resolved value first, then on name similarity. A value match is authoritative; a name match with a differing value is not a match.
 
-For every Figma variable that has **no** project token with the same value, use `AskUserQuestion`. Batch up to 4 unmapped variables per call.
+**Resolve every value before matching.** `get_variable_defs` returns each collection with
+a `modes: [{modeId, name}]` list and each variable with a full `valuesByMode` map. A
+variable that resolves to another variable arrives unresolved as
+`{type: "VARIABLE_ALIAS", id}`. Follow the alias chain to its literal value before
+comparing anything -- an alias compared as-is matches no token and produces a false
+unmapped row. One table row per variable per mode.
 
-> `{figma variable name}` = `{value}` has no matching token in `{token file}`. How should it be implemented?
+**Auto-map first, ask once.** Every Figma variable whose resolved value equals a project
+token's value is mapped automatically -- do not ask about it. Build the complete table
+with every row filled in and every remaining row marked `UNMAPPED`, print it, then ask a
+single `AskUserQuestion`:
 
-Buttons per variable: `["Map to {closest existing token} ({its value})", "Add a new token to {token file}", "Write the raw value inline"]`
+> {N} of {M} Figma variables mapped automatically. {K} have no matching project token.
 
-Never write a raw value silently. If the user picks "Add a new token", record the proposed token name and target file in the plan as an explicit task -- `/design-build` creates it.
+Buttons: `["Approve this mapping", "Walk the unmapped rows one at a time"]`
+
+- **Approve this mapping:** every `UNMAPPED` row is recorded as a new token to add,
+  named from the Figma variable, targeting the token file Step 6 identified for that
+  value's category.
+- **Walk the unmapped rows one at a time:** for each `UNMAPPED` row, use
+  `AskUserQuestion`:
+
+  > `{figma variable name}` = `{value}` has no matching token in `{token file}`. How should it be implemented?
+
+  Buttons: `["Map to {closest existing token} ({its value})", "Add a new token to {token file}", "Write the raw value inline"]`
+
+Never write a raw value silently. Every raw value in the finished plan appears as a row
+in this table with `user chose inline` as its source. If the user picks "Add a new
+token", record the proposed token name and target file in the plan as an explicit task
+-- `/design-build` creates it.
 
 Produce the final map:
 
-| Figma | Value | Implementation | Source |
-|-------|-------|----------------|--------|
-| `text/primary` | `#111827` | `colors.textPrimary` | existing, `lib/theme/colors.dart:14` |
-| `space/gutter` | `20` | `spacing.gutter` | new, add to `lib/theme/spacing.dart` |
-| -- | `#3A7BD5` | raw `#3A7BD5` | user chose inline |
+| Figma | Mode | Value | Implementation | Source |
+|-------|------|-------|----------------|--------|
+| `text/primary` | Light | `#111827` | `colors.textPrimary` | existing, `lib/theme/colors.dart:14` |
+| `text/primary` | Dark | `#F9FAFB` | `colors.textPrimary` | existing, `lib/theme/colors.dart:31` |
+| `space/gutter` | -- | `20` | `spacing.gutter` | new, add to `lib/theme/spacing.dart` |
+| -- | -- | `#3A7BD5` | raw `#3A7BD5` | user chose inline |
 
-## Step 8 -- Write the Plan
+Write `--` in the Mode column for a collection that has exactly one mode. A variable
+whose collection has two or more modes must produce one row per mode; a single-row
+entry for a multi-mode variable ships a theme that only works in one mode.
+
+## Step 8 -- Build Preferences
+
+Ask these now, at plan time, so `/design-build` never has to interrupt the build loop to
+ask. One `AskUserQuestion` call carrying all three questions.
+
+**Question 1 -- Commit strategy.**
+> How should the build commit its work?
+
+Buttons: `["No commit -- leave changes in the working tree (Recommended)", "One commit per task", "One commit at the end"]`
+
+Record as `commit_strategy: none` / `per-task` / `single`.
+
+**Question 2 -- Verification gate.**
+> What should run before the build accepts a task?
+
+Buttons: `["Run the project's build", "Run the project's tests", "No gate"]`
+
+Record as `verify_gate: build` / `test` / `none`.
+
+**Question 3 -- Capture preference.**
+> How should the built UI be captured for fidelity comparison?
+
+Buttons: `["Capture automatically (Recommended)", "I will supply screenshots", "Skip capture -- verify against the spec"]`
+
+Record as `capture_preference: auto` / `manual` / `skip`.
+
+These three are distinct build paths, not shades of one: `skip` never attempts a capture
+at all and so never triggers a build-and-launch cycle, `manual` waits for a supplied
+path, `auto` attempts capture per task.
+
+## Step 9 -- Write the Plan
 
 Write to `.claude/plans/YYYY-MM-DD-<slug>-design-plan.md` (use `date '+%Y-%m-%d'` for the prefix).
+
+**Overwrite guard.** Before writing, use the Glob tool on `.claude/plans/*<slug>-design-plan.md`.
+If a match exists, first summarize what changed in this extraction against the existing
+plan -- node count, node IDs added or dropped, token map rows that differ -- then use
+`AskUserQuestion`:
+
+> A design plan for `{slug}` already exists: `{existing path}`.
+> {one line per difference}
+
+Buttons: `["Update the existing plan", "Write a new plan file"]`
+
+- **Update the existing plan:** write to the existing path.
+- **Write a new plan file:** write to `.claude/plans/YYYY-MM-DD-<slug>-design-plan-2.md`,
+  incrementing the suffix until the name is free.
+
+Never overwrite an existing plan without this question.
 
 **Language rule:** the plan is always written in English, regardless of the conversation language.
 
 **Self-containment rule:** `/design-build` runs with Figma disconnected. Every number, token, anchor, and reconciliation note it needs must be inside this file or inside `screenshot_dir`. A plan that says "see the Figma node" is broken.
+
+**The fence below is the single declaration point for the design-plan schema.** Consumer
+skills (`/design-build`, `/design-verify`) list only the fields they read and the default
+they apply when a field is absent. No other file reproduces this fence. Every contract in
+this repo that a consumer restated has drifted; this one is declared once.
 
 Frontmatter:
 
@@ -231,11 +360,21 @@ design_source: figma-bridge
 figma_file_key: <fileKey>
 figma_file_name: <fileName>
 figma_node_ids: ["4029:12345", "4029:12400"]
+figma_frame_size: <W>x<H>
 screenshot_dir: .claude/plans/assets/<slug>/
+screenshot_scale: 2
 stack: <language>, <framework> <version>
+commit_strategy: none | per-task | single
+verify_gate: build | test | none
+capture_preference: auto | manual | skip
 created: YYYY-MM-DD
 ---
 ```
+
+`figma_frame_size` is the top-level frame's logical width and height in Figma px --
+the reference dimension every later normalization resolves against.
+`screenshot_scale` is the `scale` passed to `save_screenshots` for the reference PNGs.
+The last three come from Step 8.
 
 Body sections, in order:
 
@@ -264,17 +403,48 @@ One block per node, in tree order:
 - Reconciliation: center within the chrome-excluded region, not the screen.
   Follow lib/screens/wallet_screen.dart:88-104.
 - Box: absolute x 24 y 320 w 327 h 48; relative to Body content box x 24 y 264
+- Fit: width fill, height fixed 48
 - Layout: auto-layout HORIZONTAL, gap 8, padding 16/12/16/12,
   main axis CENTER, cross axis CENTER, sizing HUG x FIXED
 - Typography: Inter SemiBold 16/24, letter-spacing -0.2
+- Content: "Continue" -- i18n key `wallet.continue` (project uses ARB keys)
 - Fill: colors.surface (Figma surface/default #FFFFFF)
 - Stroke: 1 INSIDE, colors.border (Figma border/subtle #E5E7EB)
 - Radius: 12 12 12 12 -> radii.md
 - Effects: drop shadow 0 1 2 blur 3 rgba(0,0,0,0.05) -> shadows.sm
+- Route: /wallet, reached from HomeScreen's balance tile
 - Reference: .claude/plans/assets/<slug>/4029-12345.png
 ```
 
+Three of those lines are new and each closes a specific failure:
+
+- **`Fit:`** -- one entry per axis, `fill`, `hug`, or `fixed <N>`, derived from the
+  auto-layout sizing mode recorded in Step 4. **A `fill` axis must never be implemented
+  as the measured literal.** The 327 in the Box line is what that axis happened to
+  measure inside a 375px frame; writing it as a fixed width produces a component that is
+  wrong at every other width. Box carries the measurement, Fit carries the intent, and
+  Fit wins.
+- **`Content:`** -- the literal string for every text node, plus the i18n decision from
+  Step 6 item 7: the key name when the project has a translation layer, the inline
+  literal when it does not. Without this line the build invents copy.
+- **`Route:`** -- where the node is reachable in the running app, from Step 6 item 10.
+  `/design-verify` uses it to get the app onto the right screen before capturing. A node
+  with no reachable route (a pure leaf component) writes `Route: not independently
+  reachable` rather than omitting the line.
+
 Omit properties the node does not have. Never write a placeholder.
+
+### Assets
+Every file exported in Step 4 item 5, one row each:
+
+| Node | Node ID | Kind | Path |
+|------|---------|------|------|
+| `icon/chevron-right` | `4029:12501` | icon (svg) | `.claude/plans/assets/<slug>/4029-12501.svg` |
+| `hero-photo` | `4029:12610` | image (png @3) | `.claude/plans/assets/<slug>/4029-12610.png` |
+| `WalletCard` | `4029:12345` | reference (png @2) | `.claude/plans/assets/<slug>/4029-12345.png` |
+
+Every path in this table must exist on disk. An empty table means the design uses no
+icons or images -- write `No assets exported`, not an empty table.
 
 ### File Map
 - Create: `exact/path.ext` -- one-line purpose
@@ -287,20 +457,47 @@ Numbered. Each task names its files, its node IDs, and its acceptance criterion.
 ### Acceptance Criteria
 One criterion per task, plus one fidelity criterion per top-level node stated in measurable terms, for example: "the card's vertical center sits within 2px of the chrome-excluded region's center".
 
-## Step 9 -- Verify and Hand Off
+## Step 10 -- Verify, Review, and Hand Off
 
 1. Read the plan file back. Confirm it exists and that the Node Specs section carries real numbers.
 2. Confirm no raw `{...}` placeholder text survives anywhere in the file.
-3. Confirm every screenshot referenced under `screenshot_dir` exists on disk.
-4. Print: `> Design plan saved: .claude/plans/{filename} ({N} nodes, {M} tasks).`
+3. Confirm all five build-contract fields are present in frontmatter: `figma_frame_size`,
+   `screenshot_scale`, `commit_strategy`, `verify_gate`, `capture_preference`.
+4. Confirm every path in the `### Assets` table exists on disk.
+5. Print: `> Design plan saved: .claude/plans/{filename} ({N} nodes, {M} tasks).`
+
+Then dispatch the plan reviewer, once:
+
+```
+Agent(
+  subagent_type="quiver:plan-reviewer",
+  description="Review the design plan before handoff",
+  prompt="Review this implementation plan for logical coherence, dependency ordering,
+  coverage completeness, and alignment with its source spec.
+
+  Plan path: {plan path}
+  Source: a Figma extraction; the spec is the plan's own Node Specs section, which
+  carries the measured values every task must hit.
+
+  {full plan content}
+
+  Report FIX, ADD, and REORDER findings only. Do not rewrite the plan.",
+)
+```
+
+Wait for the agent. Do not poll and do not schedule a wakeup -- the harness notifies on
+completion. Apply its FIX, ADD, and REORDER findings inline, rewrite the plan file, and
+read it back once more. **One pass only.** Do not re-dispatch the reviewer against the
+revised plan.
 
 Then call `AskUserQuestion`:
 
 > Plan saved. What next?
 
-Buttons: `["Build it now -- run /design-build", "Review the plan first", "Stop here"]`
+Buttons: `["Build it now -- run /design-build", "Verify an existing build -- run /design-verify", "Review the plan first", "Stop here"]`
 
 - **Build it now:** invoke the `design-build` skill with the saved plan path.
+- **Verify an existing build:** invoke the `design-verify` skill with the saved plan path.
 - **Review the plan first:** print the plan body and stop.
 - **Stop here:** stop.
 
@@ -317,6 +514,11 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 - **Don't** silently write a raw color or dimension when no token matches. Ask.
 - **Don't** skip the anchor computation because the node "is obviously centered". Centered inside what is the whole question.
 - **Don't** invent a codebase precedent. If code-navigator found none, say none was found.
+- **Don't** write a `fill` axis as the literal measured width. The measurement is what that axis happened to be at one frame size; the fit is the intent.
+- **Don't** export an asset over an existing file. The bridge writes with flag `wx` and throws -- list the directory first.
+- **Don't** restate the plan frontmatter schema in another skill. Step 9's fence is the only declaration; consumers list the fields they read.
+- **Don't** compare a `VARIABLE_ALIAS` as if it were a value. Follow the alias chain to a literal first.
+- **Don't** dispatch a prompt containing `{true|false}`. `codegraph_available` and `lsp_available` are resolved to literals before Step 6 dispatches.
 
 ---
 
@@ -336,12 +538,19 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 4. With more than one file connected, Step 2 asks which file via `AskUserQuestion` and passes `fileKey` to every later call.
 5. A node ID passed as `4029-12345` is normalized to `4029:12345` before any tool call.
 6. With nothing selected and no ID argument, Step 3 prints the selection instruction and stops.
-7. Step 4 writes PNGs into `.claude/plans/assets/<slug>/` at scale 2.
-8. Step 5 emits an Anchor line for every node, and a Reconciliation line for every node whose anchor references excluded chrome.
-9. Step 6 dispatches exactly one `quiver:code-navigator` agent and waits without polling.
-10. Step 7 asks before writing any raw value, batching up to 4 unmapped variables per `AskUserQuestion` call.
-11. Step 8 writes the plan with `design_source`, `figma_file_key`, `figma_node_ids`, and `screenshot_dir` in frontmatter.
-12. Step 9 reads the plan back, verifies the screenshots exist, and offers the handoff via `AskUserQuestion`.
+7. Step 4 writes reference PNGs into `.claude/plans/assets/<slug>/` at scale 2, plus one file per icon and image leaf node (`.svg` for vectors, `.png` at scale 3 otherwise).
+8. Re-running `/design` against a node whose asset already exists does not throw -- the existing file is removed or the new name is suffixed.
+9. A `save_screenshots` sandbox rejection prints the reported sandbox root and writes there, recording it as `screenshot_dir`.
+10. Step 5 emits an Anchor line for every node, and a Reconciliation line for every node whose anchor references excluded chrome.
+11. Step 6 resolves `codegraph_available` from a Glob on `.codegraph/*` and dispatches exactly one `quiver:code-navigator` agent, with literals in the prompt, and waits without polling.
+12. Step 7 auto-maps every value-matched variable and asks exactly one approval question regardless of how many rows are unmapped.
+13. Step 7's table carries a `Mode` column with one row per mode for any multi-mode variable, and alias values are resolved before matching.
+14. Step 8 asks commit strategy, verification gate, and capture preference in one grouped `AskUserQuestion`.
+15. Step 9 finds an existing plan for the same slug, summarizes the differences, and asks before overwriting.
+16. Step 9 writes the plan with `design_source`, `figma_file_key`, `figma_node_ids`, `screenshot_dir`, `figma_frame_size`, `screenshot_scale`, `commit_strategy`, `verify_gate`, and `capture_preference` in frontmatter.
+17. Every applicable node spec carries `Fit:`, `Content:`, and `Route:` lines.
+18. The plan carries an `### Assets` section naming every exported file.
+19. Step 10 reads the plan back, verifies the assets exist, dispatches `quiver:plan-reviewer` exactly once, applies its findings, and offers the handoff via `AskUserQuestion`.
 
 **Verification checklist:**
 - [ ] `/design` and `/quiver:design` both appear in the slash menu after plugin reload.
@@ -349,7 +558,12 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 - [ ] No figma-bridge write tool is ever called.
 - [ ] The saved plan contains no raw `{...}` placeholder text.
 - [ ] Every node spec block carries literal numbers, not references to Figma.
-- [ ] Every screenshot named in the plan exists at that path.
+- [ ] Every path in the `### Assets` table exists on disk.
+- [ ] All five build-contract frontmatter fields are present: `figma_frame_size`, `screenshot_scale`, `commit_strategy`, `verify_gate`, `capture_preference`.
+- [ ] Thirty unmapped variables produce exactly one approval question.
+- [ ] No node spec writes a `fill` axis as a literal width.
+- [ ] The frontmatter fence appears in this file and in no other skill.
+- [ ] `quiver:plan-reviewer` runs once, before the handoff question, never after.
 - [ ] Unmapped Figma variables produce an `AskUserQuestion`, never a silent raw value.
 - [ ] Anchor lines name the excluded chrome and its measured size.
 - [ ] `when-to-use:` is a single-line double-quoted string.
@@ -364,3 +578,8 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 - Instance-child node IDs use the `I12740:17806;12740:17793` form. Passing only the leading segment returns the wrong node.
 - `.claude/plans/assets/` holds binary PNGs. If the project gitignores `.claude/`, the screenshots are local-only, which is intended.
 - The plugin must stay running in Figma for the whole extraction. Closing it mid-run drops the WebSocket and later calls fail.
+- `save_screenshots` writes with flag `wx`. It throws on an existing file rather than overwriting, which is why a second run against the same node fails unless the directory is listed first.
+- `save_screenshots` sandboxes `outputPath` to the MCP server's working directory, which is not always the project root. A rejection is a path problem, not a permissions problem.
+- `save_screenshots` infers the format from the `outputPath` extension. Passing a `format` that disagrees with the extension throws, and `scale` is ignored entirely for SVG and PDF.
+- `get_screenshot` returns base64 inside a JSON text blob rather than an inline image, so nothing in this skill can see it. Visual work goes through `save_screenshots` and a subsequent Read.
+- `get_variable_defs` returns `valuesByMode` keyed by `modeId`, and variable aliases stay unresolved as `{type: "VARIABLE_ALIAS", id}`. Both have to be walked client-side; neither arrives flattened.

--- a/skills/using-quiver/SKILL.md
+++ b/skills/using-quiver/SKILL.md
@@ -144,7 +144,7 @@ The canonical Quiver workflow chains these skills in order. Skip steps, reorder 
 
 If you hit a bug at any point, run `/hypothesis-debugging`.
 
-When the work starts from a Figma design rather than a written idea, `/design` replaces steps 1-2 and `/design-build` replaces step 3: `/design` extracts the selected nodes into a measurement plan, `/design-build` implements it and verifies the result against the design. Rejoin the chain at `/commit`.
+When the work starts from a Figma design rather than a written idea, `/design` replaces steps 1-2 and `/design-build` replaces step 3: `/design` extracts the selected nodes into a measurement plan, `/design-build` implements it, and `/design-verify` measures the result against the plan and writes a deviation report. `/design-build` calls `/design-verify` per task, and `/design-verify` also runs on its own against any measurement spec. Rejoin the chain at `/commit`.
 
 ---
 

--- a/skills/using-quiver/SKILL.md
+++ b/skills/using-quiver/SKILL.md
@@ -144,6 +144,8 @@ The canonical Quiver workflow chains these skills in order. Skip steps, reorder 
 
 If you hit a bug at any point, run `/hypothesis-debugging`.
 
+When the work starts from a Figma design rather than a written idea, `/design` replaces steps 1-2 and `/design-build` replaces step 3: `/design` extracts the selected nodes into a measurement plan, `/design-build` implements it and verifies the result against the design. Rejoin the chain at `/commit`.
+
 ---
 
 ## Test Plan

--- a/tests/skills/test-design-plan-contract.sh
+++ b/tests/skills/test-design-plan-contract.sh
@@ -1,0 +1,342 @@
+#!/bin/bash
+# test-design-plan-contract.sh
+# Guards the three-way design-plan frontmatter contract:
+#   producer  skills/design/SKILL.md        -- declares the schema, once
+#   consumer  skills/design-build/SKILL.md  -- reads a subset, with defaults
+#   consumer  skills/design-verify/SKILL.md -- reads a subset, with defaults
+#
+# Every contract in this repo that a consumer restated has drifted. This test fails
+# mechanically when a field moves, a fence is duplicated, or a default goes undocumented.
+#
+# Run directly: bash tests/skills/test-design-plan-contract.sh
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+TEST_DIR="/tmp/quiver-design-contract-test"
+EXIT=0
+
+DESIGN="$REPO_ROOT/skills/design/SKILL.md"
+BUILD="$REPO_ROOT/skills/design-build/SKILL.md"
+VERIFY="$REPO_ROOT/skills/design-verify/SKILL.md"
+
+# --- Helpers ---
+
+pass() { echo "  PASS: $1"; }
+fail() { echo "  FAIL: $1"; EXIT=1; }
+
+# assert_in <file> <pattern> <label>
+assert_in() {
+  if grep -q "$2" "$1"; then
+    pass "$3"
+  else
+    fail "$3"
+  fi
+}
+
+# assert_not_in <file> <pattern> <label>
+assert_not_in() {
+  if grep -q "$2" "$1"; then
+    fail "$3"
+  else
+    pass "$3"
+  fi
+}
+
+# --- Preflight: the three skill files exist ---
+
+echo "=== Preflight ==="
+for f in "$DESIGN" "$BUILD" "$VERIFY"; do
+  if [ -f "$f" ]; then
+    pass "exists: ${f#$REPO_ROOT/}"
+  else
+    fail "missing: ${f#$REPO_ROOT/}"
+  fi
+done
+
+if [ $EXIT -ne 0 ]; then
+  echo ""
+  echo "Skill files missing -- cannot check the contract."
+  exit $EXIT
+fi
+
+# --- Fixtures ---
+
+rm -rf "$TEST_DIR"
+mkdir -p "$TEST_DIR"
+
+# A plan carrying the full current frontmatter.
+cat > "$TEST_DIR/current-design-plan.md" << 'PLAN'
+---
+name: wallet-design-plan
+design_source: figma-bridge
+figma_file_key: abc123
+figma_file_name: Wallet
+figma_node_ids: ["4029:12345"]
+figma_frame_size: 375x812
+screenshot_dir: .claude/plans/assets/wallet/
+screenshot_scale: 2
+stack: Dart, Flutter 3.24
+commit_strategy: none
+verify_gate: test
+capture_preference: auto
+created: 2026-08-17
+---
+
+### Node Specs
+
+#### WalletCard (`4029:12345`)
+
+- Type: FRAME
+- Box: absolute x 24 y 320 w 327 h 48
+- Fit: width fill, height fixed 48
+- Content: "Continue" -- i18n key `wallet.continue`
+- Route: /wallet
+PLAN
+
+# A plan written before the fidelity fields existed (commit c514685 shape).
+cat > "$TEST_DIR/legacy-design-plan.md" << 'PLAN'
+---
+name: wallet-design-plan
+design_source: figma-bridge
+figma_file_key: abc123
+figma_file_name: Wallet
+figma_node_ids: ["4029:12345"]
+screenshot_dir: .claude/plans/assets/wallet/
+stack: Dart, Flutter 3.24
+created: 2026-08-16
+---
+
+### Node Specs
+
+#### WalletCard (`4029:12345`)
+
+- Type: FRAME
+- Box: absolute x 24 y 320 w 327 h 48
+PLAN
+
+# A hand-written measurement spec with no Figma provenance at all.
+cat > "$TEST_DIR/handwritten-spec.md" << 'PLAN'
+---
+name: handwritten-spec
+created: 2026-08-17
+---
+
+### Node Specs
+
+#### LoginButton (`manual-1`)
+
+- Type: BUTTON
+- Box: absolute x 16 y 600 w 343 h 52
+PLAN
+
+# A file that is not a measurement spec.
+cat > "$TEST_DIR/not-a-spec.md" << 'PLAN'
+---
+name: some-other-plan
+---
+
+## Steps
+- [ ] Step 1
+PLAN
+
+# --- Assertion 1: both consumers accept a current plan ---
+#
+# /design-build documents: design_source: figma-bridge AND a ### Node Specs section.
+# /design-verify documents: a ### Node Specs section, and nothing else.
+
+echo ""
+echo "=== 1. Current plan accepted by both consumers ==="
+
+CUR="$TEST_DIR/current-design-plan.md"
+
+if grep -q "^design_source: figma-bridge" "$CUR" && grep -q "^### Node Specs" "$CUR"; then
+  pass "current plan satisfies /design-build validation"
+else
+  fail "current plan satisfies /design-build validation"
+fi
+
+if grep -q "^### Node Specs" "$CUR"; then
+  pass "current plan satisfies /design-verify validation"
+else
+  fail "current plan satisfies /design-verify validation"
+fi
+
+# --- Assertion 2: the legacy plan is still accepted, and every absent field
+#     has a documented default in the skill that reads it ---
+
+echo ""
+echo "=== 2. Legacy plan accepted, absent-field defaults documented ==="
+
+LEG="$TEST_DIR/legacy-design-plan.md"
+
+if grep -q "^design_source: figma-bridge" "$LEG" && grep -q "^### Node Specs" "$LEG"; then
+  pass "legacy plan satisfies /design-build validation"
+else
+  fail "legacy plan satisfies /design-build validation"
+fi
+
+if grep -q "^### Node Specs" "$LEG"; then
+  pass "legacy plan satisfies /design-verify validation"
+else
+  fail "legacy plan satisfies /design-verify validation"
+fi
+
+# Every field a consumer reads must appear in that consumer's defaults table,
+# which is the row form: | `field` | ... | default |
+assert_in "$BUILD" '`commit_strategy` |' "/design-build documents a default for commit_strategy"
+assert_in "$BUILD" '`verify_gate` |' "/design-build documents a default for verify_gate"
+assert_in "$BUILD" '`screenshot_dir` |' "/design-build documents a default for screenshot_dir"
+
+assert_in "$VERIFY" '`figma_frame_size` |' "/design-verify documents a default for figma_frame_size"
+assert_in "$VERIFY" '`screenshot_scale` |' "/design-verify documents a default for screenshot_scale"
+assert_in "$VERIFY" '`screenshot_dir` |' "/design-verify documents a default for screenshot_dir"
+assert_in "$VERIFY" '`capture_preference` |' "/design-verify documents a default for capture_preference"
+
+# --- Assertion 2b: /design-verify validates on Node Specs only ---
+
+echo ""
+echo "=== 2b. /design-verify accepts a spec with no Figma provenance ==="
+
+HAND="$TEST_DIR/handwritten-spec.md"
+
+if grep -q "^### Node Specs" "$HAND"; then
+  pass "hand-written spec satisfies /design-verify validation"
+else
+  fail "hand-written spec satisfies /design-verify validation"
+fi
+
+if grep -q "^design_source:" "$HAND"; then
+  fail "hand-written spec has no design_source (fixture is wrong)"
+else
+  pass "hand-written spec has no design_source, and is still valid input"
+fi
+
+if grep -q "^### Node Specs" "$TEST_DIR/not-a-spec.md"; then
+  fail "a non-spec file is rejected"
+else
+  pass "a non-spec file is rejected"
+fi
+
+# --- Assertion 3: each new field is named in exactly the skills that own it,
+#     and the schema fence lives in the producer only ---
+
+echo ""
+echo "=== 3. Field ownership and single declaration point ==="
+
+# Producer declares all five.
+assert_in "$DESIGN" "figma_frame_size" "producer declares figma_frame_size"
+assert_in "$DESIGN" "screenshot_scale" "producer declares screenshot_scale"
+assert_in "$DESIGN" "commit_strategy" "producer declares commit_strategy"
+assert_in "$DESIGN" "verify_gate" "producer declares verify_gate"
+assert_in "$DESIGN" "capture_preference" "producer declares capture_preference"
+
+# /design-verify reads the capture-side fields and none of the commit-side ones.
+assert_in "$VERIFY" "figma_frame_size" "/design-verify reads figma_frame_size"
+assert_in "$VERIFY" "screenshot_scale" "/design-verify reads screenshot_scale"
+assert_in "$VERIFY" "capture_preference" "/design-verify reads capture_preference"
+assert_not_in "$VERIFY" "commit_strategy" "/design-verify does not read commit_strategy"
+assert_not_in "$VERIFY" "verify_gate" "/design-verify does not read verify_gate"
+
+# /design-build reads the commit-side fields and none of the capture-side ones.
+assert_in "$BUILD" "commit_strategy" "/design-build reads commit_strategy"
+assert_in "$BUILD" "verify_gate" "/design-build reads verify_gate"
+assert_not_in "$BUILD" "figma_frame_size" "/design-build does not read figma_frame_size"
+assert_not_in "$BUILD" "screenshot_scale" "/design-build does not read screenshot_scale"
+assert_not_in "$BUILD" "capture_preference" "/design-build does not read capture_preference"
+
+# The schema fence is declared once. figma_file_name: is unique to that fence.
+FENCE_HITS=$(grep -l "figma_file_name:" "$REPO_ROOT"/skills/*/SKILL.md 2>/dev/null | wc -l | tr -d ' ')
+if [ "$FENCE_HITS" = "1" ]; then
+  pass "the plan frontmatter fence appears in exactly one skill"
+else
+  fail "the plan frontmatter fence appears in $FENCE_HITS skills, expected 1"
+fi
+
+assert_in "$DESIGN" "figma_file_name:" "the one fence is in skills/design/SKILL.md"
+
+# --- Assertion 4: /design-verify is routable by the SessionStart hook ---
+
+echo ""
+echo "=== 4. /design-verify frontmatter routes ==="
+
+# The hook drops any skill whose when-to-use is not a single-line double-quoted string.
+# Replicate its extraction exactly.
+VERIFY_NAME=$(awk 'BEGIN{c=0} /^---/{c++;next} c==1 && /^name:/{gsub(/^name:[[:space:]]*/,""); print; exit}' "$VERIFY")
+VERIFY_WTU=$(awk 'BEGIN{c=0} /^---/{c++;next} c==1 && /^when-to-use:/{gsub(/^when-to-use:[[:space:]]*/,""); print; exit}' "$VERIFY" | tr -d '"<>')
+
+if [ "$VERIFY_NAME" = "design-verify" ]; then
+  pass "name: matches the directory"
+else
+  fail "name: matches the directory (got '$VERIFY_NAME')"
+fi
+
+if [ -n "$VERIFY_WTU" ]; then
+  pass "when-to-use: extracts non-empty via the hook's parser"
+else
+  fail "when-to-use: extracts non-empty via the hook's parser"
+fi
+
+# Single-line and double-quoted: the raw line must open and close with a quote.
+if grep -q '^when-to-use: ".*"$' "$VERIFY"; then
+  pass "when-to-use: is a single-line double-quoted string"
+else
+  fail "when-to-use: is a single-line double-quoted string"
+fi
+
+# End-to-end: the hook actually emits the route.
+HOOK="$REPO_ROOT/hooks/scripts/session-start-auto-dispatch.sh"
+if [ -x "$HOOK" ] || [ -f "$HOOK" ]; then
+  ROUTES=$(bash "$HOOK" 2>/dev/null)
+  if echo "$ROUTES" | grep -q "^/design-verify: "; then
+    pass "the SessionStart hook emits a /design-verify route"
+  else
+    fail "the SessionStart hook emits a /design-verify route"
+  fi
+else
+  fail "session-start-auto-dispatch.sh not found"
+fi
+
+# --- Assertion 5: R4 and R8 on the new skill, which nothing else checks ---
+
+echo ""
+echo "=== 5. Skill rules with no other automated check ==="
+
+# R4 -- no CLAUDE_PLUGIN_ROOT outside the verification checklist line that names it.
+PLUGIN_ROOT_HITS=$(grep -c "CLAUDE_PLUGIN_ROOT" "$VERIFY" || true)
+if [ "$PLUGIN_ROOT_HITS" -le 1 ]; then
+  pass "R4: no CLAUDE_PLUGIN_ROOT usage in design-verify"
+else
+  fail "R4: CLAUDE_PLUGIN_ROOT referenced $PLUGIN_ROOT_HITS times in design-verify"
+fi
+
+# R8 -- ASCII only, across all three skills.
+for f in "$DESIGN" "$BUILD" "$VERIFY"; do
+  if LC_ALL=C grep -q '[^ -~	]' "$f"; then
+    fail "R8: non-ASCII characters in ${f#$REPO_ROOT/}"
+  else
+    pass "R8: ASCII-only in ${f#$REPO_ROOT/}"
+  fi
+done
+
+# Every skill must carry a Test Plan -- the merge gate in CLAUDE.md.
+for f in "$DESIGN" "$BUILD" "$VERIFY"; do
+  if grep -q "^## Test Plan" "$f"; then
+    pass "Test Plan present in ${f#$REPO_ROOT/}"
+  else
+    fail "Test Plan missing in ${f#$REPO_ROOT/}"
+  fi
+done
+
+# --- Cleanup ---
+
+rm -rf "$TEST_DIR"
+
+echo ""
+echo "================================"
+if [ $EXIT -eq 0 ]; then
+  echo "All tests passed."
+else
+  echo "Some tests FAILED."
+fi
+exit $EXIT

--- a/tests/skills/test-design-plan-contract.sh
+++ b/tests/skills/test-design-plan-contract.sh
@@ -8,12 +8,15 @@
 # Every contract in this repo that a consumer restated has drifted. This test fails
 # mechanically when a field moves, a fence is duplicated, or a default goes undocumented.
 #
+# Every assertion reads a skill file. None writes a fixture and greps it with a rule
+# hardcoded here -- that form passes whatever the skills say, which is the opposite of a
+# drift guard.
+#
 # Run directly: bash tests/skills/test-design-plan-contract.sh
 
 set -u
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-TEST_DIR="/tmp/quiver-design-contract-test"
 EXIT=0
 
 DESIGN="$REPO_ROOT/skills/design/SKILL.md"
@@ -26,8 +29,9 @@ pass() { echo "  PASS: $1"; }
 fail() { echo "  FAIL: $1"; EXIT=1; }
 
 # assert_in <file> <pattern> <label>
+# The -- guards patterns that start with a dash, such as the --mode build flag.
 assert_in() {
-  if grep -q "$2" "$1"; then
+  if grep -q -- "$2" "$1"; then
     pass "$3"
   else
     fail "$3"
@@ -36,7 +40,7 @@ assert_in() {
 
 # assert_not_in <file> <pattern> <label>
 assert_not_in() {
-  if grep -q "$2" "$1"; then
+  if grep -q -- "$2" "$1"; then
     fail "$3"
   else
     pass "$3"
@@ -60,127 +64,29 @@ if [ $EXIT -ne 0 ]; then
   exit $EXIT
 fi
 
-# --- Fixtures ---
-
-rm -rf "$TEST_DIR"
-mkdir -p "$TEST_DIR"
-
-# A plan carrying the full current frontmatter.
-cat > "$TEST_DIR/current-design-plan.md" << 'PLAN'
----
-name: wallet-design-plan
-design_source: figma-bridge
-figma_file_key: abc123
-figma_file_name: Wallet
-figma_node_ids: ["4029:12345"]
-figma_frame_size: 375x812
-screenshot_dir: .claude/plans/assets/wallet/
-screenshot_scale: 2
-stack: Dart, Flutter 3.24
-commit_strategy: none
-verify_gate: test
-capture_preference: auto
-created: 2026-08-17
----
-
-### Node Specs
-
-#### WalletCard (`4029:12345`)
-
-- Type: FRAME
-- Box: absolute x 24 y 320 w 327 h 48
-- Fit: width fill, height fixed 48
-- Content: "Continue" -- i18n key `wallet.continue`
-- Route: /wallet
-PLAN
-
-# A plan written before the fidelity fields existed (commit c514685 shape).
-cat > "$TEST_DIR/legacy-design-plan.md" << 'PLAN'
----
-name: wallet-design-plan
-design_source: figma-bridge
-figma_file_key: abc123
-figma_file_name: Wallet
-figma_node_ids: ["4029:12345"]
-screenshot_dir: .claude/plans/assets/wallet/
-stack: Dart, Flutter 3.24
-created: 2026-08-16
----
-
-### Node Specs
-
-#### WalletCard (`4029:12345`)
-
-- Type: FRAME
-- Box: absolute x 24 y 320 w 327 h 48
-PLAN
-
-# A hand-written measurement spec with no Figma provenance at all.
-cat > "$TEST_DIR/handwritten-spec.md" << 'PLAN'
----
-name: handwritten-spec
-created: 2026-08-17
----
-
-### Node Specs
-
-#### LoginButton (`manual-1`)
-
-- Type: BUTTON
-- Box: absolute x 16 y 600 w 343 h 52
-PLAN
-
-# A file that is not a measurement spec.
-cat > "$TEST_DIR/not-a-spec.md" << 'PLAN'
----
-name: some-other-plan
----
-
-## Steps
-- [ ] Step 1
-PLAN
-
-# --- Assertion 1: both consumers accept a current plan ---
+# --- Assertion 1: each consumer's validation rule is declared where it is applied ---
 #
-# /design-build documents: design_source: figma-bridge AND a ### Node Specs section.
-# /design-verify documents: a ### Node Specs section, and nothing else.
+# These read the skill files. Writing a fixture here and grepping it with a rule this
+# test hardcodes proves only that grep works: the rule can change in the skill and the
+# fixture assertion still passes.
 
 echo ""
-echo "=== 1. Current plan accepted by both consumers ==="
+echo "=== 1. Consumer validation rules ==="
 
-CUR="$TEST_DIR/current-design-plan.md"
+assert_in "$BUILD" 'design_source: figma-bridge` in frontmatter and a `### Node Specs` section' \
+  "/design-build requires design_source and a Node Specs section"
+assert_in "$VERIFY" 'Validate on `### Node Specs` and nothing else' \
+  "/design-verify validates on the Node Specs section only"
+assert_in "$VERIFY" 'this skill never requires' \
+  "/design-verify states it never requires Figma provenance"
 
-if grep -q "^design_source: figma-bridge" "$CUR" && grep -q "^### Node Specs" "$CUR"; then
-  pass "current plan satisfies /design-build validation"
-else
-  fail "current plan satisfies /design-build validation"
-fi
-
-if grep -q "^### Node Specs" "$CUR"; then
-  pass "current plan satisfies /design-verify validation"
-else
-  fail "current plan satisfies /design-verify validation"
-fi
-
-# --- Assertion 2: the legacy plan is still accepted, and every absent field
-#     has a documented default in the skill that reads it ---
+# --- Assertion 2: every field a consumer reads has a documented default ---
+#
+# A plan written before a field existed still has to load. The default is what makes that
+# true, and it belongs in the skill that reads the field.
 
 echo ""
-echo "=== 2. Legacy plan accepted, absent-field defaults documented ==="
-
-LEG="$TEST_DIR/legacy-design-plan.md"
-
-if grep -q "^design_source: figma-bridge" "$LEG" && grep -q "^### Node Specs" "$LEG"; then
-  pass "legacy plan satisfies /design-build validation"
-else
-  fail "legacy plan satisfies /design-build validation"
-fi
-
-if grep -q "^### Node Specs" "$LEG"; then
-  pass "legacy plan satisfies /design-verify validation"
-else
-  fail "legacy plan satisfies /design-verify validation"
-fi
+echo "=== 2. Absent-field defaults documented ==="
 
 # Every field a consumer reads must appear in that consumer's defaults table,
 # which is the row form: | `field` | ... | default |
@@ -193,30 +99,35 @@ assert_in "$VERIFY" '`screenshot_scale` |' "/design-verify documents a default f
 assert_in "$VERIFY" '`screenshot_dir` |' "/design-verify documents a default for screenshot_dir"
 assert_in "$VERIFY" '`capture_preference` |' "/design-verify documents a default for capture_preference"
 
-# --- Assertion 2b: /design-verify validates on Node Specs only ---
+# --- Assertion 2b: the strings restated across the producer/consumer handshake ---
+#
+# These are the only strings in the contract written in one file and read in another.
+# Nothing else in the repo declares them, so a rename on either side is silent: every
+# build-loop verification degrades to the unverified branch while this suite still prints
+# "All tests passed". Frontmatter fields, by contrast, are each declared once.
 
 echo ""
-echo "=== 2b. /design-verify accepts a spec with no Figma provenance ==="
+echo "=== 2b. Restated handshake strings ==="
 
-HAND="$TEST_DIR/handwritten-spec.md"
+assert_in "$VERIFY" '<screenshot_dir>/verify/<task-id>.md' "/design-verify writes the agreed report path"
+assert_in "$BUILD"  '<screenshot_dir>/verify/<task-id>.md' "/design-build reads the agreed report path"
+assert_in "$VERIFY" '<screenshot_dir>/actual/<task-id>.png' "/design-verify names the agreed capture path"
 
-if grep -q "^### Node Specs" "$HAND"; then
-  pass "hand-written spec satisfies /design-verify validation"
-else
-  fail "hand-written spec satisfies /design-verify validation"
-fi
+# The build-mode invocation, flag by flag.
+assert_in "$BUILD"  '--nodes' "/design-build passes --nodes"
+assert_in "$VERIFY" '--nodes' "/design-verify accepts --nodes"
+assert_in "$BUILD"  '--task' "/design-build passes --task"
+assert_in "$VERIFY" '--task' "/design-verify accepts --task"
+assert_in "$BUILD"  '--mode build' "/design-build passes --mode build"
+assert_in "$VERIFY" '--mode build' "/design-verify accepts --mode build"
+assert_in "$VERIFY" '--mode standalone' "/design-verify accepts --mode standalone"
 
-if grep -q "^design_source:" "$HAND"; then
-  fail "hand-written spec has no design_source (fixture is wrong)"
-else
-  pass "hand-written spec has no design_source, and is still valid input"
-fi
-
-if grep -q "^### Node Specs" "$TEST_DIR/not-a-spec.md"; then
-  fail "a non-spec file is rejected"
-else
-  pass "a non-spec file is rejected"
-fi
+# Report frontmatter fields the build loop reads to tell "measured and matched" from
+# "never measured". Without these an empty deviation table reads as a pass.
+for field in comparison_path confidence created; do
+  assert_in "$VERIFY" "$field" "/design-verify writes $field into the deviation report"
+  assert_in "$BUILD"  "$field" "/design-build reads $field from the deviation report"
+done
 
 # --- Assertion 3: each new field is named in exactly the skills that own it,
 #     and the schema fence lives in the producer only ---
@@ -327,10 +238,6 @@ for f in "$DESIGN" "$BUILD" "$VERIFY"; do
     fail "Test Plan missing in ${f#$REPO_ROOT/}"
   fi
 done
-
-# --- Cleanup ---
-
-rm -rf "$TEST_DIR"
 
 echo ""
 echo "================================"


### PR DESCRIPTION
## Summary

Adds a three-stage path from a Figma frame to verified, pixel-accurate code. `/design` extracts a measurement plan, `/design-build` implements it, and `/design-verify` measures the result and writes a deviation report. Each stage is useful alone: `/design-verify` runs against any file with a `### Node Specs` section, including a hand-written spec, and needs no screenshot, no MCP server, and no installed comparison tool.

The first two skills landed in c514685. The four commits after it close the fidelity gaps that made the pipeline unreliable in practice -- three of the capture commands it recommended no longer work, and nothing in the plan carried the intent behind a measurement.

- **New:** `skills/design-verify/SKILL.md` -- capture, normalize, compare, write a deviation report
- **New:** `tests/skills/test-design-plan-contract.sh` -- fails mechanically when the three-way plan contract drifts
- **Modified:** `skills/design/SKILL.md` -- build preferences, fidelity fields, asset export, consolidated token mapping, plan review, overwrite guard
- **Modified:** `skills/design-build/SKILL.md` -- delegates verification, gates and commits from plan preferences
- **Modified:** `README.md`, `CLAUDE.md`, `skills/using-quiver/SKILL.md` -- pipeline docs and corrected inventories

### How it works

1. `/design` reads the selected Figma nodes and writes a self-contained plan. Beyond the measurements it already captured, each node spec now carries `Fit:` (per-axis fill/hug/fixed), `Content:` (the literal copy and its i18n decision), and `Route:` (where the node is reachable at runtime). The frontmatter carries the frame size, screenshot scale, and three build preferences asked once at plan time.
2. `/design-build` implements each task against that spec. It captures nothing and measures nothing.
3. Per task, `/design-build` invokes `/design-verify` with mode `build` and reads the report it writes to disk. The largest delta is fixed first, under the existing 3-attempt budget.
4. `/design-verify` resolves a capture, normalizes both images to a common logical width, compares them, and writes a fixed-shape report. Every path degrades rather than stopping.

### Design decisions

| Decision | Choice | Why |
|----------|--------|-----|
| How `/design-build` consumes verification | `/design-verify` writes a report to disk; `/design-build` reads the file | An in-loop, value-returning skill call has no precedent in this repo. A file drop matches the existing one-shot delegation shape and keeps the retry budget's state in one file instead of spanning two. |
| What `/design-verify` validates on | `### Node Specs` only, never `design_source` | A hand-written measurement spec is equivalent input to a Figma extraction. Requiring Figma provenance would make the skill useless without a prior `/design` run. |
| Where the plan schema is declared | The frontmatter fence in `skills/design/SKILL.md` only | Every contract in this repo that a consumer restated has drifted. Consumers list only the fields they read plus a default; the fixture test enforces both directions. |
| Comparison metric | Probe `magick -list metric` for `PDC`, fall back to `AE` only on older builds | ImageMagick 7.1.2-27 silently redefined `AE` from a differing-pixel count to a normalized error magnitude. Assuming either meaning returns a wrong number without failing. |
| Missing tooling | One install hint, then fall through to the next precedence level | Nothing here should block a run. The worst case is a spec-versus-code read marked low confidence, not a stop. |
| Default commit strategy | `none` | A plan written before the question existed never got the user's consent to commit. |

Three capture commands the previous version recommended were replaced: `idevicescreenshot` does not work on iOS 17+ (Apple moved the relay onto RemoteXPC over an RSD tunnel), the reference Puppeteer MCP server is archived, and the `xc-interact` MCP was a hard dependency for a job `xcrun simctl` does with no MCP at all.

## Test plan

- [ ] `bash tests/skills/test-design-plan-contract.sh` exits 0 (44 assertions)
- [ ] `bash tests/commands/test-work-plan-discovery.sh`, `tests/opencode/test-plugin-hooks.sh`, and `tests/opencode/test-using-quiver-bootstrap.sh` still exit 0
- [ ] All three design skills appear in the slash menu after a plugin reload
- [ ] `/design-verify` against a spec with no `design_source` produces a report
- [ ] `/design-verify` on a machine with no ImageMagick and no device tooling still writes a report
- [ ] `/design-build` on a plan carrying no `commit_strategy` writes no commit
- [ ] `/design-build` blocks a commit when `verify_gate` fails