### PR TITLE
Stop losing the PR preview in the approval prompt

### DIFF
--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -77,7 +77,7 @@ Analyze `git diff --cached` and the recent log. Generate a Conventional Commits 
 
 # Output
 
-**Important:** Do NOT output the commit message as separate text. Embed it directly inside the `AskUserQuestion` tool call so the user always sees the message alongside the options.
+**Important:** The user must see the full commit message before answering the prompt. Print it to the chat stream and keep the `AskUserQuestion` question itself to one short line -- see **Default (no flag)** below.
 
 Include a body or footers only for breaking changes or multi-type changes where the subject alone is genuinely ambiguous. Default to subject-only. Don't add `Co-authored-by` or attribution footers unless explicitly requested.
 
@@ -87,21 +87,27 @@ If `$ARGUMENTS` contains "push" (e.g., `/quiver:commit --push`), skip the `AskUs
 
 ## Default (no flag)
 
-Use the `AskUserQuestion` tool with the commit message embedded in the question field:
+Two steps, both mandatory: print the message, then ask. Do not paste the commit message into the `AskUserQuestion` question field -- that field is rendered as a single truncated line by some Claude Code surfaces, so a multi-line message is cut off or dropped entirely and the user is asked to approve something they cannot read.
 
-- **Question:** Build the question string using this template (replace placeholders):\
+**Step 1 -- print the message** as normal chat output, verbatim inside a fenced block, so the user sees exactly what `git commit` will receive:
 
-`"Commit Message:\n\n{type}({scope}): {subject}\n\nProceed?"`
+```
+{type}({scope}): {subject}
 
