### PR TITLE
Add CONTRIBUTING.md and fix stale hook and SYNC references in AGENTS.md

### DIFF
--- a/.claude/rules/readme-structure.md
+++ b/.claude/rules/readme-structure.md
@@ -17,7 +17,8 @@ Reference: https://github.com/EveryInc/compound-engineering-plugin/tree/main/plu
 11. **Setup** (optional) — any required config like .gitignore entries
 12. **Known Issues** (optional)
 13. **Uninstall**
-14. **License**
+14. **Contributing** -- one paragraph, links to `CONTRIBUTING.md`
+15. **License**
 
 ## Formatting Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,12 @@
 # AGENTS.md
 
+Read `CONTRIBUTING.md` before changing anything. `CLAUDE.md` has the architecture and the per-component rules.
+
 ## Must-follow constraints
 
 - Branching: Create a feature branch for any non-trivial change. If already on the correct branch, keep using it -- do not create additional branches or worktrees unless explicitly requested.
 - Safety: Do not delete or overwrite user data. Avoid destructive commands.
+- Tests: Run `bash tests/run-all.sh` before you finish. Most tests are contract checks between two copies of one string; a red test points at the copy you have not updated. Fix the copy, not the test.
 - ASCII-first: Use ASCII characters only unless the file already contains Unicode.
 - Release: Plugin version lives in `.claude-plugin/plugin.json` `"version"` field. Release is handled by a private project command -- do not bump version, create tags, or publish releases manually.
 
@@ -11,10 +14,10 @@
 
 - `.claude-plugin/plugin.json` -- Plugin manifest (name, version, skill/agent registration).
 - `.claude-plugin/marketplace.json` -- Marketplace listing metadata (keywords, tags, category).
-- `hooks/hooks.json` -- Hook event registration (currently only PreCompact).
+- `hooks/hooks.json` -- Hook event registration: PreToolUse (`pre-tool-use-guard.sh`, classifies a Bash command as deny/ask/silence), PreCompact (`pre-compact-handover.sh`, saves a handover), SessionStart (`session-start-auto-dispatch.sh`, emits the skill routing block).
 - `hooks/scripts/pre-compact-handover.sh` -- PreCompact hook implementation; uses `claude -p` for summarization.
-- `skills/handover/SKILL.md:96` -- SYNC comment pointing to hook script headings; the 8 headings live at lines 99-129.
-- `hooks/scripts/pre-compact-handover.sh:25` -- SYNC comment pointing to handover skill headings.
+- `skills/handover/SKILL.md` -- the 8 handover headings sit under a `SYNC:` comment that points at the hook script.
+- `hooks/scripts/pre-compact-handover.sh` -- the same 8 headings inside `PROMPT_PREFIX`, under a `SYNC:` comment that points back. `tests/hooks/test-handover-sync-contract.sh` fails when the two lists differ.
 
 ## Change safety rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository. Setup, tests, and PR expectations for contributors are in `CONTRIBUTING.md`; `AGENTS.md` is the short form for other coding agents. Keep the three in agreement.
 
 # Quiver
 
@@ -11,7 +11,7 @@ Dependencies: `bash`, `claude` CLI.
 
 - **`.claude-plugin/`** — Plugin manifest (`plugin.json`) and marketplace listing (`marketplace.json`). Defines name, version, hook/skill/agent registration, and MCP servers.
 - **`skills/`** — 25 skill directories (each contains `SKILL.md`). Each `SKILL.md` carries YAML front-matter (`name`, `description`) and is a self-contained prompt; the `name` field doubles as the slash invocation (`/handover`, `/review`, etc.). **Exception:** `visual-companion` also contains `server.py`, a runtime executable -- this is the only skill with non-prompt code.
