### PR TITLE
Capture from a connected device before a simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Detailed docs: [`.opencode/README.md`](.opencode/README.md)
 | A Figma frame is ready to become code | `/design` | Reads the selected nodes through the figma-bridge MCP, maps Figma variables onto the project's own theme tokens, and writes a self-contained plan to `.claude/plans/` |
 | Want the frame built and measured without babysitting it | `/design --auto` | Same extraction and same questions, then straight through the build and the fidelity measurement with no further prompt |
 | Design plan is ready, want it built pixel-accurate | `/design-build` | Implements each node against its embedded spec, then fixes whatever `/design-verify` reports, under a bounded retry budget |
-| Built UI is on screen, want to know how far off it is | `/design-verify` | Captures the running app, normalizes both images to a common logical width, measures the deviations, and writes a report to disk |
+| Built UI is on screen, want to know how far off it is | `/design-verify` | Captures the running app on a connected phone when there is one and the simulator otherwise, normalizes both images to a common logical width, measures the deviations, and writes a report to disk |
 
 ```
 /design                    # extract whatever is selected in Figma
@@ -121,7 +121,7 @@ Detailed docs: [`.opencode/README.md`](.opencode/README.md)
 
 `--auto` removes the handoffs between the three stages, not the questions that decide what gets built.
 
-- `/design` still asks which file, which nodes, what an unmapped variable resolves to, how the build should commit and verify, and whether to overwrite a plan that already exists for the same screen.
+- `/design` still asks which file, which nodes, what an unmapped variable resolves to, how the build should commit and verify, and whether to overwrite a plan that already exists for the same screen. When a selection expands into many nodes and you described none of them, it also asks which of those nodes the build should implement.
 - Those questions all arrive in one call. After that the run stays quiet until the fidelity summary.
 - One node still gets three fix attempts. Auto mode records whatever deviation is left over and moves on rather than asking.
 
@@ -303,7 +303,21 @@ brew install imagemagick
 
 The skill probes `magick -version` and `magick -list metric`, picks the `PDC` metric when the build has it, and records which comparison path produced each report. Nothing breaks without it; the reports simply carry fewer numbers.
 
-Device capture is optional in the same way. `/design-verify` uses `xcrun simctl` for iOS simulators, `adb` for Android, `pymobiledevice3` for physical iOS devices, and the Playwright MCP for web -- whichever is already on the machine. Each absent tool prints one install hint and the run continues down to the next option.
+Device capture is optional in the same way. `/design-verify` uses a connected phone when one is attached and falls back to the simulator when there is not, because a phone renders the real safe-area insets and display scaling. Which tool takes the screenshot depends on the stack:
+
+| Target | Tool | Install |
+|--------|------|---------|
+| iOS simulator | `xcrun simctl` | ships with Xcode |
+| Android phone or emulator | `adb` | ships with the Android SDK |
+| Physical iOS device | `pymobiledevice3` | `pipx install pymobiledevice3` |
+| Flutter app anywhere it runs, phone included | `marionette` | `dart pub global activate marionette_cli`, plus `marionette_flutter` in the app |
+| Web | Playwright MCP | MCP config |
+
+marionette connects to the running app's Dart VM service instead of the device, which is how it screenshots a physical phone with no device tooling installed. The app has to be running in debug with `MarionetteBinding` initialized in `main.dart`.
+
+The skill probes for these before it picks a target. When nothing on the machine can screenshot the attached phone, it drops the phone from the order and uses the simulator, since building on a device you cannot photograph loses the measurement the step exists for. Each absent tool prints one install hint and the run continues to the next option.
+
+No MCP server screenshots a physical device. The xcodebuild-wrapping servers build, install, launch, and test on one, and their screenshot tools only cover the simulator, so every row above is a plain CLI command.
 
 ## CLI Notes
 

--- a/README.md
+++ b/README.md
@@ -309,15 +309,17 @@ Device capture is optional in the same way. `/design-verify` uses a connected ph
 |--------|------|---------|
 | iOS simulator | `xcrun simctl` | ships with Xcode |
 | Android phone or emulator | `adb` | ships with the Android SDK |
-| Physical iOS device | `pymobiledevice3` | `pipx install pymobiledevice3` |
+| Physical iOS device | `pymobiledevice3` | not suggested -- used only when it already resolves |
 | Flutter app anywhere it runs, phone included | `marionette` | `dart pub global activate marionette_cli`, plus `marionette_flutter` in the app |
 | Web | Playwright MCP | MCP config |
 
 marionette connects to the running app's Dart VM service instead of the device, which is how it screenshots a physical phone with no device tooling installed. The app has to be running in debug with `MarionetteBinding` initialized in `main.dart`.
 
-The skill probes for these before it picks a target. When nothing on the machine can screenshot the attached phone, it drops the phone from the order and uses the simulator, since building on a device you cannot photograph loses the measurement the step exists for. Each absent tool prints one install hint and the run continues to the next option.
+The skill probes for these before it picks a target. When nothing on the machine can screenshot the attached phone, it drops the phone from the order and uses the simulator, since building on a device you cannot photograph loses the measurement the step exists for. An absent tool prints one line and the run continues to the next option.
 
-No MCP server screenshots a physical device. The xcodebuild-wrapping servers build, install, launch, and test on one, and their screenshot tools only cover the simulator, so every row above is a plain CLI command.
+`pymobiledevice3` is the one row with no install hint. On iOS 17+ it needs a root tunnel daemon and a mounted Developer Disk Image, which is more than a screenshot is worth from a tool you did not pick, so the skill uses it when it is already on the machine and never suggests installing it. Apple ships no alternative -- `xcrun devicectl` has no screenshot subcommand -- so a non-Flutter iOS project without it captures the simulator.
+
+No iOS MCP server screenshots a physical device. The xcodebuild-wrapping servers build, install, launch, and test on one, and their screenshot tools only cover the simulator, so every native row above is a plain CLI command. Web is the exception: the browser is where the app runs, so that row goes through the Playwright MCP.
 
 ## CLI Notes
 

--- a/skills/design-build/SKILL.md
+++ b/skills/design-build/SKILL.md
@@ -128,13 +128,16 @@ Naming the command is the only record of what ran: an unattended run prints no p
 and for a stack the launch table does not name, the command is resolved out of the
 repository's own docs rather than from a fixed binary.
 
-**A Flutter session prints a VM service URI -- keep it.** `flutter run` writes a
-`ws://127.0.0.1:<port>/<token>/ws` URI to its output once the app is up, and that URI is
-what lets `/design-verify` capture through marionette. It is the difference between
+**A Flutter session prints a VM service URI -- keep it.** `flutter run` writes
+`A Dart VM Service on <device> is available at: http://127.0.0.1:<port>/<token>/` to its
+output once the app is up. That address is printed in its HTTP form and the capture step
+needs the WebSocket form, so convert it before passing it on: swap the `http` scheme for
+`ws` and append `ws`, giving `ws://127.0.0.1:<port>/<token>/ws`. That URI is what lets
+`/design-verify` capture the app it was launched on. It is the difference between
 measuring the app on the phone it was launched on and falling back to a simulator-only
 screenshot path. Read it out of the session's streamed output, hold it for the run, and
