### PR TITLE
feat(work): give parallel orchestration a durable on-disk ledger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ marketing/
 .claude/reviews/
 .claude/plans/
 .claude/commands/
+.claude/work/
 
 # Claude Code Plugin files
 docs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Dependencies: `bash`, `claude` CLI.
 - **`agents/`** — 20 agent definitions organized by category (`review/`, `research/`, `debug/`). Agents are persona prompts spawned as subagents.
 - **`hooks/`** — `hooks.json` registers event hooks; `scripts/` holds implementations. Three hooks: PreToolUse (matcher `Bash`, classifies a command as deny/ask/silence before it runs), PreCompact (fires before context compaction, saves a handover) and SessionStart (emits the skill routing block from every skill's `when-to-use`).
 - **`install.sh`** — Repo-root install script for the runtimes with no plugin manager. Its install targets are a six-column TSV heredoc inside `targets()`; adding a runtime is one row and no other line. It symlinks into the user's clone (so `git pull` is the update mechanism) and never removes or overwrites a path that is not a symlink resolving into the repo. It must stay at the repo root -- `.gitignore` drops `/scripts/`.
-- **Storage** — Handover files are written to `<project>/.claude/handovers/`.
+- **Storage** — Handover files are written to `<project>/.claude/handovers/`. The orchestration workspace -- the ledger, task briefs, and task reports written by `skills/work/orchestrator.md` -- is written to `<project>/.claude/work/<plan-basename>/`.
 - **Rules** — `.claude/rules/` contains `skill-rules.md` (hard rules and learned lessons for skills, formerly `command-rules.md`), `review-agent-rules.md`, `cli-overlay-rules.md`, `agent-capability-rules.md`, and `readme-structure.md`.
 - **External MCP** — Context7 MCP server (`plugin.json` > `mcpServers`) provides real-time library documentation lookups for review agents.
 

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -148,18 +148,21 @@ Any path that reaches Phase 2.5 without a plan file has no plan basename -- Phas
 
 #### Check for a ledger
 
-Read `.claude/work/<plan-basename>/progress.md`. Its first line is the identity line, exactly one:
+Read `.claude/work/<plan-basename>/progress.md`. Its first two lines are the identity header:
 
 ```
 # work ledger -- plan: <full plan file path>
+# run: <ISO-8601 start timestamp>
 ```
+
+The `run:` line names the run that owns the workspace, and Phase 5c-bis checks it before deleting anything -- the plan path alone cannot separate this run from another session working the same plan.
 
 Apply these rules, which restate `skills/work/orchestrator.md` Section 0:
 
 | State | Action |
 |-------|--------|
-| No file, or a file whose first line is not a `# work ledger -- plan:` identity line | Fresh run. Create the directory if needed, overwrite the file with the identity line. Do not suffix -- a directory with no identity claims no plan. |
-| First line names this plan file, and every completion line's task number and title match the plan | Resumable. Do not re-dispatch any task carrying a `Task <N> [<task title>]: complete (branch <branch>, commits <base7>..<head7>)` line. Merge a completed task's branch unless a `Task <N>: merged` line also exists for it -- a `complete` line records that the work was done, not that it landed. A complete line reading `commits none` has no branch to merge. Resume dispatch at the first task with no matching `complete` line. |
+| No file, or a file whose first two lines are not a `# work ledger -- plan:` line followed by a `# run:` line | Fresh run. Create the directory if needed, overwrite the file with the identity header. Do not suffix -- a directory with no identity claims no plan. |
+| First line names this plan file, and every completion line's task number and title match the plan | Resumable. Do not re-dispatch any task carrying a `Task <N> [<task title>]: complete (branch <branch>, commits <base7>..<head7>)` line. Merge a completed task's branch unless a `Task <N>: merged` line also exists for it -- a `complete` line records that the work was done, not that it landed. A complete line reading `commits none` has no branch to merge. Resume dispatch at the first task with no matching `complete` line. Overwrite the `# run:` line with this run's start timestamp and read it back -- the workspace now belongs to this run. |
 
 For a ledger naming a different plan file, or a completion line whose title no longer matches the plan, `skills/work/orchestrator.md` Section 0 "Resume rules" is authoritative -- follow it there and print the line it requires.
 
@@ -288,7 +291,7 @@ status: active  -->  status: completed
 
 Runs only when orchestration was used, every task reached DONE, and Phase 4a check 7 passed. A run that ends blocked, failed, or cancelled skips this step entirely -- the surviving directory is what makes the retry cheap, and deleting it throws away the resume.
 
-1. Resolve `<workspace-dir>` to the directory this run actually used -- the suffixed one (`-2`, `-3`) if the orchestrator's suffix-retry rule fired, otherwise `.claude/work/<plan-basename>/`. Confirm `<workspace-dir>` exists and that its `progress.md` first line names this plan file. If either check fails, delete nothing and say so -- the directory belongs to a different run. Never re-derive the path from `<plan-basename>` after this step.
+1. Resolve `<workspace-dir>` to the directory this run actually used -- the suffixed one (`-2`, `-3`) if the orchestrator's suffix-retry rule fired, otherwise `.claude/work/<plan-basename>/`. Confirm `<workspace-dir>` exists, that its `progress.md` first line names this plan file, and that its `# run:` line is this run's start timestamp. If any check fails, delete nothing and say so -- the directory belongs to a different run, and a `run:` line naming another run means a concurrent session owns it. Never re-derive the path from `<plan-basename>` after this step.
 2. Name `<workspace-dir>` and its file count, then gate the delete on `AskUserQuestion`:
    > Orchestration finished and the work is committed. Delete the run workspace at `<workspace-dir>` ({N} files)?
    Buttons: `["Delete it", "Keep it"]`

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -127,7 +127,7 @@ If the plan contains genuine contradictions (e.g., two steps that conflict, a re
 Buttons: `["Continue on {branch}", "Create new branch"]`
 If continuing, move to Phase 2.5.
 
-**If on the default branch**, create a new branch by default: `git checkout -b <meaningful-name>` using a descriptive name (e.g., `feat/user-auth`, `fix/email-validation`). For parallel development, use the `using-git-worktrees` skill. Never commit to the default branch without explicit user confirmation.
+**If on the default branch**, create a new branch by default: `git checkout -b <meaningful-name>` using a descriptive name (e.g., `feat/user-auth`, `fix/email-validation`). Never commit to the default branch without explicit user confirmation.
 
 ### Phase 2.5: Orchestration Decision
 
@@ -137,8 +137,42 @@ Strategy: {sequential | parallel orchestration} ({N} tasks found)
 Reason: {why}
 ```
 
-- **1-2 tasks:** Sequential. Proceed to Phase 3.
-- **3+ tasks:** Parallel orchestration. Follow `skills/work/orchestrator.md`. Skip Phase 3 entirely -- orchestration replaces it.
+- **1-2 tasks:** Sequential. Proceed to Phase 3. The ledger below is orchestration-path-only; the sequential path keeps TodoWrite unchanged and writes nothing to disk.
+- **3+ tasks:** Parallel orchestration. Resolve the workspace and check for a ledger (below), then follow `skills/work/orchestrator.md`. Skip Phase 3 entirely -- orchestration replaces it.
+
+#### Resolve the workspace
+
+`<plan-basename>` is the loaded plan file's name without `.md`. The workspace is `.claude/work/<plan-basename>/` and the ledger is `.claude/work/<plan-basename>/progress.md`.
+
+Any path that reaches Phase 2.5 without a plan file has no basename and therefore no ledger -- Phase 1 Case B's "Other -- I'll provide a path or description" and Case C with 0 matches both do. Proceed to the orchestrator without one and say so in the strategy line.
+
+#### Check for a ledger
+
+Read `.claude/work/<plan-basename>/progress.md`. Its first line is the identity line, exactly one:
+
+```
+# work ledger -- plan: <full plan file path>
+```
+
+Apply these rules, which restate `skills/work/orchestrator.md` Section 0:
+
+| State | Action |
+|-------|--------|
+| No file | Fresh run. Create the directory, write the identity line. |
+| First line names this plan file, and every completion line's task number and title match the plan | Resumable. Skip every task carrying a `Task <N> [<task title>]: complete (branch <branch>, commits <base7>..<head7>)` line -- do not re-dispatch it and do not re-merge its branch. Resume at the first task with no matching `complete` line. |
+| First line names a different plan file | Leave that directory untouched. Retry at `.claude/work/<plan-basename>-2/`, then `-3`, and so on, until a directory is found that either does not exist or whose identity line names this plan file. Use that one for the whole run. Print one line naming the directory actually used and why. |
+| First line matches this plan file, but a completion line's task title does not match the plan's task at that number | The plan changed mid-run. Warn the user, treat the ledger as stale, and start fresh in the same directory. |
+
+#### Announce
+
+When tasks are skipped:
+> Resuming from ledger: skipping Task 1, Task 2 (already complete).
+
+When the ledger is stale:
+> Plan changed since the last run -- starting fresh.
+
+When a suffixed workspace is used:
+> A ledger for a different plan already uses that name -- using .claude/work/<name>-2/.
 
 ### Phase 3: Build
 
@@ -250,6 +284,17 @@ If the work document has YAML frontmatter with a `status` field, update it:
 status: active  -->  status: completed
 ```
 
+#### 5c-bis -- Clean up the orchestration workspace
+
+Runs only when orchestration was used, every task reached DONE, and Phase 4a check 7 passed. A run that ends blocked, failed, or cancelled skips this step entirely -- the surviving directory is what makes the retry cheap, and deleting it throws away the resume.
+
+1. Confirm the workspace directory used by this run exists and that its `progress.md` first line names this plan file. If either check fails, delete nothing and say so -- the directory belongs to a different run.
+2. Name the directory and its file count, then gate the delete on `AskUserQuestion`:
+   > Orchestration finished and the work is committed. Delete the run workspace at `.claude/work/<plan-basename>/` ({N} files)?
+   Buttons: `["Delete it", "Keep it"]`
+   On "Keep it", print one line saying it was kept and continue to 5d.
+3. On "Delete it", remove the directory, then re-list `.claude/work/` to confirm it is gone, and name what was deleted in the 5d summary.
+
 #### 5d -- Notify user
 
 Summarize:
@@ -293,6 +338,7 @@ Summarize:
 4. Phase 2.5 announces the strategy (sequential or parallel) and task count before continuing.
 5. For review-fix plans, Phase 4c parses findings, applies BLOCKING/WARNING gates, and prints the convergence verdict; Phase 4d is skipped automatically.
 6. Phase 5 delegates to `/quiver:commit` and `/quiver:create-pr`, gating each action with `AskUserQuestion`.
+7. A 3+ task plan creates `.claude/work/<plan-basename>/progress.md` with the identity line before the first group dispatches; a successful run through Phase 5 offers to delete it.
 
 **Verification checklist:**
 - [ ] Slash menu shows `/work`; plan banner printed before code changes.
@@ -300,8 +346,13 @@ Summarize:
 - [ ] Non-git directory: plan loads and Phases 3-4 run; Phase 5 exits without commit/PR.
 - [ ] Review-fix plans: verification table and convergence verdict shown; non-review-fix plans skip Phase 4c.
 - [ ] Commit and PR steps both go through `AskUserQuestion`; skill never auto-pushes.
+- [ ] Interrupting a run after Group 0 and re-invoking /work on the same plan re-dispatches no task carrying a complete line, and prints which tasks it skipped.
+- [ ] A ledger whose identity line names a different plan file is left untouched and a suffixed workspace is used instead.
+- [ ] Workspace deletion goes through AskUserQuestion and is verified by a re-list.
 
 **Known gotchas:**
 - Phase 4c parses the synthesized report format from the review skill; the SYNC comment must stay paired with the matching marker in `skills/review/SKILL.md`.
 - For 3+ task plans the orchestrator (`skills/work/orchestrator.md`) replaces Phase 3; do not run Phase 3's TodoWrite loop alongside it.
 - `git add .` is banned; always stage explicit file paths.
+- The orchestration workspace survives a blocked, failed, or cancelled run on purpose -- that is what makes the next invocation resumable.
+- The ledger, not the printed progress table, is the authority after a compaction.

--- a/skills/work/SKILL.md
+++ b/skills/work/SKILL.md
@@ -144,7 +144,7 @@ Reason: {why}
 
 `<plan-basename>` is the loaded plan file's name without `.md`. The workspace is `.claude/work/<plan-basename>/` and the ledger is `.claude/work/<plan-basename>/progress.md`.
 
-Any path that reaches Phase 2.5 without a plan file has no basename and therefore no ledger -- Phase 1 Case B's "Other -- I'll provide a path or description" and Case C with 0 matches both do. Proceed to the orchestrator without one and say so in the strategy line.
+Any path that reaches Phase 2.5 without a plan file has no plan basename -- Phase 1 Case B's "Other -- I'll provide a path or description" and Case C with 0 matches both do. Derive one instead of proceeding without it: slugify the task description to at most 40 characters and use `.claude/work/adhoc-<slug>/`. The workspace and ledger are otherwise identical, and the identity line names the task description in place of a plan file path. The orchestrator requires a workspace for every run -- every dispatch step writes to one. Name the derived workspace in the strategy line.
 
 #### Check for a ledger
 
@@ -158,10 +158,10 @@ Apply these rules, which restate `skills/work/orchestrator.md` Section 0:
 
 | State | Action |
 |-------|--------|
-| No file | Fresh run. Create the directory, write the identity line. |
-| First line names this plan file, and every completion line's task number and title match the plan | Resumable. Skip every task carrying a `Task <N> [<task title>]: complete (branch <branch>, commits <base7>..<head7>)` line -- do not re-dispatch it and do not re-merge its branch. Resume at the first task with no matching `complete` line. |
-| First line names a different plan file | Leave that directory untouched. Retry at `.claude/work/<plan-basename>-2/`, then `-3`, and so on, until a directory is found that either does not exist or whose identity line names this plan file. Use that one for the whole run. Print one line naming the directory actually used and why. |
-| First line matches this plan file, but a completion line's task title does not match the plan's task at that number | The plan changed mid-run. Warn the user, treat the ledger as stale, and start fresh in the same directory. |
+| No file, or a file whose first line is not a `# work ledger -- plan:` identity line | Fresh run. Create the directory if needed, overwrite the file with the identity line. Do not suffix -- a directory with no identity claims no plan. |
+| First line names this plan file, and every completion line's task number and title match the plan | Resumable. Do not re-dispatch any task carrying a `Task <N> [<task title>]: complete (branch <branch>, commits <base7>..<head7>)` line. Merge a completed task's branch unless a `Task <N>: merged` line also exists for it -- a `complete` line records that the work was done, not that it landed. A complete line reading `commits none` has no branch to merge. Resume dispatch at the first task with no matching `complete` line. |
+
+For a ledger naming a different plan file, or a completion line whose title no longer matches the plan, `skills/work/orchestrator.md` Section 0 "Resume rules" is authoritative -- follow it there and print the line it requires.
 
 #### Announce
 
@@ -288,12 +288,12 @@ status: active  -->  status: completed
 
 Runs only when orchestration was used, every task reached DONE, and Phase 4a check 7 passed. A run that ends blocked, failed, or cancelled skips this step entirely -- the surviving directory is what makes the retry cheap, and deleting it throws away the resume.
 
-1. Confirm the workspace directory used by this run exists and that its `progress.md` first line names this plan file. If either check fails, delete nothing and say so -- the directory belongs to a different run.
-2. Name the directory and its file count, then gate the delete on `AskUserQuestion`:
-   > Orchestration finished and the work is committed. Delete the run workspace at `.claude/work/<plan-basename>/` ({N} files)?
+1. Resolve `<workspace-dir>` to the directory this run actually used -- the suffixed one (`-2`, `-3`) if the orchestrator's suffix-retry rule fired, otherwise `.claude/work/<plan-basename>/`. Confirm `<workspace-dir>` exists and that its `progress.md` first line names this plan file. If either check fails, delete nothing and say so -- the directory belongs to a different run. Never re-derive the path from `<plan-basename>` after this step.
+2. Name `<workspace-dir>` and its file count, then gate the delete on `AskUserQuestion`:
+   > Orchestration finished and the work is committed. Delete the run workspace at `<workspace-dir>` ({N} files)?
    Buttons: `["Delete it", "Keep it"]`
    On "Keep it", print one line saying it was kept and continue to 5d.
-3. On "Delete it", remove the directory, then re-list `.claude/work/` to confirm it is gone, and name what was deleted in the 5d summary.
+3. On "Delete it", remove `<workspace-dir>` -- the exact path confirmed in step 1 and shown in step 2, no other -- then re-list `.claude/work/` to confirm it is gone, and name what was deleted in the 5d summary.
 
 #### 5d -- Notify user
 

--- a/skills/work/orchestrator.md
+++ b/skills/work/orchestrator.md
@@ -21,19 +21,22 @@ Orchestration keeps its state on disk, not in the session. A run that is compact
 
 `<plan-basename>` is the loaded plan file's name without `.md`. `skills/work/SKILL.md` Phase 2.5 resolves the workspace before handing off. A run with no plan file takes `adhoc-<slug>` as its basename, slugified from the task description -- every run has a workspace and a ledger, because every dispatch step below requires one.
 
-### Identity line
+### Identity header
 
-The first line of `progress.md`, exactly one:
+The first two lines of `progress.md`, in this order:
 
 ```
 # work ledger -- plan: <full plan file path>
+# run: <ISO-8601 start timestamp>
 ```
 
-When the run has no plan file, the task description takes the place of the path on that same line.
+When the run has no plan file, the task description takes the place of the path on the first line. The timestamp is taken once, when orchestration begins: `date -u '+%Y-%m-%dT%H:%M:%SZ'`.
+
+The `run:` line names the run that currently owns the workspace. Two sessions working the same plan in the same repo both resolve the same directory and both read an identity line naming their own plan, so the plan path alone cannot tell them apart. The `run:` line can, and `skills/work/SKILL.md` Phase 5c-bis checks it before deleting anything.
 
 ### Ledger grammar
 
-Every other line of `progress.md` is one of exactly these seven forms:
+Every line after the identity header is one of exactly these seven forms:
 
 ```
 Group <G>: dispatched (<task numbers>)
@@ -55,8 +58,8 @@ At the start of orchestration, read `.claude/work/<plan-basename>/progress.md`:
 
 | State | Action |
 |-------|--------|
-| No file, or a file whose first line is not a `# work ledger -- plan:` identity line | Fresh run. Create the directory if needed, overwrite the file with the identity line. Do not suffix -- a directory with no identity claims no plan. |
-| First line names this plan file, and every completion line's task number and title match the plan | Resumable. Do not re-dispatch any task carrying a `complete` line. Merge a completed task's branch unless a `Task <N>: merged` line also exists for it -- a `complete` line records that the work was done, not that it landed. A complete line reading `commits none` has no branch to merge. Resume dispatch at the first task with no matching `complete` line. |
+| No file, or a file whose first two lines are not a `# work ledger -- plan:` line followed by a `# run:` line | Fresh run. Create the directory if needed, overwrite the file with the identity header. Do not suffix -- a directory with no identity claims no plan. |
+| First line names this plan file, and every completion line's task number and title match the plan | Resumable. Do not re-dispatch any task carrying a `complete` line. Merge a completed task's branch unless a `Task <N>: merged` line also exists for it -- a `complete` line records that the work was done, not that it landed. A complete line reading `commits none` has no branch to merge. Resume dispatch at the first task with no matching `complete` line. Overwrite the `# run:` line with this run's start timestamp and read it back -- the workspace now belongs to this run. If it named a different run, say so in one line before continuing. |
 | First line names a different plan file | Leave that directory untouched. Retry at `.claude/work/<plan-basename>-2/`, then `-3`, and so on, until a directory is found that either does not exist or whose identity line names this plan file. Use that one for the whole run. Print one line naming the directory actually used and why. |
 | First line matches this plan file, but a completion line's task title does not match the plan's task at that number, or names a task number the plan does not have | The plan changed mid-run. Warn the user, treat the ledger as stale, and start fresh in the same directory. |
 

--- a/skills/work/orchestrator.md
+++ b/skills/work/orchestrator.md
@@ -6,6 +6,65 @@ This document defines the subagent orchestration logic used by the work skill wh
 
 ---
 
+## 0. Workspace and Ledger
+
+Orchestration keeps its state on disk, not in the session. A run that is compacted, interrupted, or resumed reads that state back rather than remembering it.
+
+### Workspace layout
+
+```
+.claude/work/<plan-basename>/
+  progress.md          -- the ledger
+  task-<N>-brief.md    -- one task's requirements, extracted from the plan
+  task-<N>-report.md   -- that task's full report, written by the subagent
+```
+
+`<plan-basename>` is the loaded plan file's name without `.md`. `skills/work/SKILL.md` Phase 2.5 resolves the workspace before handing off; a run with no plan file has no basename and therefore no ledger.
+
+### Identity line
+
+The first line of `progress.md`, exactly one:
+
+```
+# work ledger -- plan: <full plan file path>
+```
+
+### Ledger grammar
+
+Every other line of `progress.md` is one of exactly these six forms:
+
+```
+Group <G>: dispatched (<task numbers>)
+Task <N> [<task title>]: complete (branch <branch>, commits <base7>..<head7>)
+Task <N> [<task title>]: blocked -- <one-line reason>
+Task <N> [<task title>]: failed -- <one-line reason>
+Group <G>: merged (<task numbers>, no conflicts)
+Group <G>: merge stopped -- conflict in <file list>
+```
+
+This section is the single source of truth for the grammar. Section 2 and Section 3 append these lines; they do not redefine them.
+
+### Resume rules
+
+At the start of orchestration, read `.claude/work/<plan-basename>/progress.md`:
+
+| State | Action |
+|-------|--------|
+| No file | Fresh run. Create the directory, write the identity line. |
+| First line names this plan file, and every completion line's task number and title match the plan | Resumable. Skip every task carrying a `complete` line -- do not re-dispatch it and do not re-merge its branch. Resume at the first task with no matching `complete` line. |
+| First line names a different plan file | Leave that directory untouched. Retry at `.claude/work/<plan-basename>-2/`, then `-3`, and so on, until a directory is found that either does not exist or whose identity line names this plan file. Use that one for the whole run. Print one line naming the directory actually used and why. |
+| First line matches this plan file, but a completion line's task title does not match the plan's task at that number | The plan changed mid-run. Warn the user, treat the ledger as stale, and start fresh in the same directory. |
+
+### Cleanup
+
+The workspace is deleted by `skills/work/SKILL.md` Phase 5 after a successful run, never by the orchestrator. A run that ends blocked, failed, or cancelled leaves the directory in place -- that is what makes the next invocation resumable.
+
+### Write discipline
+
+Every ledger append is followed by reading the file back to confirm the line landed (skill rule L3). A ledger write that cannot be verified is reported to the user and orchestration stops -- an unverifiable ledger makes resume unsound.
+
+---
+
 ## 1. Dependency Resolution
 
 Dependency resolution determines the order in which tasks execute. It runs three steps, then builds execution groups.
@@ -92,61 +151,82 @@ Dispatching Group 0...
 
 ### Prompt Template
 
-Each subagent receives a self-contained prompt. The orchestrator fills in the template fields from the plan:
+The dispatch is a file handoff, not a paste. The task's requirements go to disk as a brief; the prompt carries the path.
+
+**Part 1 -- the brief.** Before dispatching task N:
+
+1. Write `.claude/work/<plan-basename>/task-<N>-brief.md` with the Write tool, containing the task's own text extracted from the plan -- title, description, acceptance criteria, and file list (Create / Modify / Test, exact paths) -- plus the plan header's architecture context. Read the file back to confirm it was written (skill rule L3).
+2. Delete any existing `task-<N>-report.md` for this task number, then confirm it is gone (L3). The report path is fixed per task, so on a resumed or retried run a report from the previous attempt is already there; leaving it would let the orchestrator read a stale report as if the new subagent had written it. The delete is the entire mitigation for that hazard, so an unverified delete reintroduces the defect it exists to close.
+
+**Part 2 -- the dispatch prompt.** The prompt carries no plan prose. Its context section is exactly three items -- the plan preamble, other tasks' text, and summaries of completed tasks are all excluded:
 
 ```
-# Task: {task_title}
+Task {N} of {total}, execution group {G}.
 
-## Description
-{task_description}
+Your requirements are in .claude/work/<plan-basename>/task-{N}-brief.md. Read it first.
+It lists the files you may create, modify, and test.
 
-## Acceptance Criteria
-{acceptance_criteria}
-
-## Files to Modify
-{file_list — exact paths, one per line, prefixed with Create/Modify/Test}
-
-## Context
-{plan_preamble and architecture notes from the plan header}
+Write your full account to .claude/work/<plan-basename>/task-{N}-report.md.
 
 ## Instructions
-1. Read all files listed above to understand current state and existing patterns.
+1. Read all files listed in the brief to understand current state and existing patterns.
 2. Implement the changes described, following the codebase's existing conventions.
 3. Run the project's test suite after implementation.
 4. Self-review your changes: check for missing edge cases, naming consistency, and adherence to acceptance criteria.
-5. Summarize what you did, what tests pass, and any concerns.
 
 ## Constraints
-- Only modify the files listed above. If you discover a needed change in another file, report it as a blocker instead of making the change.
+- Only modify the files listed in the brief. If you discover a needed change in another file, report it as a blocker instead of making the change.
 - Follow existing code patterns (naming, structure, error handling).
 - Do not add AI attribution comments or generated-by markers.
 - If you encounter an ambiguity or need a decision from the user, report BLOCKED status with a clear description of what you need.
 ```
 
+**Return contract.** The agent's final text is data, not prose. It writes its full account -- what it implemented, what it tested, files changed, self-review findings, concerns -- to the report path, and returns only these lines, in this order:
+
+```
+STATUS | DONE | BLOCKED | FAILED
+BRANCH | <branch name>
+BASE | <short sha of the branch point>
+COMMITS | <short sha> <subject>                 (zero or more lines, one per commit)
+TESTS | <one line>
+REASON | <one line, only when STATUS is not DONE>
+REPORT | <path to task-<N>-report.md>
+```
+
+`COMMITS` is one line per commit rather than a pipe-delimited list, because a commit subject can contain `|` and the field separator would then be ambiguous. `<base7>` in Section 0's `complete` line is the `BASE` value; `<head7>` is the short sha on the last `COMMITS` line.
+
+Anything beyond these lines is ignored. The detail belongs in the report file, which the orchestrator reads only when it needs it -- that is what keeps a run's controller context a function of the number of tasks rather than the size of the work each task did.
+
 ### Dispatch Mechanics
 
 For each execution group, in order:
 
-1. **Create tracking entries:** Call `TaskCreate` for each task in the group, recording task title, status `IN_PROGRESS`, and assigned group number.
-2. **Spawn agents:** For each task, spawn one Agent with:
+1. **Write the briefs:** For each task in the group, write its `task-<N>-brief.md` and delete any stale `task-<N>-report.md`, per Prompt Template Part 1. Both writes are read back before the group dispatches.
+2. **Create tracking entries:** Call `TaskCreate` for each task in the group, recording task title, status `IN_PROGRESS`, and assigned group number.
+3. **Spawn agents:** For each task, spawn one Agent with:
    - `subagent_type="general-purpose"`
    - `isolation="worktree"` (each agent works in its own git worktree)
    - `run_in_background=true`
    - The filled-in prompt template as the agent's instructions.
-3. **Wait for group completion:** Wait for all agents in the current group to finish. Never call `ScheduleWakeup` as a fallback in case a notification is missed -- the harness always notifies on completion, and a fallback wakeup past the 5-minute prompt-cache TTL forces a full-context reprocess for no benefit.
-4. **Process results:** Collect each agent's output and determine status (see Result Collection below).
-5. **Update tracking:** Call `TaskUpdate` for each task with its final status.
-6. **Proceed to next group:** If all tasks in the current group are DONE or if independent tasks in the next group are unblocked, move to the next group.
+4. **Record the dispatch:** Append `Group <G>: dispatched (<task numbers>)` to the ledger and read the file back to confirm the line landed. `TaskCreate` remains the live in-session view and the ledger is the durable record; the two are complementary, not redundant, and neither replaces the other.
+5. **Wait for group completion:** Wait for all agents in the current group to finish. Never call `ScheduleWakeup` as a fallback in case a notification is missed -- the harness always notifies on completion, and a fallback wakeup past the 5-minute prompt-cache TTL forces a full-context reprocess for no benefit.
+6. **Process results:** Collect each agent's output and determine status (see Result Collection below).
+7. **Update tracking:** Call `TaskUpdate` for each task with its final status.
+8. **Proceed to next group:** If all tasks in the current group are DONE or if independent tasks in the next group are unblocked, move to the next group.
 
 ### Result Collection
 
-Each completed subagent maps to one of three statuses:
+Status is read from the return contract's `STATUS` line, not from the prose of a summary. Every ledger append below is verified by reading the file back.
 
-| Status    | Detection                                          | Action                                         |
-|-----------|----------------------------------------------------|-------------------------------------------------|
-| **DONE**  | All acceptance criteria met, tests pass            | Queue the task's branch for merge               |
-| **BLOCKED** | Agent reports needing info, a decision, or access to a file outside its scope | Pause all tasks that depend on this one, report the blocker to the user |
-| **FAILED** | Unrecoverable error (build failure, test crash, environment issue) | Pause all tasks that depend on this one, report the failure to the user |
+| Status | Detection | Action |
+|--------|-----------|--------|
+| **DONE** | `STATUS \| DONE` | Append `Task <N> [<task title>]: complete (branch <branch>, commits <base7>..<head7>)`, taking `<branch>` from `BRANCH`, `<base7>` from `BASE`, and `<head7>` from the short sha on the last `COMMITS` line. Queue the branch for merge. Do not read the report file. |
+| **BLOCKED** | `STATUS \| BLOCKED` | Append `Task <N> [<task title>]: blocked -- <one-line reason>`, taking the reason from `REASON`. Read the report file at `REPORT` for the detail. Pause dependents, report to the user. |
+| **FAILED** | `STATUS \| FAILED` | Append `Task <N> [<task title>]: failed -- <one-line reason>`, taking the reason from `REASON`. Read the report file at `REPORT` for the detail. Pause dependents, report to the user. |
+
+An agent that returns nothing -- killed on a terminal error, or skipped -- is neither blocked nor complete. Append no ledger line for it. The absent `complete` line is what makes the next invocation re-dispatch it cleanly.
+
+**When a report file is read.** The orchestrator reads a `task-<N>-report.md` only on a BLOCKED or FAILED status, or when post-merge validation points at that task. A DONE task's report is written and never opened.
 
 **Handling BLOCKED/FAILED tasks:**
 
@@ -167,11 +247,13 @@ Merge branches in topological order — a task's branch merges only after all of
 For each completed task branch, in topological order:
 
 1. Run `git merge <worktree-branch> --no-edit` into the working branch.
-2. **Auto-merge succeeds:** Continue to the next branch. Clean up the worktree.
-3. **Conflict detected:** Stop the merge sequence immediately. Report to the user with:
+2. **Auto-merge succeeds:** Continue to the next branch. Clean up the worktree. Once the whole group's branches have merged, append `Group <G>: merged (<task numbers>, no conflicts)` to the ledger and read it back.
+3. **Conflict detected:** Stop the merge sequence immediately. Append `Group <G>: merge stopped -- conflict in <file list>` to the ledger, then report to the user with:
    - The conflicting file list (from `git diff --name-only --diff-filter=U`)
    - Which task branches have merged so far
    - Which task branches remain unmerged
+
+The ledger already records which branches merged, so the "which task branches have merged so far" item is read from it rather than from memory.
 
 Do not attempt automatic conflict resolution. The user must resolve conflicts before the merge sequence continues.
 
@@ -186,9 +268,13 @@ After all branches have merged successfully:
    - Likely responsible task (based on which files the failing tests cover)
    - Suggestion: re-run the responsible task's agent with the test failure as context.
 
+   Read that task's `task-<N>-report.md` for the detail before reporting. This is the third and last case where a report file is read.
+
 ---
 
 ## 4. Progress Reporting
+
+The printed tables are a view, not the state. After a context compaction the ledger at `.claude/work/<plan-basename>/progress.md` is the authority for what has been dispatched, completed, and merged; rebuild the table from it rather than from anything remembered.
 
 ### At Start
 
@@ -212,8 +298,12 @@ When a group completes, announce it before dispatching the next:
 
 ```
 Group 0 complete. All tasks DONE.
+  Task 1: 47 passed, 0 failed.
+  Task 2: 12 passed, 0 failed.
 Dispatching Group 1 (2 tasks in parallel)...
 ```
+
+Print each task's `TESTS` line from the return contract in the group-completion announcement. That is the one place `TESTS` is consumed, and it is why the field is in the contract.
 
 ### At End — Success
 

--- a/skills/work/orchestrator.md
+++ b/skills/work/orchestrator.md
@@ -19,7 +19,7 @@ Orchestration keeps its state on disk, not in the session. A run that is compact
   task-<N>-report.md   -- that task's full report, written by the subagent
 ```
 
-`<plan-basename>` is the loaded plan file's name without `.md`. `skills/work/SKILL.md` Phase 2.5 resolves the workspace before handing off; a run with no plan file has no basename and therefore no ledger.
+`<plan-basename>` is the loaded plan file's name without `.md`. `skills/work/SKILL.md` Phase 2.5 resolves the workspace before handing off. A run with no plan file takes `adhoc-<slug>` as its basename, slugified from the task description -- every run has a workspace and a ledger, because every dispatch step below requires one.
 
 ### Identity line
 
@@ -29,18 +29,23 @@ The first line of `progress.md`, exactly one:
 # work ledger -- plan: <full plan file path>
 ```
 
+When the run has no plan file, the task description takes the place of the path on that same line.
+
 ### Ledger grammar
 
-Every other line of `progress.md` is one of exactly these six forms:
+Every other line of `progress.md` is one of exactly these seven forms:
 
 ```
 Group <G>: dispatched (<task numbers>)
 Task <N> [<task title>]: complete (branch <branch>, commits <base7>..<head7>)
 Task <N> [<task title>]: blocked -- <one-line reason>
 Task <N> [<task title>]: failed -- <one-line reason>
+Task <N>: merged
 Group <G>: merged (<task numbers>, no conflicts)
 Group <G>: merge stopped -- conflict in <file list>
 ```
+
+`Task <N>: merged` records one branch landing. `Group <G>: merged (...)` summarizes the whole group and is written only after every branch in it has landed, so it cannot stand in for the per-task line.
 
 This section is the single source of truth for the grammar. Section 2 and Section 3 append these lines; they do not redefine them.
 
@@ -50,10 +55,10 @@ At the start of orchestration, read `.claude/work/<plan-basename>/progress.md`:
 
 | State | Action |
 |-------|--------|
-| No file | Fresh run. Create the directory, write the identity line. |
-| First line names this plan file, and every completion line's task number and title match the plan | Resumable. Skip every task carrying a `complete` line -- do not re-dispatch it and do not re-merge its branch. Resume at the first task with no matching `complete` line. |
+| No file, or a file whose first line is not a `# work ledger -- plan:` identity line | Fresh run. Create the directory if needed, overwrite the file with the identity line. Do not suffix -- a directory with no identity claims no plan. |
+| First line names this plan file, and every completion line's task number and title match the plan | Resumable. Do not re-dispatch any task carrying a `complete` line. Merge a completed task's branch unless a `Task <N>: merged` line also exists for it -- a `complete` line records that the work was done, not that it landed. A complete line reading `commits none` has no branch to merge. Resume dispatch at the first task with no matching `complete` line. |
 | First line names a different plan file | Leave that directory untouched. Retry at `.claude/work/<plan-basename>-2/`, then `-3`, and so on, until a directory is found that either does not exist or whose identity line names this plan file. Use that one for the whole run. Print one line naming the directory actually used and why. |
-| First line matches this plan file, but a completion line's task title does not match the plan's task at that number | The plan changed mid-run. Warn the user, treat the ledger as stale, and start fresh in the same directory. |
+| First line matches this plan file, but a completion line's task title does not match the plan's task at that number, or names a task number the plan does not have | The plan changed mid-run. Warn the user, treat the ledger as stale, and start fresh in the same directory. |
 
 ### Cleanup
 
@@ -155,7 +160,7 @@ The dispatch is a file handoff, not a paste. The task's requirements go to disk 
 
 **Part 1 -- the brief.** Before dispatching task N:
 
-1. Write `.claude/work/<plan-basename>/task-<N>-brief.md` with the Write tool, containing the task's own text extracted from the plan -- title, description, acceptance criteria, and file list (Create / Modify / Test, exact paths) -- plus the plan header's architecture context. Read the file back to confirm it was written (skill rule L3).
+1. Write `.claude/work/<plan-basename>/task-<N>-brief.md` with the Write tool, containing the task's own text extracted from the plan -- title, description, acceptance criteria, and file list (Create / Modify / Test, exact paths) -- plus the plan header's architecture context. When the run has no plan file, the brief carries that task's slice of the task description and the file list resolved for it -- the brief is the subagent's only source of requirements either way. Read the file back to confirm it was written (skill rule L3).
 2. Delete any existing `task-<N>-report.md` for this task number, then confirm it is gone (L3). The report path is fixed per task, so on a resumed or retried run a report from the previous attempt is already there; leaving it would let the orchestrator read a stale report as if the new subagent had written it. The delete is the entire mitigation for that hazard, so an unverified delete reintroduces the defect it exists to close.
 
 **Part 2 -- the dispatch prompt.** The prompt carries no plan prose. Its context section is exactly three items -- the plan preamble, other tasks' text, and summaries of completed tasks are all excluded:
@@ -173,6 +178,7 @@ Write your full account to .claude/work/<plan-basename>/task-{N}-report.md.
 2. Implement the changes described, following the codebase's existing conventions.
 3. Run the project's test suite after implementation.
 4. Self-review your changes: check for missing edge cases, naming consistency, and adherence to acceptance criteria.
+5. Commit each logical unit on your worktree branch, then report every commit on a COMMITS line. If the tree already matched the spec and there was nothing to commit, return no COMMITS line.
 
 ## Constraints
 - Only modify the files listed in the brief. If you discover a needed change in another file, report it as a blocker instead of making the change.
@@ -193,7 +199,7 @@ REASON | <one line, only when STATUS is not DONE>
 REPORT | <path to task-<N>-report.md>
 ```
 
-`COMMITS` is one line per commit rather than a pipe-delimited list, because a commit subject can contain `|` and the field separator would then be ambiguous. `<base7>` in Section 0's `complete` line is the `BASE` value; `<head7>` is the short sha on the last `COMMITS` line.
+`COMMITS` is one line per commit rather than a pipe-delimited list, because a commit subject can contain `|` and the field separator would then be ambiguous. `<base7>` in Section 0's `complete` line is the `BASE` value; `<head7>` is the short sha on the last `COMMITS` line. When there is no `COMMITS` line the task changed nothing to commit -- write `commits none` in place of `commits <base7>..<head7>` and merge no branch for that task.
 
 Anything beyond these lines is ignored. The detail belongs in the report file, which the orchestrator reads only when it needs it -- that is what keeps a run's controller context a function of the number of tasks rather than the size of the work each task did.
 
@@ -220,7 +226,7 @@ Status is read from the return contract's `STATUS` line, not from the prose of a
 
 | Status | Detection | Action |
 |--------|-----------|--------|
-| **DONE** | `STATUS \| DONE` | Append `Task <N> [<task title>]: complete (branch <branch>, commits <base7>..<head7>)`, taking `<branch>` from `BRANCH`, `<base7>` from `BASE`, and `<head7>` from the short sha on the last `COMMITS` line. Queue the branch for merge. Do not read the report file. |
+| **DONE** | `STATUS \| DONE` | Append `Task <N> [<task title>]: complete (branch <branch>, commits <base7>..<head7>)`, taking `<branch>` from `BRANCH`, `<base7>` from `BASE`, and `<head7>` from the short sha on the last `COMMITS` line. With no `COMMITS` line, write `commits none` and queue no branch. Otherwise queue the branch for merge. Do not read the report file. |
 | **BLOCKED** | `STATUS \| BLOCKED` | Append `Task <N> [<task title>]: blocked -- <one-line reason>`, taking the reason from `REASON`. Read the report file at `REPORT` for the detail. Pause dependents, report to the user. |
 | **FAILED** | `STATUS \| FAILED` | Append `Task <N> [<task title>]: failed -- <one-line reason>`, taking the reason from `REASON`. Read the report file at `REPORT` for the detail. Pause dependents, report to the user. |
 
@@ -247,13 +253,13 @@ Merge branches in topological order — a task's branch merges only after all of
 For each completed task branch, in topological order:
 
 1. Run `git merge <worktree-branch> --no-edit` into the working branch.
-2. **Auto-merge succeeds:** Continue to the next branch. Clean up the worktree. Once the whole group's branches have merged, append `Group <G>: merged (<task numbers>, no conflicts)` to the ledger and read it back.
+2. **Auto-merge succeeds:** Append `Task <N>: merged` to the ledger and read it back, before moving on -- a branch that landed must be recorded at the moment it lands, not once its group finishes. Continue to the next branch. Clean up the worktree. Once the whole group's branches have merged, append `Group <G>: merged (<task numbers>, no conflicts)` to the ledger and read it back.
 3. **Conflict detected:** Stop the merge sequence immediately. Append `Group <G>: merge stopped -- conflict in <file list>` to the ledger, then report to the user with:
    - The conflicting file list (from `git diff --name-only --diff-filter=U`)
    - Which task branches have merged so far
    - Which task branches remain unmerged
 
-The ledger already records which branches merged, so the "which task branches have merged so far" item is read from it rather than from memory.
+Each branch that landed carries its own `Task <N>: merged` line, so the "which task branches have merged so far" item is read from the ledger rather than from memory -- including after a compaction, when memory is gone and the group line has not been written.
 
 Do not attempt automatic conflict resolution. The user must resolve conflicts before the merge sequence continues.
 

--- a/tests/skills/test-work-ledger-contract.sh
+++ b/tests/skills/test-work-ledger-contract.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# test-work-ledger-contract.sh
+# Guards the /work orchestration ledger contract, which lives in two files by construction:
+#   producer  skills/work/orchestrator.md -- Section 0 declares the workspace layout, the
+#             identity line, the six ledger line forms, and the subagent return contract
+#   consumer  skills/work/SKILL.md        -- Phase 2.5 restates the workspace path, the
+#             identity line, and the complete-line spelling to decide what to skip on resume
+#
+# The consumer restates the producer's strings verbatim. A rename on either side changes
+# which tasks a resumed run re-dispatches without changing anything a reader would notice,
+# so every assertion reads the live skill files. No fixture is written and grepped with a
+# rule hardcoded here.
+#
+# Run directly: bash tests/skills/test-work-ledger-contract.sh
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+EXIT=0
+
+PRODUCER="$REPO_ROOT/skills/work/orchestrator.md"
+CONSUMER="$REPO_ROOT/skills/work/SKILL.md"
+GITIGNORE="$REPO_ROOT/.gitignore"
+
+pass() { echo "  PASS: $1"; }
+fail() { echo "  FAIL: $1"; EXIT=1; }
+
+# assert_in <file> <pattern> <label>
+# The -- guards patterns that start with a dash. Bracket-expression metacharacters in a
+# ledger placeholder are escaped at the call site, not stripped here.
+assert_in() {
+  if grep -q -- "$2" "$1"; then
+    pass "$3"
+  else
+    fail "$3"
+  fi
+}
+
+# assert_not_in <file> <pattern> <label>
+assert_not_in() {
+  if grep -q -- "$2" "$1"; then
+    fail "$3"
+  else
+    pass "$3"
+  fi
+}
+
+echo "=== 1. Preflight ==="
+
+for f in "$PRODUCER" "$CONSUMER"; do
+  if [ -f "$f" ]; then
+    pass "${f#$REPO_ROOT/} exists"
+  else
+    fail "${f#$REPO_ROOT/} is missing"
+  fi
+done
+
+if [ "$EXIT" != "0" ]; then
+  echo ""
+  echo "Preflight failed -- skipping the rest."
+  exit "$EXIT"
+fi
+
+echo ""
+echo "=== 2. The producer declares all six ledger line forms ==="
+
+# Each pattern is long enough that renaming a placeholder fails the assertion. The
+# leading [ of a task-title placeholder is escaped so BRE reads it as a literal
+# bracket rather than opening a bracket expression.
+assert_in "$PRODUCER" 'Group <G>: dispatched (' "dispatched line form declared"
+assert_in "$PRODUCER" '\[<task title>]: complete (branch ' "complete line form declared"
+assert_in "$PRODUCER" '\[<task title>]: blocked -- ' "blocked line form declared"
+assert_in "$PRODUCER" '\[<task title>]: failed -- ' "failed line form declared"
+assert_in "$PRODUCER" 'Group <G>: merged (' "merged line form declared"
+assert_in "$PRODUCER" 'Group <G>: merge stopped -- conflict in ' "merge-stopped line form declared"
+
+echo ""
+echo "=== 3. Restated handshake strings appear in both files ==="
+
+# These four cross the producer/consumer boundary. The other five line forms exist only
+# in the producer, which is why section 2 asserts them there and this section does not.
+for f in "$PRODUCER" "$CONSUMER"; do
+  L="${f#$REPO_ROOT/}"
+  assert_in "$f" '\.claude/work/<plan-basename>/' "workspace path in $L"
+  assert_in "$f" 'progress\.md' "ledger filename in $L"
+  assert_in "$f" '# work ledger -- plan:' "identity line in $L"
+  assert_in "$f" '\[<task title>]: complete (branch ' "full complete-line spelling in $L"
+done
+
+echo ""
+echo "=== 4. The return contract is declared once, in the producer ==="
+
+for field in 'STATUS |' 'BRANCH |' 'BASE |' 'COMMITS |' 'TESTS |' 'REASON |' 'REPORT |'; do
+  assert_in "$PRODUCER" "$field" "return contract declares $field"
+done
+assert_in "$PRODUCER" 'Anything beyond these lines is ignored' "the return cap is stated"
+
+# The pasted-context field and the dangling back-reference this change removed. Their
+# return is the regression these two assertions catch.
+assert_not_in "$PRODUCER" 'plan_preamble' "no plan_preamble field in the dispatch prompt"
+assert_not_in "$PRODUCER" 'files listed above' "no dangling 'files listed above' back-reference"
+
+echo ""
+echo "=== 5. No dangling skill reference in the consumer ==="
+
+# Computed from the file, not hardcoded -- a hardcoded name stops guarding the next one.
+FOUND=0
+for name in $(grep -oE '`[A-Za-z0-9._-]+` skill' "$CONSUMER" | sed -e 's/^`//' -e 's/` skill$//' | sort -u); do
+  FOUND=$((FOUND + 1))
+  if [ -d "$REPO_ROOT/skills/$name" ]; then
+    pass "referenced skill '$name' resolves to skills/$name/"
+  else
+    fail "referenced skill '$name' has no directory at skills/$name/"
+  fi
+done
+if [ "$FOUND" = "0" ]; then
+  pass "no backtick-quoted skill references to resolve"
+fi
+
+echo ""
+echo "=== 6. Rules with no other automated check ==="
+
+# R8 -- the consumer is ASCII-only. The bracket expression carries a literal tab; \t
+# inside a bracket expression matches a backslash and a t, not a tab.
+if LC_ALL=C grep -q '[^ -~	]' "$CONSUMER"; then
+  fail "R8: non-ASCII characters in ${CONSUMER#$REPO_ROOT/}"
+else
+  pass "R8: ASCII-only in ${CONSUMER#$REPO_ROOT/}"
+fi
+
+# orchestrator.md is deliberately exempt: it already carries non-ASCII bytes, which R8
+# permits for a file that had them before the rule was applied.
+
+assert_in "$GITIGNORE" '^\.claude/work/$' "the workspace is gitignored"
+
+echo ""
+echo "================================"
+if [ "$EXIT" = "0" ]; then
+  echo "All tests passed."
+else
+  echo "Some tests FAILED."
+fi
+exit "$EXIT"

--- a/tests/skills/test-work-ledger-contract.sh
+++ b/tests/skills/test-work-ledger-contract.sh
@@ -2,9 +2,9 @@
 # test-work-ledger-contract.sh
 # Guards the /work orchestration ledger contract, which lives in two files by construction:
 #   producer  skills/work/orchestrator.md -- Section 0 declares the workspace layout, the
-#             identity line, the seven ledger line forms, and the subagent return contract
+#             two-line identity header, the seven ledger line forms, and the return contract
 #   consumer  skills/work/SKILL.md        -- Phase 2.5 restates the workspace path, the
-#             identity line, the complete-line spelling, the merge-evidence rule, and the
+#             identity header, the complete-line spelling, the merge-evidence rule, and the
 #             fresh-run rule, to decide what to re-dispatch and what to re-merge on resume
 #
 # The consumer restates the producer's strings verbatim. A rename on either side changes
@@ -79,7 +79,7 @@ assert_in "$PRODUCER" 'Group <G>: merge stopped -- conflict in ' "merge-stopped 
 echo ""
 echo "=== 3. Restated handshake strings appear in both files ==="
 
-# These six cross the producer/consumer boundary. The other four line forms exist only in
+# These seven cross the producer/consumer boundary. The other four line forms exist only in
 # the producer, which is why section 2 asserts them there and this section does not.
 #
 # The last two are the resume rules the consumer still restates after the suffix-retry and
@@ -91,7 +91,8 @@ for f in "$PRODUCER" "$CONSUMER"; do
   L="${f#$REPO_ROOT/}"
   assert_in "$f" '\.claude/work/<plan-basename>/' "workspace path in $L"
   assert_in "$f" 'progress\.md' "ledger filename in $L"
-  assert_in "$f" '# work ledger -- plan:' "identity line in $L"
+  assert_in "$f" '# work ledger -- plan:' "plan identity line in $L"
+  assert_in "$f" '# run: <ISO-8601 start timestamp>' "run identity line in $L"
   assert_in "$f" '\[<task title>]: complete (branch ' "full complete-line spelling in $L"
   assert_in "$f" 'unless a `Task <N>: merged` line also exists for it' "merge-evidence resume rule in $L"
   assert_in "$f" 'Do not suffix -- a directory with no identity claims no plan\.' "fresh-run resume rule in $L"

--- a/tests/skills/test-work-ledger-contract.sh
+++ b/tests/skills/test-work-ledger-contract.sh
@@ -2,9 +2,10 @@
 # test-work-ledger-contract.sh
 # Guards the /work orchestration ledger contract, which lives in two files by construction:
 #   producer  skills/work/orchestrator.md -- Section 0 declares the workspace layout, the
-#             identity line, the six ledger line forms, and the subagent return contract
+#             identity line, the seven ledger line forms, and the subagent return contract
 #   consumer  skills/work/SKILL.md        -- Phase 2.5 restates the workspace path, the
-#             identity line, and the complete-line spelling to decide what to skip on resume
+#             identity line, the complete-line spelling, the merge-evidence rule, and the
+#             fresh-run rule, to decide what to re-dispatch and what to re-merge on resume
 #
 # The consumer restates the producer's strings verbatim. A rename on either side changes
 # which tasks a resumed run re-dispatches without changing anything a reader would notice,
@@ -62,7 +63,7 @@ if [ "$EXIT" != "0" ]; then
 fi
 
 echo ""
-echo "=== 2. The producer declares all six ledger line forms ==="
+echo "=== 2. The producer declares all seven ledger line forms ==="
 
 # Each pattern is long enough that renaming a placeholder fails the assertion. The
 # leading [ of a task-title placeholder is escaped so BRE reads it as a literal
@@ -71,21 +72,35 @@ assert_in "$PRODUCER" 'Group <G>: dispatched (' "dispatched line form declared"
 assert_in "$PRODUCER" '\[<task title>]: complete (branch ' "complete line form declared"
 assert_in "$PRODUCER" '\[<task title>]: blocked -- ' "blocked line form declared"
 assert_in "$PRODUCER" '\[<task title>]: failed -- ' "failed line form declared"
-assert_in "$PRODUCER" 'Group <G>: merged (' "merged line form declared"
+assert_in "$PRODUCER" 'Task <N>: merged' "per-task merged line form declared"
+assert_in "$PRODUCER" 'Group <G>: merged (' "group merged line form declared"
 assert_in "$PRODUCER" 'Group <G>: merge stopped -- conflict in ' "merge-stopped line form declared"
 
 echo ""
 echo "=== 3. Restated handshake strings appear in both files ==="
 
-# These four cross the producer/consumer boundary. The other five line forms exist only
-# in the producer, which is why section 2 asserts them there and this section does not.
+# These six cross the producer/consumer boundary. The other four line forms exist only in
+# the producer, which is why section 2 asserts them there and this section does not.
+#
+# The last two are the resume rules the consumer still restates after the suffix-retry and
+# stale-plan rows moved to the producer alone. Both decide control flow that no other
+# assertion covers: 'Task <N>: merged' is the only thing separating a completed task that
+# landed from one that did not, and the fresh-run clause is what keeps a header-less ledger
+# from being read as another plan's directory.
 for f in "$PRODUCER" "$CONSUMER"; do
   L="${f#$REPO_ROOT/}"
   assert_in "$f" '\.claude/work/<plan-basename>/' "workspace path in $L"
   assert_in "$f" 'progress\.md' "ledger filename in $L"
   assert_in "$f" '# work ledger -- plan:' "identity line in $L"
   assert_in "$f" '\[<task title>]: complete (branch ' "full complete-line spelling in $L"
+  assert_in "$f" 'unless a `Task <N>: merged` line also exists for it' "merge-evidence resume rule in $L"
+  assert_in "$f" 'Do not suffix -- a directory with no identity claims no plan\.' "fresh-run resume rule in $L"
 done
+
+# The suffix-retry and stale-plan rules are the producer's alone. A copy reappearing in the
+# consumer is the duplication this change removed, and drifts silently when it does.
+assert_not_in "$CONSUMER" 'then `-3`, and so on' "no restated suffix-retry rule in the consumer"
+assert_not_in "$CONSUMER" 'treat the ledger as stale' "no restated stale-plan rule in the consumer"
 
 echo ""
 echo "=== 4. The return contract is declared once, in the producer ==="
@@ -94,6 +109,10 @@ for field in 'STATUS |' 'BRANCH |' 'BASE |' 'COMMITS |' 'TESTS |' 'REASON |' 'RE
   assert_in "$PRODUCER" "$field" "return contract declares $field"
 done
 assert_in "$PRODUCER" 'Anything beyond these lines is ignored' "the return cap is stated"
+
+# A DONE task may legally return no COMMITS line, so the complete line needs a spelling for
+# that case. Without one the orchestrator improvises a line the resume match may not match.
+assert_in "$PRODUCER" 'commits none' "the zero-commit complete line is defined"
 
 # The pasted-context field and the dangling back-reference this change removed. Their
 # return is the regression these two assertions catch.


### PR DESCRIPTION
## Summary

`/work` routes any plan with 3+ tasks to `skills/work/orchestrator.md`. That path tracked state only through `TaskCreate`/`TaskUpdate`, which is in-session: a context compaction erased the run's progress, so the next invocation re-dispatched everything, including tasks that had already completed and merged. The dispatch prompt also pasted the plan preamble and architecture notes into every subagent and asked for a free-prose summary back with no bound, which made controller context a function of how much work each task did rather than how many tasks there were.

This gives the orchestration path a durable on-disk ledger, replaces the pasted plan prose with a brief-file / report-file handoff bounded by an explicit return contract, and deletes a dangling `using-git-worktrees` skill reference that pointed at no directory.

- **New file:** `tests/skills/test-work-ledger-contract.sh` -- binds the ledger grammar declared in `orchestrator.md` to the resume rules restated in `SKILL.md`, and fails on any backtick-quoted skill reference in `SKILL.md` naming a directory absent from `skills/`.
- **Modified:** `skills/work/orchestrator.md` -- new Section 0 (workspace layout, identity line, six ledger line forms, resume table); the Prompt Template rewritten as a file handoff with a return contract; ledger appends wired into dispatch, result collection, merge, and progress reporting.
- **Modified:** `skills/work/SKILL.md` -- Phase 2.5 resolves the workspace and applies the resume rules; Phase 5 gains a gated `5c-bis` cleanup step; the dangling skill reference is deleted; the Test Plan is extended.
- **Modified:** `.gitignore`, `CLAUDE.md` -- `.claude/work/` is gitignored and recorded as a write target.

### How it works

1. Phase 2.5 resolves `.claude/work/<plan-basename>/` and reads `progress.md`. Its first line is an identity line naming the plan file.
2. If that line names this plan, every task carrying a `complete` line is skipped: not re-dispatched, not re-merged. If it names a different plan, that directory is left untouched and the run moves to `<plan-basename>-2`.
3. Before dispatching task N, the orchestrator writes `task-<N>-brief.md` with that task's own text and deletes any stale `task-<N>-report.md` left by a previous attempt.
4. The dispatch prompt carries three things: one line of placement context, the brief path, and the report path. No plan prose.
5. The subagent writes its full account to the report file and returns only the contract lines (`STATUS`, `BRANCH`, `BASE`, `COMMITS`, `TESTS`, `REASON`, `REPORT`). Anything beyond them is ignored.
6. Result collection keys on `STATUS` and appends the matching ledger line. A DONE task's report is never opened; reports are read only on BLOCKED, FAILED, or a post-merge test failure pointing at that task.

### Design decisions

| Decision | Choice | Why |
|----------|--------|-----|
| Return cap | Seven-field line grammar, not a line count | A line count is unenforceable. `skills/ship/SKILL.md:285-294` is the only cap in the repo that is actually enforced, and it is a pipe-token grammar; this follows it. |
| `COMMITS` shape | One line per commit | A commit subject can contain `\|`, so a pipe-delimited list would have an ambiguous separator. |
| Stale report files | Deleted when the brief is written, delete verified | The report path is fixed per task, so on a retry the previous attempt's report already sits there. If the new subagent dies before writing, the orchestrator would read it as current. Same defect and same fix as `skills/design-build/SKILL.md:221-227`. |
| Basename collision | Numeric suffix (`-2`, `-3`, ...) | `SKILL.md` globs `.claude/plans/*.md` and `**/plans/*.md` together, so two plans can share a basename. Suffixing leaves the foreign ledger untouched and still yields a distinct workspace, with no prompt. |
| `TaskCreate` vs the ledger | Both kept | `TaskCreate` is the live in-session view; the ledger is the durable record. Neither replaces the other. |
| Workspace cleanup | Phase 5 only, gated on `AskUserQuestion` | A run that ends blocked, failed, or cancelled keeps its directory, which is what makes the retry cheap. The delete is user-confirmed per skill rule R6 and verified by a re-list. |

One deviation from the source spec: it asked for a `.claude/work/` entry in the README's Setup section gitignore list. `README.md` has no Setup section and no occurrence of "gitignore", so that instruction was unexecutable as written. The `.gitignore` change ships, and the write target is recorded in `CLAUDE.md`, which is where this repo actually tracks them.

## Test plan

- [ ] `bash tests/run-all.sh` passes -- 13 test files, up from 12.
- [ ] `bash tests/skills/test-work-ledger-contract.sh` exits 0 and prints `All tests passed.`
- [ ] Section 5 of the new test is live, not vacuous: running its extractor against `master:skills/work/SKILL.md` fails on `using-git-worktrees`.
- [ ] `git check-ignore -q .claude/work/` exits 0.
- [ ] `grep -rn "using-git-worktrees" skills/ agents/ hooks/ tests/ README.md` returns no matches.
- [ ] Manual: interrupt a 3+ task `/work` run after Group 0, re-invoke on the same plan, and confirm no task carrying a `complete` line is re-dispatched and the skip line prints.
- [ ] Manual: a successful orchestrated run reaches Phase 5 `5c-bis` and offers to delete the workspace via `AskUserQuestion`.