-- **`agents/`** — 20 agent definitions organized by category (`review/`, `research/`, `debug/`). Agents are persona prompts spawned as subagents.
+- **`agents/`** — 20 agent definitions organized by category (`review/`, `research/`, `debug/`, `workflow/`). Agents are persona prompts spawned as subagents.
 - **`hooks/`** — `hooks.json` registers event hooks; `scripts/` holds implementations. Three hooks: PreToolUse (matcher `Bash`, classifies a command as deny/ask/silence before it runs), PreCompact (fires before context compaction, saves a handover) and SessionStart (emits the skill routing block from every skill's `when-to-use`).
 - **`install.sh`** — Repo-root install script for the runtimes with no plugin manager. Its install targets are a six-column TSV heredoc inside `targets()`; adding a runtime is one row and no other line. It symlinks into the user's clone (so `git pull` is the update mechanism) and never removes or overwrites a path that is not a symlink resolving into the repo. It must stay at the repo root -- `.gitignore` drops `/scripts/`.
 - **Storage** — Handover files are written to `<project>/.claude/handovers/`. The orchestration workspace -- the ledger, task briefs, and task reports written by `skills/work/orchestrator.md` -- is written to `<project>/.claude/work/<plan-basename>/`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to Quiver
+
+Thanks for helping out. Quiver has one maintainer, so small, focused PRs get merged fastest. If you found a bug, open a PR. If you want to add a skill, an agent, or a hook, or change how one behaves, open an issue first so we can agree on the approach before you spend an evening on it. Every feature has to pass the admission test in `CLAUDE.md`: useful on its own, and able to feed or consume other skills.
+
+## Setup
+
+Quiver is prompts and bash. There is nothing to build.
+
+```bash
+git clone https://github.com/yagizdo/quiver.git
+cd quiver
+```
+
+To try your changes in Claude Code without installing them, start a session with the clone as a plugin directory:
+
+```bash
+claude --plugin-dir /path/to/quiver
+```
+
+For OpenCode, `./install.sh` symlinks the clone into place, so every edit is live. Cursor and the Codex CLI have their own plugin managers; see [Installation](README.md#installation) in the README.
+
+## Tests
+
+```bash
+bash tests/run-all.sh
+```
+
+CI runs the same command on every PR. The tests are bash scripts under `tests/`, and most of them are contract checks: they read the real skill, agent, hook, and manifest files and fail when two copies of the same string drift apart. If you rename a heading or a frontmatter field and a test goes red, the test is pointing at the copy you have not updated yet. Fix the copy, not the test.
+
+A new test goes at `tests/<area>/test-<name>.sh`. The runner discovers it, so nothing else needs editing. It must run under `bash` from any directory, exit 0 on pass, and exit nonzero on fail. Shared helpers are named `lib-*.sh` so the runner does not treat them as tests.
+
+Skill behaviour has no automated tests; the contract tests only check that a skill's strings still match their copies elsewhere. Each `SKILL.md` ends with a `## Test Plan` section. Run it in a real session and say in the PR what you saw.
+
+## Code
+
+- Skills are prompts, not scripts. The shell blocks gather data; the prose tells the model what to do with it. What a shell block may and may not contain is listed under "Adding a Skill" in `CLAUDE.md`, and the hard rules are in `.claude/rules/skill-rules.md`.
+- Agents are persona prompts under `agents/<category>/`. Run `/quiver:create-agent` to scaffold one. It fills in the capability profile that `tests/agents/test-capability-profile-contract.sh` checks.
+- A new skill or agent also needs a row in the README. `.claude/rules/readme-structure.md` says where it goes and which skills are deliberately left out.
+- Hooks are bash scripts under `hooks/scripts/`, registered in `hooks/hooks.json`.
+- ASCII only, unless the file already contains Unicode.
+- Do not bump the version. It lives in three manifests and the README badge, and the maintainer's release script moves all four at once. `tests/manifests/test-manifest-parity.sh` fails when they disagree.
+- `docs/` is gitignored. Notes that explain a PR belong in the PR description or in an issue.
+
+## Pull requests
+
+Branch from `master` and keep each PR to one change. The PR title usually becomes the commit subject on `master`, so write it in the imperative mood, like "Add a PreToolUse guard for destructive Bash commands". In the description, say what problem the PR solves, what changed, and how you tested it.
+
+## AI tools
+
+Quiver is a plugin for AI coding tools, so using one to work on it is expected. Read and understand every line before you submit it, because you are the one I will be talking to in review. Keep AI out of the git metadata: no "Generated with Claude Code" style lines in commits or PR descriptions, and no `Co-Authored-By:` trailers naming an AI tool. GitHub turns those trailers into contributor credits, and that list is for people. `AGENTS.md` and `CLAUDE.md` carry the rules a coding agent needs; point yours at them if it does not read them on its own.
+
+Contributions are licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Quiver is a development lifecycle plugin for AI coding CLIs. Purpose-built skill
 - [External Dependencies](#external-dependencies)
 - [CLI Notes](#cli-notes)
 - [Uninstall](#uninstall)
+- [Contributing](#contributing)
 - [License](#license)
 
 ## Typical workflow
@@ -387,6 +388,10 @@ On OpenCode, from the clone:
 ```
 
 That removes only the symlinks that resolve into the clone, and reports anything it declined to remove.
+
+## Contributing
+
+Bug fix: open a PR. New skill, agent, or hook, or a behaviour change: open an issue first. Setup, tests, and PR expectations are in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 


### PR DESCRIPTION
## Problem

Quiver had no contributor guide, and README never told a reader how to get one merged. AGENTS.md also carried two claims that were no longer true: that `hooks/hooks.json` registers only PreCompact (it registers three hooks), and line-numbered SYNC references that had already drifted by one line, which CLAUDE.md says we stopped doing for exactly that reason.

## Changes

- `CONTRIBUTING.md`: new. Setup (`claude --plugin-dir <clone>` to try changes without installing, `./install.sh` for OpenCode), how to run and add tests, the "fix the copy, not the test" rule for contract tests, code rules pulled from CLAUDE.md and `.claude/rules/`, PR expectations, and the policy on AI tools in git metadata.
- `README.md`: Contents entry and a `## Contributing` section between Uninstall and License.
- `.claude/rules/readme-structure.md`: Contributing added to the structure order so the rule matches the README.
- `AGENTS.md`: pointer to CONTRIBUTING.md and CLAUDE.md, the test command as a constraint, the hooks line corrected to all three hooks, and the SYNC references rewritten without line numbers, naming `tests/hooks/test-handover-sync-contract.sh` as the gate.
- `CLAUDE.md`: pointer to CONTRIBUTING.md and AGENTS.md; `workflow/` added to the agent category list, which the "Adding an Agent" section already named.

No version bump; the manifests and badge are untouched.

## Testing

`bash tests/run-all.sh`: all 17 test files pass. CONTRIBUTING.md and AGENTS.md are ASCII-only. Every relative link target exists and the `#contributing` anchor matches the new header.