-pass it on every 3b invocation. Re-read it after a session restart: the port changes, and
-a stale URI fails to connect rather than reconnecting.
+pass it on every 3b invocation. Re-read it after a session restart: the port and the token
+are both regenerated, and a stale URI fails to connect rather than reconnecting.
 
 Start no session when no run target resolves, and none when the plan's
 `capture_preference` is `skip` or `manual`. `/design-verify` runs no build-and-launch on
@@ -209,9 +212,10 @@ This skill does not capture and does not compare. It delegates, then reads a fil
    ID, and mode `build`:
    `/design-verify <plan path> --nodes <this task's node IDs> --task <task id> --mode build`
 
-   Add `--vm-uri <uri>` when the run session holds one. Without it `/design-verify` looks
-   for a registered marionette instance and then gives up on that capture row, which on a
-   physical device means no capture at all.
+   Add `--vm-uri <uri>` when the run session holds one. Without it `/design-verify` has
+   to resolve the URI on its own, which only works when it ran the launch itself -- and
+   when this run owns the session, it did not. On a physical device that means no capture
+   at all.
 3. Re-read `<screenshot_dir>/verify/<task-id>.md`.
 
 **The report path is fixed per task, so the file's existence proves nothing on a re-run.**

--- a/skills/design-build/SKILL.md
+++ b/skills/design-build/SKILL.md
@@ -128,6 +128,14 @@ Naming the command is the only record of what ran: an unattended run prints no p
 and for a stack the launch table does not name, the command is resolved out of the
 repository's own docs rather than from a fixed binary.
 
+**A Flutter session prints a VM service URI -- keep it.** `flutter run` writes a
+`ws://127.0.0.1:<port>/<token>/ws` URI to its output once the app is up, and that URI is
+what lets `/design-verify` capture through marionette. It is the difference between
+measuring the app on the phone it was launched on and falling back to a simulator-only
+screenshot path. Read it out of the session's streamed output, hold it for the run, and
+pass it on every 3b invocation. Re-read it after a session restart: the port changes, and
+a stale URI fails to connect rather than reconnecting.
+
 Start no session when no run target resolves, and none when the plan's
 `capture_preference` is `skip` or `manual`. `/design-verify` runs no build-and-launch on
 those plans, so a session would have nothing to keep fresh. Print
@@ -200,6 +208,10 @@ This skill does not capture and does not compare. It delegates, then reads a fil
 2. Invoke the `design-verify` skill with the plan path, this task's node IDs, this task's
    ID, and mode `build`:
    `/design-verify <plan path> --nodes <this task's node IDs> --task <task id> --mode build`
+
+   Add `--vm-uri <uri>` when the run session holds one. Without it `/design-verify` looks
+   for a registered marionette instance and then gives up on that capture row, which on a
+   physical device means no capture at all.
 3. Re-read `<screenshot_dir>/verify/<task-id>.md`.
 
 **The report path is fixed per task, so the file's existence proves nothing on a re-run.**
@@ -425,6 +437,7 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 16c. Teardown runs on every exit path -- the last task, a stop, "Stop here", and a cancelled `AskUserQuestion`. A skipped task and a failed gate keep the session and the run moves to the next task. A simulator or dev server the user had open before the run is left running.
 16d. A failed run-session launch spends a session attempt rather than one from the task's 3c budget, and three failures stop session ownership for the rest of the run without stopping the run. Task 1 still enters 3a with a full 3-attempt budget after three failed launches.
 16e. With no session owned, each 3b invocation still verifies -- `/design-verify` rebuilds and relaunches under its own cap.
+16f. A Flutter run session's VM service URI is read from its output and forwarded on every 3b invocation as `--vm-uri`. After a session restart the URI is re-read, and a non-Flutter session forwards none.
 17. `--auto` is stripped before a plan path is resolved, and `/design-build --auto` with several plans on disk takes the most recent and names the count instead of asking.
 18. A full `/design --auto` run reaches no `AskUserQuestion` after `/design` Step 8, all the way to the Phase 4 summary.
 19. The auto handoff prints the `/review`, `/commit`, and `/create-pr` commands as text and invokes none of them.

--- a/skills/design-verify/SKILL.md
+++ b/skills/design-verify/SKILL.md
@@ -46,6 +46,7 @@ Parse `$ARGUMENTS`:
 | `--screenshot <path>` | a capture the user already has | none |
 | `--nodes <id,id>` | restrict verification to these node IDs | every node in the plan |
 | `--task <id>` | names the report file | the first node ID |
+| `--vm-uri <ws-uri>` | the Dart VM service URI a marionette capture attaches to | a registered marionette instance, else the row is skipped |
 | `--mode standalone` or `--mode build` | who is running this | `standalone` |
 
 **Mode arrives as an argument. Never detect the caller.** There is no inspection of the
@@ -89,6 +90,16 @@ missing, print:
 ```
 
 **Stop here.**
+
+### Nodes marked reference only are not verified
+
+A node spec carrying `Scope: reference only -- not built by this plan` was extracted for
+context, not built. Skip it and record it under the report's `## Notes` with that reason.
+Measuring it reports real deviations against code nobody wrote, and in a build loop those
+deviations enter a fix cycle that edits working parts of the screen.
+
+An explicit `--nodes` list wins: a node named on the command line is verified whatever its
+`Scope:` line says, because naming it is the stronger signal.
 
 ### Frontmatter fields this skill reads
 