-  Plain text only -- no ANSI escape codes. `AskUserQuestion` renders the question in a TUI box that prints escape sequences literally instead of styling them.
+{body lines, if the message has a body}
+```
 
-  If the message has a body, append body lines after the subject separated by newlines.
+**Step 2 -- ask, and wait for the answer:**
+
+- **Question:** `"Commit this?"` -- one short line. No newlines, no message text, no ANSI escape codes. `AskUserQuestion` renders the question in a TUI box that prints escape sequences literally instead of styling them.
 - **Header:** "Action"
 - **Options:**
   1. **Commit** — "Commit with this message"
   2. **Commit & Push** — "Commit and push to remote"
   3. **Edit** — "Revise the message"
   4. **Cancel** — "Abort without committing"
+
+Printing the message is not approval. It is only the readable copy of what the prompt is about, and it exists because the prompt cannot display it. Never run `git commit` without an answer from this `AskUserQuestion`. The user asking for a commit in their message is not the answer either -- that is what put the skill on this step. `--push` is the only path that skips the prompt.
 
 ---
 
@@ -156,7 +162,7 @@ If `git commit` fails, show the error verbatim and suggest the user fix the issu
 **Expected behavior:**
 1. Skill runs the four git shell blocks; on a non-git directory it prints `> No git repository detected. /commit requires a git repo.` and stops.
 2. With nothing changed, skill tells the user there's nothing to commit. With unstaged-only changes, skill tells the user to stage first.
-3. With staged changes, skill drafts a Conventional Commits message (type/scope/subject) and presents it via `AskUserQuestion` with `Commit / Commit & Push / Edit / Cancel`.
+3. With staged changes, skill drafts a Conventional Commits message (type/scope/subject), prints it to chat in a fenced block, then asks via `AskUserQuestion` with a one-line question and `Commit / Commit & Push / Edit / Cancel`.
 4. With `--push` argument, skill skips the prompt and runs commit then push (`git push` if upstream exists, `git push -u origin <branch>` otherwise).
 5. On failure, skill shows the error verbatim and exits without retrying or adding `--no-verify`.
 
@@ -164,8 +170,11 @@ If `git commit` fails, show the error verbatim and suggest the user fix the issu
 - [ ] Slash menu shows `/commit`.
 - [ ] Generated commit message starts with a valid type (`feat`, `fix`, `docs`, etc.) and a subject ≤72 chars.
 - [ ] No `Co-authored-by` or AI-attribution footers appear in the commit.
-- [ ] The interactive prompt is an `AskUserQuestion` with the message embedded in the question, not plain text.
+- [ ] The full commit message is visible in the chat stream before the prompt appears; the `AskUserQuestion` question is a single short line containing no message text.
+- [ ] `git commit` runs only after the prompt is answered -- printing the message and committing in one uninterrupted turn is a failure, even when the user's message asked for a commit.
 - [ ] `--push` path commits and pushes without prompting.
 
 **Known gotchas:**
+- Splitting the message out of the question field removes what used to force the prompt: when the message lived inside the question, the skill could not show it without asking. With the two separated, the printed message looks like a confirmation on its own and the prompt gets skipped. The guard paragraph under the options is why the skip is called out there.
+- The `AskUserQuestion` question field is rendered single-line and truncated on some surfaces, and ANSI escape codes print literally (`\x1b[2m` shows up as `@[2m`). Keep the question to one short plain-text line and put the message in the chat stream.
 - Pushing without an upstream requires `git push -u origin <branch>`; do not silently fall back to `git push` when no upstream is configured.

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -91,7 +91,9 @@ Use the `AskUserQuestion` tool with the commit message embedded in the question 
 
 - **Question:** Build the question string using this template (replace placeholders):\
 
-`"\x1b[2mCommit Message:\x1b[0m\n\n{type}({scope}): {subject}\n\nProceed?"`
+`"Commit Message:\n\n{type}({scope}): {subject}\n\nProceed?"`
+
+  Plain text only -- no ANSI escape codes. `AskUserQuestion` renders the question in a TUI box that prints escape sequences literally instead of styling them.
 
   If the message has a body, append body lines after the subject separated by newlines.
 - **Header:** "Action"
@@ -166,5 +168,4 @@ If `git commit` fails, show the error verbatim and suggest the user fix the issu
 - [ ] `--push` path commits and pushes without prompting.
 
 **Known gotchas:**
-- The `\x1b[2m` ANSI dim escape inside the question string assumes the user's terminal renders ANSI; non-ANSI terminals will see literal escape codes but the message remains readable.
 - Pushing without an upstream requires `git push -u origin <branch>`; do not silently fall back to `git push` when no upstream is configured.

--- a/skills/create-pr/SKILL.md
+++ b/skills/create-pr/SKILL.md
@@ -128,6 +128,10 @@ The body depth should scale with the PR size:
 
 Generate the body from the full diff content, commit history, and diff stats. Write for a reviewer -- explain the *why* and *how*, not just the *what*.
 
+**Language rule:** the title and body are always written in English, regardless of the conversation language. Only use another language if the user explicitly asks for it in this invocation. A PR is a repository artifact read by people who were not in this conversation.
+
+**Structure rule:** the body follows the template above -- `## Summary` first, then the size-appropriate sections. Do not collapse it into one prose paragraph. If a section has nothing to say, drop the section rather than padding it.
+
 ---
 
 ## Step 4 -- Present & Execute
@@ -138,12 +142,18 @@ If `$ARGUMENTS` contains "draft", skip the `AskUserQuestion` step. Show the gene
 
 ### Default (no flag)
 
-Use the `AskUserQuestion` tool:
+**Print the preview to chat first, then ask.** Do not paste the body into the `AskUserQuestion` question field. That field is rendered as a single truncated line by some Claude Code surfaces, so a multi-line body is cut off or dropped entirely and the user is asked to approve something they cannot read.
 
-- **Question:** Build the question string using this template (replace placeholders):
+Print, as normal chat output:
 
-  `"\x1b[2mPR Title:\x1b[0m\n{title}\n\n\x1b[2mPR Body:\x1b[0m\n{body}\n\nProceed?"`
+> **PR Title:** {title}
+> **Base:** `{base_branch}` <- `{current_branch}`
 
+Then the body verbatim inside a fenced ```markdown block, so the user sees exactly what `gh pr create` will receive.
+
+Then call `AskUserQuestion`:
+
+- **Question:** `"Create this PR?"` -- one short line. No newlines, no body text, no ANSI escape codes.
 - **Header:** "Pull Request"
 - **Options:**
   1. **Create PR** -- "Create pull request"
@@ -215,7 +225,7 @@ Never retry automatically.
 1. Skill runs the six git shell blocks and stops with a clear message if any of: not a git repo, no remote, dirty working tree.
 2. Skill resolves the base branch via the priority order (`--base` flag > `origin/HEAD` > `main` > `master` > `develop` > prompt).
 3. Skill pushes the branch (`git push` with upstream, otherwise `git push -u origin <branch>`).
-4. Skill builds a title (≤72 chars, imperative mood) and a body whose depth scales with PR size; presents both via `AskUserQuestion` with `Create PR / Create as Draft / Edit / Cancel`.
+4. Skill builds a title (≤72 chars, imperative mood) and a body whose depth scales with PR size, prints both to chat (body in a fenced block), then asks via `AskUserQuestion` with a one-line question and `Create PR / Create as Draft / Edit / Cancel`.
 5. With `--draft`, skill skips the prompt and runs `gh pr create --draft …`.
 6. Final output shows the PR URL parsed from `gh` stdout.
 
@@ -223,9 +233,12 @@ Never retry automatically.
 - [ ] Slash menu shows `/create-pr`.
 - [ ] Skill stops cleanly with a single explanatory line on `NO_GIT`, `NO_REMOTE`, dirty tree, base-branch ambiguity, or zero commits ahead.
 - [ ] Body uses HEREDOC formatting in the actual `gh pr create` invocation.
+- [ ] Title and body are in English even when the conversation is in another language, and the body keeps its `## Summary` / section structure instead of one prose paragraph.
+- [ ] The full body is visible in the chat stream before the prompt appears; the `AskUserQuestion` question is a single short line containing no body text.
 - [ ] No AI-attribution lines appear in the title or body.
 - [ ] `--base <branch>` overrides every other base-branch source.
 
 **Known gotchas:**
+- The `AskUserQuestion` question field is rendered single-line and truncated on some surfaces, and ANSI escape codes print literally (`\x1b[2m` shows up as `@[2m`). Keep the question to one short plain-text line and put the preview in the chat stream.
 - `gh pr create` exits non-zero when a PR already exists; the skill must surface the error and suggest `gh pr list --head <branch>` rather than retrying.
 - Bitbucket and Azure DevOps are not supported by `gh`; the user must run a platform-specific tool manually for those.

--- a/skills/create-pr/SKILL.md
+++ b/skills/create-pr/SKILL.md
@@ -142,16 +142,16 @@ If `$ARGUMENTS` contains "draft", skip the `AskUserQuestion` step. Show the gene
 
 ### Default (no flag)
 
-**Print the preview to chat first, then ask.** Do not paste the body into the `AskUserQuestion` question field. That field is rendered as a single truncated line by some Claude Code surfaces, so a multi-line body is cut off or dropped entirely and the user is asked to approve something they cannot read.
+Two steps, both mandatory: print the preview, then ask. Do not paste the body into the `AskUserQuestion` question field -- that field is rendered as a single truncated line by some Claude Code surfaces, so a multi-line body is cut off or dropped entirely and the user is asked to approve something they cannot read.
 
-Print, as normal chat output:
+**Step 4a -- print the preview** as normal chat output:
 
 > **PR Title:** {title}
 > **Base:** `{base_branch}` <- `{current_branch}`
 
 Then the body verbatim inside a fenced ```markdown block, so the user sees exactly what `gh pr create` will receive.
 
-Then call `AskUserQuestion`:
+**Step 4b -- ask, and wait for the answer:**
 
 - **Question:** `"Create this PR?"` -- one short line. No newlines, no body text, no ANSI escape codes.
 - **Header:** "Pull Request"
@@ -160,6 +160,8 @@ Then call `AskUserQuestion`:
   2. **Create as Draft** -- "Create as draft pull request"
   3. **Edit** -- "Revise the title or description"
   4. **Cancel** -- "Abort without creating PR"
+
+Printing the preview is not approval. It is only the readable copy of what the prompt is about, and it exists because the prompt cannot display it. Never run `gh pr create` without an answer from this `AskUserQuestion`. The user asking for a PR in their message is not the answer either -- that is what put the skill on this step. `--draft` is the only path that skips the prompt.
 
 ---
 
@@ -235,10 +237,12 @@ Never retry automatically.
 - [ ] Body uses HEREDOC formatting in the actual `gh pr create` invocation.
 - [ ] Title and body are in English even when the conversation is in another language, and the body keeps its `## Summary` / section structure instead of one prose paragraph.
 - [ ] The full body is visible in the chat stream before the prompt appears; the `AskUserQuestion` question is a single short line containing no body text.
+- [ ] `gh pr create` runs only after the prompt is answered -- printing the preview and creating the PR in one uninterrupted turn is a failure, even when the user's message asked for a PR.
 - [ ] No AI-attribution lines appear in the title or body.
 - [ ] `--base <branch>` overrides every other base-branch source.
 
 **Known gotchas:**
+- Splitting the preview out of the question field removes what used to force the prompt: when the body lived inside the question, the skill could not show it without asking. With the two separated, the printed preview looks like a confirmation on its own and the prompt gets skipped. Step 4b is the guard, and it is why the skip is called out there in its own paragraph.
 - The `AskUserQuestion` question field is rendered single-line and truncated on some surfaces, and ANSI escape codes print literally (`\x1b[2m` shows up as `@[2m`). Keep the question to one short plain-text line and put the preview in the chat stream.
 - `gh pr create` exits non-zero when a PR already exists; the skill must surface the error and suggest `gh pr list --head <branch>` rather than retrying.
 - Bitbucket and Azure DevOps are not supported by `gh`; the user must run a platform-specific tool manually for those.


### PR DESCRIPTION
## Summary

Fixes three defects in the interactive prompts of `/create-pr` and `/commit`. All three were reported from real runs: escape codes leaking into the prompt box, a PR description that never appeared for approval, and PR bodies written in the conversation language instead of English.

- **Modified:** `skills/create-pr/SKILL.md` -- preview moved out of the question field, language and structure rules added
- **Modified:** `skills/commit/SKILL.md` -- ANSI escapes removed, stale gotcha dropped

### How it works

1. `AskUserQuestion` renders the question with `wrap:"truncate"` (measured in the Claude Code 2.1.258 binary), so the question is a single line clipped at the terminal width. `/create-pr` was pasting an entire multi-line PR body into that field, which is why the description was cut off or missing entirely at approval time. The skill now prints the title and the body (in a fenced block, verbatim) to the chat stream, and the question is the single line `"Create this PR?"`.
2. The same field prints ANSI escapes literally rather than styling them, so the `\x1b[2m` dim codes in both skills rendered as `@[2m` in the prompt. Removed from both, with a gotcha recording why. The `/commit` gotcha claiming the codes would render on ANSI terminals was wrong and is gone.
3. `/create-pr` carried no language rule, so the body followed the conversation language and flattened into one prose paragraph. It is now pinned to English with the section template enforced, matching `/plan`, `/brainstorm` and `/design`.

## Test plan

- [x] `bash tests/run-all.sh` -- 18 test files, all passing
- [ ] Run `/create-pr` on a branch with a multi-file diff: full body visible in chat before the prompt, question is one line, no escape codes
- [ ] Run `/create-pr` in a Turkish conversation: title and body come out in English with `## Summary` structure intact
- [ ] Run `/commit`: message renders clean in the prompt box, no `@[2m`