@@ -154,6 +165,30 @@ Buttons: `["Verify against the spec by reading the code", "I'll supply a screens
 
 When mode is `build`, skip that question and fall through silently.
 
+### Probe the capture tooling once, before resolving the target
+
+The target order below drops a physical-device row when nothing can photograph that
+device, so what is installed has to be known before the target is chosen, not after a
+capture fails. Run these probes once per run, with the Bash tool. Skip the block entirely
+when `capture_preference` is `skip` -- that plan attempts no capture, so nothing it
+reports could change a decision:
+
+| Probe | Answers |
+|-------|---------|
+| `command -v marionette` | can a Flutter app be captured wherever it runs, physical device included |
+| `command -v pymobiledevice3` | can a physical iOS device be captured on a non-Flutter stack |
+| `magick -version` | will the comparison be measured or structural (Phase 5 re-reads this) |
+
+`command -v` rather than a version flag: the question is whether the binary resolves, and
+a wrong flag guess reports a present tool as missing.
+
+Print one line naming everything absent, then continue -- this block decides which rows
+are reachable, it never stops the run:
+
+```
+> Capture tooling: marionette missing, pymobiledevice3 missing, magick present.
+```
+
 ### Resolve the target once per run
 
 Resolve the target once, before the first capture, never per node. Detect the project
@@ -161,21 +196,51 @@ type from its manifest, then take the first live target in that type's order:
 
 | Manifest at the project root | Project type | Target order |
 |------------------------------|--------------|--------------|
-| `pubspec.yaml` | Flutter | the device named by `flutter devices --machine`, then that device's platform row below |
-| `*.xcodeproj`, `*.xcworkspace`, or `Package.swift` | iOS | iOS simulator, then physical iOS device |
-| `build.gradle` or `build.gradle.kts` declaring an Android plugin | Android | Android emulator or device |
+| `pubspec.yaml` | Flutter | wired physical device, then wireless physical device, then simulator or emulator |
+| `*.xcodeproj`, `*.xcworkspace`, or `Package.swift` | iOS | wired physical device, then wireless physical device, then iOS simulator |
+| `build.gradle` or `build.gradle.kts` declaring an Android plugin | Android | wired physical device, then wireless physical device, then Android emulator |
 | `package.json` naming `next`, `react`, `vue`, `svelte`, or `vite` | Web | Web |
+
+**A physical device outranks a simulator because it is the only target that renders what
+ships** -- real safe-area insets, real fonts, real display scaling. The simulator is the
+fallback, not the default.
+
+**A device row is only reachable when a capture path for it resolved** in the tooling
+probe above, and which tool that is depends on the stack:
+
+| Physical device | Captured by |
+|-----------------|-------------|
+| Android | `adb`, the same binary the emulator row uses -- nothing extra to install |
+| Flutter, any platform | `marionette`, or the platform's own tool below |
+| iOS, non-Flutter | `pymobiledevice3` only |
+
+With none of them present for the stack in hand, the device can still be built to and
+launched on, and nothing can photograph it -- so the device rows are dropped and the run
+continues at the simulator row. Building on a target that cannot be captured trades a
+measured comparison for a spec read, which is the opposite of why the device ranks first.
+
+**Wired before wireless.** Both answer the same probes and both capture through the same
+tooling; a wireless capture crosses the network for every frame and drops mid-run more
+often. Resolve the transport per platform:
+
+- **iOS:** `xcrun devicectl list devices --json-output <tmp-path>`, then read each
+  device's `connectionProperties.transportType` -- `wired` sorts before `localNetwork`.
+  The JSON file is devicectl's only supported interface for scripts; its stdout table is
+  documented as human-readable output and must not be parsed.
+- **Android:** `adb devices -l`. A serial shaped `host:port` is a wireless connection; a
+  bare serial is USB.
+- **Flutter:** `flutter devices --machine` names the target, then its platform's rule
+  above resolves the transport.
 
 Then resolve the tie:
 
 - **One live target:** use it.
-- **Several live** -- a booted simulator and an attached phone, or `flutter devices
-  --machine` returning more than one entry. In `standalone` mode ask with
-  `AskUserQuestion`, one button per live target. In `build` mode never ask: take the
-  first live target in the order above and name the choice in the report's
-  `capture_method`.
-- **No manifest matches:** walk the four command rows below top to bottom and take the
-  first target whose absence probe reports something live.
+- **Several live** -- two attached phones, or a phone and a booted simulator. In
+  `standalone` mode ask with `AskUserQuestion`, one button per live target. In `build`
+  mode never ask: take the first live target in the order above and name the choice in
+  the report's `capture_method`.
+- **No manifest matches:** walk the command rows below top to bottom and take the first
+  target whose absence probe reports something live.
 
 An Android capture compared against an iOS-frame export produces a deviation on every
 row, so the resolved target is recorded in the report rather than left implicit.
@@ -205,11 +270,25 @@ gets one targeted fix -- read the error, change one thing -- and one retry.
 
 | Target | Build-and-launch command |
 |--------|--------------------------|
-| Flutter | `flutter run -d <device-id>` |
-| iOS | `xcodebuild -scheme <scheme> -destination 'platform=iOS Simulator,name=<device>' build`, then `xcrun simctl install booted <app-path>` and `xcrun simctl launch booted <bundle-id>` |
-| Android | `./gradlew installDebug`, then `adb -s <SERIAL> shell am start -n <package>/<activity>` |
+| Flutter | `flutter run -d <device-id>` -- the same `<device-id>` the target resolution picked, physical device or simulator |
+| iOS simulator | `xcodebuild -scheme <scheme> -destination 'platform=iOS Simulator,name=<device>' build`, then `xcrun simctl install booted <app-path>` and `xcrun simctl launch booted <bundle-id>` |
+| iOS physical device | `xcodebuild -scheme <scheme> -destination 'id=<udid>' build`, then `xcrun devicectl device install app --device <udid> <app-path>` and `xcrun devicectl device process launch --device <udid> <bundle-id>` |
+| Android | `./gradlew installDebug`, then `adb -s <SERIAL> shell am start -n <package>/<activity>` -- `<SERIAL>` is the resolved target, device or emulator |
 | Web | the dev server script named in `package.json` -- `dev`, then `start` |
 | Any other stack | the run command the project itself documents -- a README quickstart, a `Makefile` target, a package-manager script. When none is discoverable, run no launch at all and continue on the spec read. |
+
+**The launch row and the capture row resolve to the same target.** They are two halves of
+one decision made once in the target resolution above, and splitting them is the failure
+this rule exists to prevent: launching a simulator build while capturing an attached
+phone photographs whatever that phone was already running, and every deviation afterwards
+describes a binary this run never wrote.
+
+**A device build that fails on code signing falls back to the simulator once.** Read the
+error: a signing, provisioning, or `no eligible devices` failure is a machine-setup
+problem no code fix reaches, so retrying it on the device spends the whole budget on the
+same wall. Re-resolve to the simulator row, print
+`> Device build failed on code signing -- falling back to the simulator.`, and continue.
+The fallback costs one attempt, and it happens once per run.
 
 The four named rows are the stacks with a standard command, not the stacks that are
 allowed. An unlisted one -- Kotlin/JVM, Go, a Makefile-driven build -- resolves through
@@ -239,12 +318,31 @@ Print the launch result once: `> Launch: {target}`, or
 
 | Target | Capture command | Absence probe |
 |--------|-----------------|---------------|
+| Flutter app on any target, physical device included | `marionette --uri <vm-service-uri> take-screenshots --output <path>` | `marionette --version`, then a `connect` that resolves a URI (see below) |
 | iOS simulator | `xcrun simctl io booted screenshot --type=png <path>` | `xcrun simctl list devices booted -j`, parse the JSON for a non-empty booted list |
 | Android emulator or device | `adb -s <SERIAL> exec-out screencap -p > <path>` | `adb devices -l`, parse the device lines |
 | Physical iOS device | `pymobiledevice3 developer dvt screenshot <path>`, or `pymobiledevice3 developer core-device screen-capture screenshot <path>` on iOS 17+ | `idevice_id -l`, parse the output for a UDID |
-| Flutter | resolve the run target from `flutter devices --machine`, then use that platform's row above | parse the JSON array's length, never the exit code |
+| Flutter without marionette | resolve the run target from `flutter devices --machine`, then use that platform's row above | parse the JSON array's length, never the exit code |
 | Web | Playwright MCP `browser_take_screenshot` with `filename`; add `element` and `target` for a clipped capture | `ToolSearch` for `browser_take_screenshot` |
-| iOS or Android via an xcbuild or marionette MCP (optional) | use the MCP's build-run and screenshot tools when the session exposes them; otherwise fall back to the CLI row for that target | `ToolSearch` for the MCP's build-run tool |
+
+### Resolving the VM service URI for marionette
+
+marionette attaches to the running app's Dart VM service rather than to the device, which
+is what makes it the one capture path that works on a physical phone without extra device
+tooling. It needs a `ws://.../ws` URI. Resolve it in this order and take the first that
+answers:
+
+1. **`--vm-uri <uri>`** on this skill's own invocation. `/design-build` owns the run
+   session, reads the URI out of its `flutter run` output, and forwards it here.
+2. **A registered marionette instance** -- `marionette doctor` lists the registered
+   instances and their connectivity. When exactly one is reachable, capture with
+   `marionette -i <instance> take-screenshots --output <path>`.
+3. **Neither** -- skip this row and fall to the next one. Do not prompt for a URI: a
+   missing URI is missing tooling, and missing tooling never stops this skill.
+
+With the marionette MCP loaded in the session, `connect` followed by `take_screenshots`
+is equivalent to the CLI row and may be used instead. The CLI is listed first because it
+needs no MCP server, which is the same reason every other row here is a CLI command.
 
 Notes that change what these commands mean:
 
@@ -256,8 +354,22 @@ Notes that change what these commands mean:
 - **Playwright, not Puppeteer.** The reference Puppeteer MCP server is archived. In the
   Playwright MCP the element parameter is `target` (renamed from `ref`), and `fullPage`
   cannot be combined with an element screenshot.
-- **No MCP server is required for any native target.** The simulator, emulator, and
-  physical-device paths are plain CLI commands run with the Bash tool.
+- **A marionette capture is the app's own view, not the device screen.** It photographs
+  the Flutter view, so the OS-drawn overlay -- status bar clock and battery, the home
+  indicator -- is absent from the image while every pixel the app itself drew is present.
+  Record it as `capture_surface: app-view` and read the two consequences in Phase 4.
+- **marionette needs the app prepared and running in debug.** The app must depend on
+  `marionette_flutter` and call `MarionetteBinding.ensureInitialized()`, and the VM
+  service only exists in debug or profile builds. A release build has no URI to connect
+  to. When `connect` fails, print the install hint once and fall to the next row.
+- **marionette downscales large screenshots by default**, to fit within 2000x2000
+  physical px. Phase 4 checks for it; the app-side fix is `maxScreenshotSize: null` in
+  `MarionetteConfiguration`.
+- **No MCP server is required for any target.** Every row above is a CLI command run with
+  the Bash tool. This is not a preference -- no iOS MCP captures from a physical device.
+  The xcodebuild-wrapping servers expose build, install, launch, and test for devices and
+  stop there, and their screenshot tools are simulator-only, so an MCP row here would
+  duplicate `simctl` under a second name and still leave the device uncovered.
 
 ### Exit codes lie here -- route on parsed output
 
@@ -287,6 +399,14 @@ the precedence ladder:
 > pymobiledevice3 not found -- install with: pipx install pymobiledevice3
 > Continuing without a device capture.
 ```
+
+The hint names the install command for the tool that was actually missing:
+
+| Tool | Install hint |
+|------|--------------|
+| `marionette` | `dart pub global activate marionette_cli` |
+| `pymobiledevice3` | `pipx install pymobiledevice3` |
+| `magick` | `brew install imagemagick` |
 
 Do not print an install hint more than once per run. Do not stop.
 
@@ -318,6 +438,14 @@ that looks like a right one.
   Its logical size is the node's `Box:` width and height.
 - **A device capture is the whole screen** at the device's pixel ratio. Its logical size
   is the frame, not the node.
+- **An app-view capture is the app's own surface** -- the same logical rect as the screen
+  for an app that draws edge to edge, so it normalizes exactly like a device capture. Two
+  things differ, and both belong in the report rather than in the arithmetic. A node whose
+  box overlaps a band the OS draws over the app -- the status bar, the home indicator --
+  is being compared against Figma pixels no app-view capture can contain, so record that
+  difference as a chrome artifact, not as design drift. And a capture measuring exactly
+  2000 physical px on either axis hit marionette's default downscale cap: mark the report
+  `confidence: low` and print the `maxScreenshotSize: null` hint once.
 
 Intermediates land beside the capture: `<screenshot_dir>/actual/<task-id>-ref.png`,
 `-norm.png`, and `-crop.png`.
@@ -495,7 +623,8 @@ Fixed report shape -- identical in both modes, so a human reading a standalone r
 plan: .claude/plans/2026-08-17-wallet-design-plan.md
 task_id: 3
 nodes: ["4029:12345"]
-capture_method: ios-simulator | android-adb | ios-device | web-playwright | supplied | none
+capture_method: ios-simulator | android-adb | ios-device | flutter-marionette | web-playwright | supplied | none
+capture_surface: device-screen | app-view | none
 comparison_path: imagemagick-pdc | imagemagick-ae | structural | spec-check
 confidence: high | low
 normalized: true | false
@@ -531,6 +660,9 @@ Rules for the report:
   `code` for a value read from the implementation. A row with no source is a guess.
 - **`diff_pixels` records the screening metric**, or `none` when no metric ran. It is
   never a `Measured` value.
+- **`capture_surface` records what the image is**, not which tool made it. A reader
+  comparing two runs needs to know whether the missing status bar was a design change or
+  the capture path changing under them, and `capture_method` alone does not say.
 - **`confidence: low`** whenever normalization was skipped, the comparison path is
   `spec-check` or `structural`, `figma_frame_size` was absent, or the two normalized
   sides did not end up the same size.
@@ -585,6 +717,15 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 - **Don't** capture from whichever target answers first when several are live. Resolve the
   target from the project manifest, then ask (standalone) or take the ordered first
   (build).
+- **Don't** build on one target and capture from another. One resolution, both halves.
+- **Don't** rank a physical device first when no tool can photograph it. Probe the capture
+  tooling before the target order is applied, not after a capture fails.
+- **Don't** retry a code-signing failure on the device. Fall back to the simulator once
+  and spend the remaining attempts on something a retry can change.
+- **Don't** prompt for a VM service URI. An unresolvable URI is missing tooling, and
+  missing tooling never interrupts this skill.
+- **Don't** add an MCP row for a physical-device capture. No iOS MCP has one -- the
+  xcodebuild-wrapping servers stop at build, install, launch, and test.
 - **Don't** treat `magick compare` exit code 1 as a failure. It means the images differ,
   which is the entire point of running it.
 - **Don't** use `-metric AE` without probing `magick -list metric` for `PDC` first. On
@@ -592,6 +733,7 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 - **Don't** route on exit status for any capture tool. 148, 255, and a successful 0 on an
   empty device list all mean something other than what they look like.
 - **Don't** detect which skill invoked this one. Mode is an argument.
+- **Don't** verify a node marked `Scope: reference only` unless `--nodes` names it.
 - **Don't** demand a screenshot. Every path degrades to a spec read.
 - **Don't** block on a missing tool. One install hint, then continue.
 - **Don't** put a capture probe inside a `` !`...` `` block. Non-git commands with `||`
@@ -615,6 +757,8 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 **Expected behavior:**
 1. Both shell blocks exit 0 in a git repo and in a non-git directory.
 2. A plan with `### Node Specs` but no `design_source` is accepted and verified.
+2b. A node carrying `Scope: reference only` is skipped and listed under `## Notes`, and is
+    verified anyway when `--nodes` names it explicitly.
 3. A file with no `### Node Specs` section is rejected with a message; nothing is written.
 4. A plan missing all five new frontmatter fields loads on the documented defaults.
 5. `--screenshot <path>` is used directly; no capture is attempted. It is used even when
@@ -636,9 +780,23 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
     continues on the spec read and the report records
     `capture_method: none -- launch failed after 3 attempts`.
 8d. With `capture_preference: skip`, no build-and-launch attempt runs at all.
-8e. With no xcbuild or marionette MCP in the session, the CLI row for the resolved target
-    is used and nothing reports a missing MCP as an error.
-9. An iOS simulator capture succeeds with no `xc-interact` MCP configured.
+8e. With no MCP server loaded at all, the CLI row for the resolved target is used and
+    nothing reports a missing MCP as an error.
+8f. The capture-tooling probe runs once, before the target is resolved, and prints one
+    line naming every absent tool with its install command.
+8g. With a physical device attached and neither `marionette` nor `pymobiledevice3`
+    installed, the device rows are dropped and the simulator row is used.
+8h. With two devices attached, one wired and one wireless, the wired one is resolved
+    first; the transport comes from `connectionProperties.transportType` in devicectl's
+    JSON output file, never from its stdout table.
+8i. A device build failing on code signing falls back to the simulator exactly once,
+    prints the fallback line, and spends one attempt doing it.
+8j. A Flutter app running on a physical device is captured through marionette when a URI
+    resolves from `--vm-uri` or a registered instance, and the report records
+    `capture_method: flutter-marionette` with `capture_surface: app-view`.
+8k. With `marionette` absent, a Flutter run falls to its platform's CLI row and prints the
+    `dart pub global activate marionette_cli` hint once.
+9. An iOS simulator capture succeeds with no MCP server configured.
 10. `xcrun simctl` exiting 148, `adb` exiting 255, and `flutter devices --machine`
     printing `[]` with exit 0 are all routed from parsed output, not exit status.
 11. `--mode standalone` makes the manual-screenshot offer once; `--mode build` never does.
@@ -671,7 +829,10 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 - [ ] The report is written in both modes and in every comparison path.
 - [ ] The build-and-launch attempt cap reads 3 and the degrade path continues without a
       capture rather than stopping.
-- [ ] The MCP capture row reads use-if-present with a named CLI fallback.
+- [ ] Every capture row is a CLI command; no row requires an MCP server.
+- [ ] The capture-tooling probe appears before the target resolution, not after it.
+- [ ] The launch table and the capture table resolve the same target.
+- [ ] `capture_surface` is written into every report's frontmatter.
 - [ ] `when-to-use:` is a single-line double-quoted string.
 - [ ] No `CLAUDE_PLUGIN_ROOT` reference anywhere in this file.
 - [ ] No Unicode characters or emoji in this file.
@@ -703,3 +864,19 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 - `flutter run` does not return while the app is alive. Waiting on it blocks the run;
   read its streamed output instead and treat the first `Error:` line as the attempt's
   failure.
+- `xcrun devicectl` prints a device table to stdout and documents that table as
+  human-readable output. `--json-output <path>` writing a file is the only interface it
+  supports for scripts, so a run that greps the table is reading something Apple does not
+  promise to keep stable.
+- `xcrun devicectl` has no screenshot subcommand, and neither does any MCP server built
+  on top of it. A physical device is the only target where build, install, and launch all
+  work while capture needs a separate tool.
+- marionette photographs the Flutter view, so a screenshot from it never contains the
+  status bar clock or the home indicator. Against a Figma frame that draws them, that band
+  reports a deviation on every run and no code change fixes it.
+- marionette silently downscales screenshots to fit 2000x2000 physical px. The image is
+  well-formed and the deviations it produces look like real drift, which is the same
+  failure mode as an unnormalized comparison.
+- marionette only works in debug and profile builds, because the VM service does not
+  exist in release. A release build produces no URI, and the failure reads as a
+  connection error rather than a mode error.

--- a/skills/design-verify/SKILL.md
+++ b/skills/design-verify/SKILL.md
@@ -177,6 +177,7 @@ reports could change a decision:
 |-------|---------|
 | `command -v marionette` | can a Flutter app be captured wherever it runs, physical device included |
 | `command -v pymobiledevice3` | can a physical iOS device be captured on a non-Flutter stack |
+| `command -v adb` | can an Android device or emulator be captured, and detected at all |
 | `magick -version` | will the comparison be measured or structural (Phase 5 re-reads this) |
 
 `command -v` rather than a version flag: the question is whether the binary resolves, and
@@ -311,17 +312,14 @@ below already follow. `flutter run` stays in the foreground until the app exits,
 in the background and read its output; a build error prints `Error:` lines and never
 returns an exit status you can wait on.
 
-Print the launch result once: `> Launch: {target}`, or
-`> Launch: failed after 3 attempts -- continuing on the spec read.`
-
 ### Per-target capture commands
 
 | Target | Capture command | Absence probe |
 |--------|-----------------|---------------|
-| Flutter app on any target, physical device included | `marionette --uri <vm-service-uri> take-screenshots --output <path>` | `marionette --version`, then a `connect` that resolves a URI (see below) |
+| Flutter app on any target, physical device included | `marionette --uri <vm-service-uri> take-screenshots --output <path>` | `command -v marionette` from the probe block, then a URI that resolves through the ladder below |
 | iOS simulator | `xcrun simctl io booted screenshot --type=png <path>` | `xcrun simctl list devices booted -j`, parse the JSON for a non-empty booted list |
 | Android emulator or device | `adb -s <SERIAL> exec-out screencap -p > <path>` | `adb devices -l`, parse the device lines |
-| Physical iOS device | `pymobiledevice3 developer dvt screenshot <path>`, or `pymobiledevice3 developer core-device screen-capture screenshot <path>` on iOS 17+ | `idevice_id -l`, parse the output for a UDID |
+| Physical iOS device | `pymobiledevice3 developer dvt screenshot <path>`, or `pymobiledevice3 developer core-device screen-capture screenshot <path>` on iOS 17+ | `pymobiledevice3 usbmux list`, parse the output for a UDID |
 | Flutter without marionette | resolve the run target from `flutter devices --machine`, then use that platform's row above | parse the JSON array's length, never the exit code |
 | Web | Playwright MCP `browser_take_screenshot` with `filename`; add `element` and `target` for a clipped capture | `ToolSearch` for `browser_take_screenshot` |
 
@@ -334,15 +332,25 @@ answers:
 
 1. **`--vm-uri <uri>`** on this skill's own invocation. `/design-build` owns the run
    session, reads the URI out of its `flutter run` output, and forwards it here.
-2. **A registered marionette instance** -- `marionette doctor` lists the registered
-   instances and their connectivity. When exactly one is reachable, capture with
-   `marionette -i <instance> take-screenshots --output <path>`.
-3. **Neither** -- skip this row and fall to the next one. Do not prompt for a URI: a
+2. **This run's own launch output.** When this skill ran the `flutter run` under "The app
+   must be running and fresh", the address is in the streamed output it is already reading
+   for `Error:` lines. `flutter run` prints it in its HTTP form --
+   `A Dart VM Service on <device> is available at: http://127.0.0.1:<port>/<token>/` --
+   so convert it: swap the `http` scheme for `ws` and append `ws`. Re-read it after any
+   relaunch; the port and the token are both regenerated.
+3. **A registered marionette instance** -- `marionette doctor` lists the registered
+   instances and their connectivity. When exactly one is reachable *and* it is the target
+   this run resolved, capture with
+   `marionette -i <instance> take-screenshots --output <path>`. An instance registered by
+   some other Flutter app on this machine is not this run's app; skip the row rather than
+   photograph the wrong one.
+4. **None of them** -- skip this row and fall to the next one. Do not prompt for a URI: a
    missing URI is missing tooling, and missing tooling never stops this skill.
 
 With the marionette MCP loaded in the session, `connect` followed by `take_screenshots`
 is equivalent to the CLI row and may be used instead. The CLI is listed first because it
-needs no MCP server, which is the same reason every other row here is a CLI command.
+needs no MCP server, which is the same reason every other native row here is a CLI
+command.
 
 Notes that change what these commands mean:
 
@@ -361,15 +369,18 @@ Notes that change what these commands mean:
 - **marionette needs the app prepared and running in debug.** The app must depend on
   `marionette_flutter` and call `MarionetteBinding.ensureInitialized()`, and the VM
   service only exists in debug or profile builds. A release build has no URI to connect
-  to. When `connect` fails, print the install hint once and fall to the next row.
+  to. When the capture fails to attach, print the install hint once and fall to the next
+  row.
 - **marionette downscales large screenshots by default**, to fit within 2000x2000
   physical px. Phase 4 checks for it; the app-side fix is `maxScreenshotSize: null` in
   `MarionetteConfiguration`.
-- **No MCP server is required for any target.** Every row above is a CLI command run with
-  the Bash tool. This is not a preference -- no iOS MCP captures from a physical device.
-  The xcodebuild-wrapping servers expose build, install, launch, and test for devices and
-  stop there, and their screenshot tools are simulator-only, so an MCP row here would
-  duplicate `simctl` under a second name and still leave the device uncovered.
+- **No MCP server is required for any native target.** Every native row above --
+  simulator, emulator, and physical device -- is a CLI command run with the Bash tool.
+  This is not a preference: no iOS MCP captures from a physical device. The
+  xcodebuild-wrapping servers expose build, install, launch, and test for devices and stop
+  there, and their screenshot tools are simulator-only, so an MCP row there would duplicate
+  `simctl` under a second name and still leave the device uncovered. Web is the one row
+  that goes through an MCP, because the browser is where the app runs.
 
 ### Exit codes lie here -- route on parsed output
 
@@ -392,11 +403,11 @@ each side independently.
 
 ### Missing tooling is informational, never terminal
 
-When a tool is absent, print exactly one line naming what to install, then continue down
+When a tool is absent, print exactly one line naming what is missing, then continue down
 the precedence ladder:
 
 ```
-> pymobiledevice3 not found -- install with: pipx install pymobiledevice3
+> marionette not found -- install with: dart pub global activate marionette_cli
 > Continuing without a device capture.
 ```
 
@@ -405,8 +416,21 @@ The hint names the install command for the tool that was actually missing:
 | Tool | Install hint |
 |------|--------------|
 | `marionette` | `dart pub global activate marionette_cli` |
-| `pymobiledevice3` | `pipx install pymobiledevice3` |
+| `adb` | ships with the Android SDK -- name the SDK, not a package |
 | `magick` | `brew install imagemagick` |
+| `pymobiledevice3` | none -- report the absence, see below |
+
+**`pymobiledevice3` is used when it resolves and never recommended.** Every other tool
+here installs with one command and needs no elevated privileges. That one does not: on
+iOS 17+ it also needs a root tunnel daemon (`sudo pymobiledevice3 remote tunneld`) and a
+mounted Developer Disk Image, which is a larger ask than one screenshot is worth from a
+tool the user did not choose. It stays in the capture table because a machine that already
+has it gets a real device capture out of it. When it is absent, report that and move on --
+no install command, no second line:
+
+```
+> pymobiledevice3 not found -- capturing the simulator instead.
+```
 
 Do not print an install hint more than once per run. Do not stop.
 
@@ -829,7 +853,7 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 - [ ] The report is written in both modes and in every comparison path.
 - [ ] The build-and-launch attempt cap reads 3 and the degrade path continues without a
       capture rather than stopping.
-- [ ] Every capture row is a CLI command; no row requires an MCP server.
+- [ ] Every native capture row is a CLI command; only Web requires an MCP server.
 - [ ] The capture-tooling probe appears before the target resolution, not after it.
 - [ ] The launch table and the capture table resolve the same target.
 - [ ] `capture_surface` is written into every report's frontmatter.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -375,6 +375,23 @@ Buttons: `["Update the existing plan", "Write a new plan file"]`
 Record as `plan_write: update` / `new`. This one is a routing answer, not plan
 frontmatter -- Step 9 consumes it and it is never written into the plan.
 
+**Question 5 -- Build scope.** Asked only when both of these hold: the extraction produced
+more than one node spec, and `$ARGUMENTS` describes nothing. Strip the flags and the node
+IDs from `$ARGUMENTS`; what remains is the description. When the user wrote what they
+wanted -- "this card on the settings screen", with or without a screenshot -- they already
+answered this, and asking again is the interruption Step 8 exists to avoid.
+
+> The selection expands to {N} node specs. Which of them should the build implement?
+
+Buttons: `["All {N} -- build the whole selection", "Only {top-level node name} -- keep the rest as reference"]`
+
+Record as `scope: all` / `selection`. This one is a routing answer, not plan frontmatter --
+Step 9 consumes it when it writes the `### Goal` line, the `Scope:` lines in the node
+specs, and the task list.
+
+Default it to `all` when the question was not asked. A described selection is a scoped
+selection, and Step 9 scopes it from the description rather than from a button.
+
 The three build preferences are distinct build paths, not shades of one: `skip` never attempts a capture
 at all and so never triggers a build-and-launch cycle, `manual` waits for a supplied
 path, `auto` attempts capture per task.
@@ -445,7 +462,9 @@ The last three come from Step 8.
 Body sections, in order:
 
 ### Goal
-One sentence: what screen or component gets built, and where it lives.
+One sentence: what screen or component gets built, and where it lives. When the scope is
+narrower than the extraction -- one component out of a whole page -- add a second
+sentence naming what is in scope and what the rest of the nodes are there for.
 
 ### Stack and Conventions
 From Step 6. Where components live, how styles attach, which token files apply.
@@ -498,6 +517,18 @@ Three of those lines are new and each closes a specific failure:
   with no reachable route (a pure leaf component) writes `Route: not independently
   reachable` rather than omitting the line.
 
+A node the build must not implement carries one more line:
+
+```
+- Scope: reference only -- not built by this plan
+```
+
+It exists because a page selection extracts every child, and a child nobody asked for is
+still context worth keeping: it carries the anchors and spacing its siblings are measured
+against. Without this line, `/design-build` implements it and `/design-verify` measures
+it, and the run reports real deviations on parts of the screen the user never asked to
+touch. The line is what makes "extracted" and "in scope" two different things.
+
 Omit properties the node does not have. Never write a placeholder.
 
 ### Assets
@@ -519,6 +550,12 @@ icons or images -- write `No assets exported`, not an empty table.
 
 ### Tasks
 Numbered. Each task names its files, its node IDs, and its acceptance criterion. Order: new tokens first, then leaf components, then composition, then the screen. Each task is 2-10 minutes and independently verifiable.
+
+**Only in-scope nodes get tasks.** A node carrying `Scope: reference only` appears in the
+node specs and in no task. The task list is what `/design-build` walks, so this is where
+the scope decision actually takes effect -- the `### Goal` sentence records it and the
+`Scope:` lines mark it, but a reference node with a task would be built regardless of
+both.
 
 ### Acceptance Criteria
 One criterion per task, plus one fidelity criterion per top-level node stated in measurable terms, for example: "the card's vertical center sits within 2px of the chrome-excluded region's center".
@@ -631,6 +668,8 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 12. Step 7 auto-maps every value-matched variable and asks exactly one approval question regardless of how many rows are unmapped.
 13. Step 7's table carries a `Mode` column with one row per mode for any multi-mode variable, and alias values are resolved before matching.
 14. Step 8 asks commit strategy, verification gate, and capture preference in one grouped `AskUserQuestion`.
+14b. Step 8 asks the scope question only when the extraction produced more than one node spec and `$ARGUMENTS` carries no description beyond flags and node IDs. A described selection reaches no scope question.
+14c. Answering "Only {node}" writes `Scope: reference only -- not built by this plan` on every other node spec, gives those nodes no task, and names the scope in the `### Goal` section. Answering "All" writes no `Scope:` line anywhere.
 15. Step 8 finds an existing plan for the same slug, summarizes the differences, and carries the overwrite question in that same call; Step 9 writes on that answer without asking again.
 16. Step 9 writes the plan with `design_source`, `figma_file_key`, `figma_node_ids`, `screenshot_dir`, `figma_frame_size`, `screenshot_scale`, `commit_strategy`, `verify_gate`, and `capture_preference` in frontmatter.
 17. Every applicable node spec carries `Fit:`, `Content:`, and `Route:` lines.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -375,19 +375,35 @@ Buttons: `["Update the existing plan", "Write a new plan file"]`
 Record as `plan_write: update` / `new`. This one is a routing answer, not plan
 frontmatter -- Step 9 consumes it and it is never written into the plan.
 
-**Question 5 -- Build scope.** Asked only when both of these hold: the extraction produced
-more than one node spec, and `$ARGUMENTS` describes nothing. Strip the flags and the node
-IDs from `$ARGUMENTS`; what remains is the description. When the user wrote what they
+**Question 5 -- Build scope.** Asked only when all four of these hold: Step 3 resolved
+exactly one top-level node, that node has more than one extracted child, `$ARGUMENTS`
+describes nothing, and the Glob above matched no existing plan. Strip the flags and the
+node IDs from `$ARGUMENTS`; what remains is the description. When the user wrote what they
 wanted -- "this card on the settings screen", with or without a screenshot -- they already
 answered this, and asking again is the interruption Step 8 exists to avoid.
 
-> The selection expands to {N} node specs. Which of them should the build implement?
+**Question 4 and Question 5 never share a call.** `AskUserQuestion` carries four questions
+and Questions 1 through 3 hold three of the slots, so an existing plan and an open scope
+decision cannot both be asked. The existing plan wins: a re-run inherits the scope its
+plan already recorded in the `### Goal` line, and asking again would let one button
+silently rescope a plan the user is updating.
 
-Buttons: `["All {N} -- build the whole selection", "Only {top-level node name} -- keep the rest as reference"]`
+> {top-level node name} expands to {N} node specs. Build the whole screen, or one
+> component out of it?
 
-Record as `scope: all` / `selection`. This one is a routing answer, not plan frontmatter --
-Step 9 consumes it when it writes the `### Goal` line, the `Scope:` lines in the node
-specs, and the task list.
+Buttons: `"The whole {top-level node name}"`, then one `"Only {child name}"` button per
+direct child of the top-level node. Four options is the ceiling, so carry the three
+largest children by node box and let the user name any other through the free-text option.
+
+Record as `scope: all`, or `scope: <chosen node id>`. This one is a routing answer, not
+plan frontmatter -- Step 9 consumes it when it writes the `### Goal` line, the `Scope:`
+lines in the node specs, and the task list.
+
+**The narrowing button names a child, never the top-level node.** The top-level node is
+the selection root and every other spec is its descendant, so scoping to it marks its own
+children as reference and leaves a task list that builds an empty frame. Scoping to a
+child is what the question is for: it keeps that child's subtree and turns its siblings
+into reference.
 
 Default it to `all` when the question was not asked. A described selection is a scoped
 selection, and Step 9 scopes it from the description rather than from a button.
@@ -668,8 +684,8 @@ Follow all rules in `.claude/rules/skill-rules.md`. Additionally:
 12. Step 7 auto-maps every value-matched variable and asks exactly one approval question regardless of how many rows are unmapped.
 13. Step 7's table carries a `Mode` column with one row per mode for any multi-mode variable, and alias values are resolved before matching.
 14. Step 8 asks commit strategy, verification gate, and capture preference in one grouped `AskUserQuestion`.
-14b. Step 8 asks the scope question only when the extraction produced more than one node spec and `$ARGUMENTS` carries no description beyond flags and node IDs. A described selection reaches no scope question.
-14c. Answering "Only {node}" writes `Scope: reference only -- not built by this plan` on every other node spec, gives those nodes no task, and names the scope in the `### Goal` section. Answering "All" writes no `Scope:` line anywhere.
+14b. Step 8 asks the scope question only when Step 3 resolved exactly one top-level node with more than one extracted child, `$ARGUMENTS` carries no description beyond flags and node IDs, and no existing plan matched the slug. A described selection reaches no scope question, and Question 4 and Question 5 never appear in the same call -- the call carries four questions at most.
+14c. Answering "Only {child}" writes `Scope: reference only -- not built by this plan` on every node spec outside the chosen child's subtree, gives those nodes no task, and names the scope in the `### Goal` section. The chosen child and its own descendants stay in scope. Answering "The whole {node}" writes no `Scope:` line anywhere.
 15. Step 8 finds an existing plan for the same slug, summarizes the differences, and carries the overwrite question in that same call; Step 9 writes on that answer without asking again.
 16. Step 9 writes the plan with `design_source`, `figma_file_key`, `figma_node_ids`, `screenshot_dir`, `figma_frame_size`, `screenshot_scale`, `commit_strategy`, `verify_gate`, and `capture_preference` in frontmatter.
 17. Every applicable node spec carries `Fit:`, `Content:`, and `Route:` lines.

--- a/tests/skills/test-design-launch-contract.sh
+++ b/tests/skills/test-design-launch-contract.sh
@@ -60,7 +60,7 @@ echo "=== 2. Every capture path is a CLI command, and the device rows are gated 
 # No MCP server captures a physical iOS device -- the xcodebuild-wrapping ones stop at
 # build, install, launch, and test. A capture row that needs an MCP is therefore a row
 # that silently drops to a spec read on the one target the device order exists to reach.
-assert_in "$VERIFY" 'No MCP server is required for any target' "capture rows need no MCP server"
+assert_in "$VERIFY" 'No MCP server is required for any native target' "native capture rows need no MCP server"
 assert_in "$VERIFY" 'marionette --uri' "the Flutter device capture row names its CLI"
 assert_in "$VERIFY" 'pymobiledevice3 developer' "the physical iOS capture row names its CLI"
 

--- a/tests/skills/test-design-launch-contract.sh
+++ b/tests/skills/test-design-launch-contract.sh
@@ -55,10 +55,26 @@ assert_in "$BUILD" '| Any other target |' "the refresh table has a fallback row"
 assert_in "$BUILD" 'is not an error' "an unnamed stack is stated to be no error"
 
 echo ""
-echo "=== 2. The optional MCP capture row keeps a CLI fallback ==="
+echo "=== 2. Every capture path is a CLI command, and the device rows are gated on one ==="
 
-assert_in "$VERIFY" 'xcbuild or marionette MCP (optional)' "the MCP capture row is marked optional"
-assert_in "$VERIFY" 'otherwise fall back to the CLI row' "the MCP row names its CLI fallback"
+# No MCP server captures a physical iOS device -- the xcodebuild-wrapping ones stop at
+# build, install, launch, and test. A capture row that needs an MCP is therefore a row
+# that silently drops to a spec read on the one target the device order exists to reach.
+assert_in "$VERIFY" 'No MCP server is required for any target' "capture rows need no MCP server"
+assert_in "$VERIFY" 'marionette --uri' "the Flutter device capture row names its CLI"
+assert_in "$VERIFY" 'pymobiledevice3 developer' "the physical iOS capture row names its CLI"
+
+# The probe has to run before the target order is applied. Ranking a device first and
+# discovering afterwards that nothing can photograph it trades a measured comparison for
+# a spec read on exactly the target that was chosen for being most accurate.
+assert_in "$VERIFY" '^### Probe the capture tooling once, before resolving the target$' "the tooling probe has its own step"
+assert_in "$VERIFY" 'A device row is only reachable when a capture path for it resolved' "device rows are gated on a resolved capture path"
+
+# Launch and capture are two halves of one resolution. Split, the run photographs a
+# binary it never built.
+assert_in "$VERIFY" 'The launch row and the capture row resolve to the same target' "launch and capture share one target"
+assert_in "$VERIFY" '| iOS physical device |' "the launch table has a physical device row"
+assert_in "$VERIFY" 'falls back to the simulator once' "a signing failure falls back once"
 
 echo ""
 echo "=== 3. /design-build owns the run session ==="


### PR DESCRIPTION
## What

`/design-verify` ranked the iOS simulator ahead of a physical device and had no way to photograph a device on any stack but Flutter. A run with a phone attached silently measured whatever the simulator was showing, and the deviations it reported described a binary that run never built.

## Changes

**Target resolution**
- Probe the capture tooling once, before the target order is applied. A device row is only reachable when something on the machine can screenshot that device: `adb` on Android, `marionette` on Flutter, `pymobiledevice3` on iOS otherwise.
- Every stack now orders wired device, wireless device, then simulator. iOS transport comes from `devicectl --json-output` (its stdout table is documented as human-readable only); Android from the serial shape.

**Physical device support**
- Added the `devicectl` build-install-launch row, and the rule that the launch row and the capture row resolve to one target.
- A code-signing failure falls back to the simulator once instead of spending three attempts on a machine-setup problem.

**marionette**
- Added as a capture path. It attaches to the running Flutter app's Dart VM service rather than to the device, which is how it screenshots a physical phone with no device tooling installed.
- `/design-build` reads the VM service URI out of its own run session and forwards it as `--vm-uri`.
- The report records `capture_surface`. A marionette capture omits the OS-drawn chrome, so a deviation confined to that band is a chrome artifact; a capture that hit marionette's 2000px downscale cap is marked low confidence.

**Removed**
- The optional xcbuild MCP capture row. No iOS MCP captures a physical device: the xcodebuild-wrapping servers stop at build, install, launch, and test, and their screenshot tools only cover the simulator. On the simulator the row duplicated `simctl` under a second name.

**Scope**
- `/design` asks which nodes are in scope when a selection expands to more than one node spec and the invocation described none of them. Out-of-scope nodes keep their specs as context, get no task, and are not verified, so a page selection no longer reports deviations on parts of the screen nobody asked to touch.

## Verification

`bash tests/run-all.sh` -- 10 test files, 22 assertions, all passing. `tests/skills/test-design-launch-contract.sh` section 2 was rewritten: it asserted the old MCP row was optional with a CLI fallback, and now asserts that every capture path is a CLI command, the probe runs before target resolution, and launch and capture share one target.